### PR TITLE
Open up initializer of ChatChannelSwipeableListItem

### DIFF
--- a/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelSwipeableListItem.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelSwipeableListItem.swift
@@ -39,7 +39,7 @@ public struct ChatChannelSwipeableListItem<Factory: ViewFactory, ChannelListItem
     private var trailingLeftButtonTapped: (ChatChannel) -> Void
     private var leadingButtonTapped: (ChatChannel) -> Void
     
-    internal init(
+    public init(
         factory: Factory,
         channelListItem: ChannelListItem,
         currentChannelId: Binding<String?>,


### PR DESCRIPTION
### 🔗 Issue Link
none

### 🎯 Goal

We need to expose the initializer because of the recent changes to allow users to replace the used `View` (`ChannelListItem`) inside of the swipeable list item.

### 🛠 Implementation

Change the initializer from `internal` to `public`.

### 🧪 Testing

Implementing a custom app that wants to customize the `ChatChannelSwipeableListItem` with its own implementation for the `View` of the `ChannelListItem`.

### 🎨 Changes

_Add relevant screenshots or videos showcasing the changes._

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
