### PR TITLE
Custom Channel List Dividers

### DIFF
--- a/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelList.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelList.swift
@@ -158,7 +158,7 @@ struct ChannelsLazyVStack<Factory: ViewFactory>: View {
                     }
                 }
                 
-                Divider()
+                factory.makeChannelListDividerItem()
             }
         }
     }

--- a/Sources/StreamChatSwiftUI/DefaultViewFactory.swift
+++ b/Sources/StreamChatSwiftUI/DefaultViewFactory.swift
@@ -92,6 +92,10 @@ extension ViewFactory {
         )
     }
     
+    public func makeChannelListDividerItem() -> some View {
+        Divider()
+    }
+    
     public func makeTrailingSwipeActionsView(
         channel: ChatChannel,
         offsetX: CGFloat,

--- a/Sources/StreamChatSwiftUI/ViewFactory.swift
+++ b/Sources/StreamChatSwiftUI/ViewFactory.swift
@@ -59,6 +59,10 @@ public protocol ViewFactory: AnyObject {
         leadingSwipeButtonTapped: @escaping (ChatChannel) -> Void
     ) -> ChannelListItemType
     
+    associatedtype ChannelListDividerItem: View
+    /// Creates the channel list divider item.
+    func makeChannelListDividerItem() -> ChannelListDividerItem
+    
     associatedtype MoreActionsView: View
     /// Creates the more channel actions view.
     /// - Parameters:

--- a/docusaurus/docs/iOS/swiftui/components/helper-views.md
+++ b/docusaurus/docs/iOS/swiftui/components/helper-views.md
@@ -102,7 +102,31 @@ In the channel list item creation method, you are provided with several paramete
 - `trailingSwipeLeftButtonTapped`: called when the left button of the trailing swiped area is tapped.
 - `leadingSwipeButtonTapped`: called when the button of the leading swiped area is tapped.
 
-The last three parameters have no effect if you have specified `EmptyView` for the leading and trailing swipe area of a channel list item. By default, the leading area returns `EmptyView`. In the following section, we will see how these areas can be customized.
+The last three parameters have no effect if you have specified `EmptyView` for the leading and trailing swipe area of a channel list item. By default, the leading area returns `EmptyView`. In one of the following sections, we will see how these areas can be customized.
+
+## Changing the Divider of the Chat Channel List
+
+It is not only possible to swap the channel list items itself but also to customize the divider between the items. You can do that by implementing `makeChannelListDividerItem` in the `ViewFactory`. The only requisite is that the item you return needs to be a `View`, which offers you all the freedom you need.
+
+The default implementation uses a simple `Divider` and looks like this:
+
+```swift
+public func makeChannelListDividerItem() -> some View {
+    Divider()
+}
+```
+
+If you want your list to not have a divider whatsoever, you can simply return an `EmptyView` here.
+
+Remember to always inject your custom view factory in your view hierarchy:
+
+```swift
+var body: some Scene {
+    WindowGroup {
+        ChatChannelListView(viewFactory: CustomViewFactory.shared)
+    }
+}
+```
 
 ## Customizing the Leading and Trailing Areas
 


### PR DESCRIPTION
### 🔗 Issue Link
[Jira](https://stream-io.atlassian.net/browse/SWUI-90)

### 🎯 Goal

We want the user to be able to create a custom divider in the channel list if desired.

### 🛠 Implementation

* Expand the `ViewFactory` protocol with `makeChannelListDividerItem()`
* Provide a default implementation in the `DefaultViewFactory`
* Use the factory method for divider creation in `ChatChannelList` to dynamically use the option that is currently set

### 🧪 Testing

Implement `makeChannelListDividerItem()` in `DemoAppFactory` and provider a custom solution for the Demo app. Run it to see it in action.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Affected documentation updated (docusaurus, tutorial, CMS (task created)
