### PR TITLE
The swipeable list item is reusable with any chat channel item

### DIFF
--- a/Sources/StreamChatSwiftUI/DefaultViewFactory.swift
+++ b/Sources/StreamChatSwiftUI/DefaultViewFactory.swift
@@ -70,10 +70,8 @@ extension ViewFactory {
         trailingSwipeRightButtonTapped: @escaping (ChatChannel) -> Void,
         trailingSwipeLeftButtonTapped: @escaping (ChatChannel) -> Void,
         leadingSwipeButtonTapped: @escaping (ChatChannel) -> Void
-    ) -> ChatChannelSwipeableListItem<Self> {
-        ChatChannelSwipeableListItem(
-            factory: self,
-            currentChannelId: swipedChannelId,
+    ) -> some View {
+        let listItem = ChatChannelNavigatableListItem(
             channel: channel,
             channelName: channelName,
             avatar: avatar,
@@ -81,7 +79,13 @@ extension ViewFactory {
             disabled: disabled,
             selectedChannel: selectedChannel,
             channelDestination: channelDestination,
-            onItemTap: onItemTap,
+            onItemTap: onItemTap
+        )
+        return ChatChannelSwipeableListItem(
+            factory: self,
+            channelListItem: listItem,
+            currentChannelId: swipedChannelId,
+            channel: channel,
             trailingRightButtonTapped: trailingSwipeRightButtonTapped,
             trailingLeftButtonTapped: trailingSwipeLeftButtonTapped,
             leadingSwipeButtonTapped: leadingSwipeButtonTapped


### PR DESCRIPTION
### 🎯 Goal

Make the swipeable channel item reusable with any view.

### 🛠 Implementation

Made the swipeable view generic over the injected view.

### 🧪 Testing

Functionality is the same as before, make sure there are no side effects.

### 🎨 Changes

No visible changes.

### ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
