### PR TITLE
Feature/reseting swipe area

### DIFF
--- a/DemoAppSwiftUI/iMessagePocView.swift
+++ b/DemoAppSwiftUI/iMessagePocView.swift
@@ -88,7 +88,10 @@ struct iMessagePocView: View {
     private func customViewOverlay() -> some View {
         switch viewModel.customChannelPopupType {
         case let .moreActions(channel):
-            factory.makeMoreChannelActionsView(for: channel) {
+            factory.makeMoreChannelActionsView(
+                for: channel,
+                currentChannelId: $viewModel.currentChannelId
+            ) {
                 withAnimation {
                     viewModel.customChannelPopupType = nil
                 }

--- a/DemoAppSwiftUI/iMessagePocView.swift
+++ b/DemoAppSwiftUI/iMessagePocView.swift
@@ -46,7 +46,7 @@ struct iMessagePocView: View {
                     factory: factory,
                     channels: viewModel.channels,
                     selectedChannel: $viewModel.selectedChannel,
-                    currentChannelId: $viewModel.currentChannelId,
+                    swipedChannelId: $viewModel.swipedChannelId,
                     onlineIndicatorShown: viewModel.onlineIndicatorShown(for:),
                     imageLoader: channelHeaderLoader.image(for:),
                     onItemTap: { channel in
@@ -90,7 +90,7 @@ struct iMessagePocView: View {
         case let .moreActions(channel):
             factory.makeMoreChannelActionsView(
                 for: channel,
-                currentChannelId: $viewModel.currentChannelId
+                swipedChannelId: $viewModel.swipedChannelId
             ) {
                 withAnimation {
                     viewModel.customChannelPopupType = nil

--- a/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelList.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelList.swift
@@ -11,7 +11,7 @@ public struct ChannelList<Factory: ViewFactory>: View {
     private var factory: Factory
     var channels: LazyCachedMapCollection<ChatChannel>
     @Binding var selectedChannel: ChatChannel?
-    @Binding var currentChannelId: String?
+    @Binding var swipedChannelId: String?
     private var scrollable: Bool
     private var onlineIndicatorShown: (ChatChannel) -> Bool
     private var imageLoader: (ChatChannel) -> UIImage
@@ -27,7 +27,7 @@ public struct ChannelList<Factory: ViewFactory>: View {
         factory: Factory,
         channels: LazyCachedMapCollection<ChatChannel>,
         selectedChannel: Binding<ChatChannel?>,
-        currentChannelId: Binding<String?>,
+        swipedChannelId: Binding<String?>,
         scrollable: Bool = true,
         onlineIndicatorShown: @escaping (ChatChannel) -> Bool,
         imageLoader: @escaping (ChatChannel) -> UIImage,
@@ -52,7 +52,7 @@ public struct ChannelList<Factory: ViewFactory>: View {
         self.leadingSwipeButtonTapped = leadingSwipeButtonTapped
         self.scrollable = scrollable
         _selectedChannel = selectedChannel
-        _currentChannelId = currentChannelId
+        _swipedChannelId = swipedChannelId
     }
     
     public var body: some View {
@@ -72,7 +72,7 @@ public struct ChannelList<Factory: ViewFactory>: View {
             factory: factory,
             channels: channels,
             selectedChannel: $selectedChannel,
-            currentChannelId: $currentChannelId,
+            swipedChannelId: $swipedChannelId,
             onlineIndicatorShown: onlineIndicatorShown,
             imageLoader: imageLoader,
             onItemTap: onItemTap,
@@ -92,7 +92,7 @@ struct ChannelsLazyVStack<Factory: ViewFactory>: View {
     private var factory: Factory
     var channels: LazyCachedMapCollection<ChatChannel>
     @Binding var selectedChannel: ChatChannel?
-    @Binding var currentChannelId: String?
+    @Binding var swipedChannelId: String?
     private var onlineIndicatorShown: (ChatChannel) -> Bool
     private var imageLoader: (ChatChannel) -> UIImage
     private var onItemTap: (ChatChannel) -> Void
@@ -107,7 +107,7 @@ struct ChannelsLazyVStack<Factory: ViewFactory>: View {
         factory: Factory,
         channels: LazyCachedMapCollection<ChatChannel>,
         selectedChannel: Binding<ChatChannel?>,
-        currentChannelId: Binding<String?>,
+        swipedChannelId: Binding<String?>,
         onlineIndicatorShown: @escaping (ChatChannel) -> Bool,
         imageLoader: @escaping (ChatChannel) -> UIImage,
         onItemTap: @escaping (ChatChannel) -> Void,
@@ -130,7 +130,7 @@ struct ChannelsLazyVStack<Factory: ViewFactory>: View {
         self.trailingSwipeLeftButtonTapped = trailingSwipeLeftButtonTapped
         self.leadingSwipeButtonTapped = leadingSwipeButtonTapped
         _selectedChannel = selectedChannel
-        _currentChannelId = currentChannelId
+        _swipedChannelId = swipedChannelId
     }
     
     public var body: some View {
@@ -141,9 +141,9 @@ struct ChannelsLazyVStack<Factory: ViewFactory>: View {
                     channelName: channelNaming(channel),
                     avatar: imageLoader(channel),
                     onlineIndicatorShown: onlineIndicatorShown(channel),
-                    disabled: currentChannelId == channel.id,
+                    disabled: swipedChannelId == channel.id,
                     selectedChannel: $selectedChannel,
-                    swipedChannelId: $currentChannelId,
+                    swipedChannelId: $swipedChannelId,
                     channelDestination: channelDestination,
                     onItemTap: onItemTap,
                     trailingSwipeRightButtonTapped: trailingSwipeRightButtonTapped,

--- a/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListView.swift
@@ -63,7 +63,7 @@ public struct ChatChannelListView<Factory: ViewFactory>: View {
                             factory: viewFactory,
                             channels: viewModel.channels,
                             selectedChannel: $viewModel.selectedChannel,
-                            currentChannelId: $viewModel.currentChannelId,
+                            swipedChannelId: $viewModel.swipedChannelId,
                             onlineIndicatorShown: viewModel.onlineIndicatorShown(for:),
                             imageLoader: channelHeaderLoader.image(for:),
                             onItemTap: onItemTap,
@@ -113,11 +113,11 @@ public struct ChatChannelListView<Factory: ViewFactory>: View {
         case let .moreActions(channel):
             viewFactory.makeMoreChannelActionsView(
                 for: channel,
-                currentChannelId: $viewModel.currentChannelId
+                swipedChannelId: $viewModel.swipedChannelId
             ) {
                 withAnimation {
                     viewModel.customChannelPopupType = nil
-                    viewModel.currentChannelId = nil
+                    viewModel.swipedChannelId = nil
                 }
             } onError: { error in
                 viewModel.showErrorPopup(error)

--- a/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListView.swift
@@ -111,9 +111,13 @@ public struct ChatChannelListView<Factory: ViewFactory>: View {
     private func customViewOverlay() -> some View {
         switch viewModel.customChannelPopupType {
         case let .moreActions(channel):
-            viewFactory.makeMoreChannelActionsView(for: channel) {
+            viewFactory.makeMoreChannelActionsView(
+                for: channel,
+                currentChannelId: $viewModel.currentChannelId
+            ) {
                 withAnimation {
                     viewModel.customChannelPopupType = nil
+                    viewModel.currentChannelId = nil
                 }
             } onError: { error in
                 viewModel.showErrorPopup(error)

--- a/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListViewModel.swift
@@ -50,7 +50,7 @@ open class ChatChannelListViewModel: ObservableObject, ChatChannelListController
     }
 
     @Published public var deeplinkChannel: ChatChannel?
-    @Published public var currentChannelId: String?
+    @Published public var swipedChannelId: String?
     @Published public var channelAlertType: ChannelAlertType? {
         didSet {
             if channelAlertType != nil {

--- a/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelSwipeableListItem.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelSwipeableListItem.swift
@@ -14,7 +14,7 @@ public struct ChatChannelSwipeableListItem<Factory: ViewFactory, ChannelListItem
     
     @GestureState private var offset: CGSize = .zero
     
-    @Binding var currentChannelId: String?
+    @Binding var swipedChannelId: String?
     
     private let itemWidth: CGFloat = 60
     private var menuWidth: CGFloat {
@@ -42,7 +42,7 @@ public struct ChatChannelSwipeableListItem<Factory: ViewFactory, ChannelListItem
     public init(
         factory: Factory,
         channelListItem: ChannelListItem,
-        currentChannelId: Binding<String?>,
+        swipedChannelId: Binding<String?>,
         channel: ChatChannel,
         trailingRightButtonTapped: @escaping (ChatChannel) -> Void,
         trailingLeftButtonTapped: @escaping (ChatChannel) -> Void,
@@ -54,7 +54,7 @@ public struct ChatChannelSwipeableListItem<Factory: ViewFactory, ChannelListItem
         self.trailingRightButtonTapped = trailingRightButtonTapped
         self.trailingLeftButtonTapped = trailingLeftButtonTapped
         leadingButtonTapped = leadingSwipeButtonTapped
-        _currentChannelId = currentChannelId
+        _swipedChannelId = swipedChannelId
     }
     
     public var body: some View {
@@ -95,8 +95,8 @@ public struct ChatChannelSwipeableListItem<Factory: ViewFactory, ChannelListItem
                 dragChanged(to: offset.width)
             }
         })
-        .onChange(of: currentChannelId, perform: { _ in
-            if currentChannelId != channel.id && offsetX != 0 {
+        .onChange(of: swipedChannelId, perform: { _ in
+            if swipedChannelId != channel.id && offsetX != 0 {
                 setOffsetX(value: 0)
             }
         })
@@ -108,7 +108,7 @@ public struct ChatChannelSwipeableListItem<Factory: ViewFactory, ChannelListItem
             channel: channel,
             offsetX: offsetX,
             buttonWidth: buttonWidth,
-            currentChannelId: $currentChannelId,
+            swipedChannelId: $swipedChannelId,
             leftButtonTapped: trailingLeftButtonTapped,
             rightButtonTapped: trailingRightButtonTapped
         )
@@ -123,7 +123,7 @@ public struct ChatChannelSwipeableListItem<Factory: ViewFactory, ChannelListItem
             channel: channel,
             offsetX: offsetX,
             buttonWidth: buttonWidth,
-            currentChannelId: $currentChannelId,
+            swipedChannelId: $swipedChannelId,
             buttonTapped: leadingButtonTapped
         )
     }
@@ -151,7 +151,7 @@ public struct ChatChannelSwipeableListItem<Factory: ViewFactory, ChannelListItem
         }
                  
         if horizontalTranslation != 0 {
-            currentChannelId = channel.id
+            swipedChannelId = channel.id
             offsetX = horizontalTranslation
         } else {
             offsetX = 0
@@ -164,13 +164,13 @@ public struct ChatChannelSwipeableListItem<Factory: ViewFactory, ChannelListItem
         }
         if offsetX == 0 {
             openSideLock = nil
-            currentChannelId = nil
+            swipedChannelId = nil
         }
     }
 
     private func dragEnded() {
         if offsetX == 0 {
-            currentChannelId = nil
+            swipedChannelId = nil
             openSideLock = nil
         } else if offsetX > 0 && showLeadingSwipeActions {
             if offsetX.magnitude < openTriggerValue ||

--- a/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelSwipeableListItem.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelSwipeableListItem.swift
@@ -95,6 +95,11 @@ public struct ChatChannelSwipeableListItem<Factory: ViewFactory, ChannelListItem
                 dragChanged(to: offset.width)
             }
         })
+        .onChange(of: currentChannelId, perform: { _ in
+            if currentChannelId != channel.id && offsetX != 0 {
+                setOffsetX(value: 0)
+            }
+        })
         .id("\(channel.id)-swipeable")
     }
     
@@ -103,6 +108,7 @@ public struct ChatChannelSwipeableListItem<Factory: ViewFactory, ChannelListItem
             channel: channel,
             offsetX: offsetX,
             buttonWidth: buttonWidth,
+            currentChannelId: $currentChannelId,
             leftButtonTapped: trailingLeftButtonTapped,
             rightButtonTapped: trailingRightButtonTapped
         )
@@ -117,6 +123,7 @@ public struct ChatChannelSwipeableListItem<Factory: ViewFactory, ChannelListItem
             channel: channel,
             offsetX: offsetX,
             buttonWidth: buttonWidth,
+            currentChannelId: $currentChannelId,
             buttonTapped: leadingButtonTapped
         )
     }

--- a/Sources/StreamChatSwiftUI/ChatChannelList/MoreChannelActionsView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannelList/MoreChannelActionsView.swift
@@ -12,13 +12,13 @@ public struct MoreChannelActionsView: View {
     @Injected(\.fonts) private var fonts
     
     @StateObject var viewModel: MoreChannelActionsViewModel
-    @Binding var currentChannelId: String?
+    @Binding var swipedChannelId: String?
     var onDismiss: () -> Void
     
     public init(
         channel: ChatChannel,
         channelActions: [ChannelAction],
-        currentChannelId: Binding<String?>,
+        swipedChannelId: Binding<String?>,
         onDismiss: @escaping () -> Void
     ) {
         _viewModel = StateObject(
@@ -28,7 +28,7 @@ public struct MoreChannelActionsView: View {
             )
         )
         self.onDismiss = onDismiss
-        _currentChannelId = currentChannelId
+        _swipedChannelId = swipedChannelId
     }
     
     public var body: some View {

--- a/Sources/StreamChatSwiftUI/ChatChannelList/MoreChannelActionsView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannelList/MoreChannelActionsView.swift
@@ -12,11 +12,13 @@ public struct MoreChannelActionsView: View {
     @Injected(\.fonts) private var fonts
     
     @StateObject var viewModel: MoreChannelActionsViewModel
+    @Binding var currentChannelId: String?
     var onDismiss: () -> Void
     
     public init(
         channel: ChatChannel,
         channelActions: [ChannelAction],
+        currentChannelId: Binding<String?>,
         onDismiss: @escaping () -> Void
     ) {
         _viewModel = StateObject(
@@ -26,6 +28,7 @@ public struct MoreChannelActionsView: View {
             )
         )
         self.onDismiss = onDismiss
+        _currentChannelId = currentChannelId
     }
     
     public var body: some View {

--- a/Sources/StreamChatSwiftUI/DefaultViewFactory.swift
+++ b/Sources/StreamChatSwiftUI/DefaultViewFactory.swift
@@ -43,6 +43,7 @@ extension ViewFactory {
     
     public func makeMoreChannelActionsView(
         for channel: ChatChannel,
+        currentChannelId: Binding<String?>,
         onDismiss: @escaping () -> Void,
         onError: @escaping (Error) -> Void
     ) -> some View {
@@ -53,6 +54,7 @@ extension ViewFactory {
                 onDismiss: onDismiss,
                 onError: onError
             ),
+            currentChannelId: currentChannelId,
             onDismiss: onDismiss
         )
     }
@@ -96,6 +98,7 @@ extension ViewFactory {
         channel: ChatChannel,
         offsetX: CGFloat,
         buttonWidth: CGFloat,
+        currentChannelId: Binding<String?>,
         leftButtonTapped: @escaping (ChatChannel) -> Void,
         rightButtonTapped: @escaping (ChatChannel) -> Void
     ) -> some View {
@@ -112,6 +115,7 @@ extension ViewFactory {
         channel: ChatChannel,
         offsetX: CGFloat,
         buttonWidth: CGFloat,
+        currentChannelId: Binding<String?>,
         buttonTapped: (ChatChannel) -> Void
     ) -> some View {
         EmptyView()

--- a/Sources/StreamChatSwiftUI/DefaultViewFactory.swift
+++ b/Sources/StreamChatSwiftUI/DefaultViewFactory.swift
@@ -43,7 +43,7 @@ extension ViewFactory {
     
     public func makeMoreChannelActionsView(
         for channel: ChatChannel,
-        currentChannelId: Binding<String?>,
+        swipedChannelId: Binding<String?>,
         onDismiss: @escaping () -> Void,
         onError: @escaping (Error) -> Void
     ) -> some View {
@@ -54,7 +54,7 @@ extension ViewFactory {
                 onDismiss: onDismiss,
                 onError: onError
             ),
-            currentChannelId: currentChannelId,
+            swipedChannelId: swipedChannelId,
             onDismiss: onDismiss
         )
     }
@@ -86,7 +86,7 @@ extension ViewFactory {
         return ChatChannelSwipeableListItem(
             factory: self,
             channelListItem: listItem,
-            currentChannelId: swipedChannelId,
+            swipedChannelId: swipedChannelId,
             channel: channel,
             trailingRightButtonTapped: trailingSwipeRightButtonTapped,
             trailingLeftButtonTapped: trailingSwipeLeftButtonTapped,
@@ -102,7 +102,7 @@ extension ViewFactory {
         channel: ChatChannel,
         offsetX: CGFloat,
         buttonWidth: CGFloat,
-        currentChannelId: Binding<String?>,
+        swipedChannelId: Binding<String?>,
         leftButtonTapped: @escaping (ChatChannel) -> Void,
         rightButtonTapped: @escaping (ChatChannel) -> Void
     ) -> some View {
@@ -119,7 +119,7 @@ extension ViewFactory {
         channel: ChatChannel,
         offsetX: CGFloat,
         buttonWidth: CGFloat,
-        currentChannelId: Binding<String?>,
+        swipedChannelId: Binding<String?>,
         buttonTapped: (ChatChannel) -> Void
     ) -> some View {
         EmptyView()

--- a/Sources/StreamChatSwiftUI/ViewFactory.swift
+++ b/Sources/StreamChatSwiftUI/ViewFactory.swift
@@ -63,10 +63,12 @@ public protocol ViewFactory: AnyObject {
     /// Creates the more channel actions view.
     /// - Parameters:
     ///  - channel: the channel where the actions are applied.
+    ///  - currentChannelId: optional id of the channel being active (swiped).
     ///  - onDismiss: handler when the more actions view is dismissed.
     ///  - onError: handler when an error happened.
     func makeMoreChannelActionsView(
         for channel: ChatChannel,
+        currentChannelId: Binding<String?>,
         onDismiss: @escaping () -> Void,
         onError: @escaping (Error) -> Void
     ) -> MoreActionsView
@@ -89,6 +91,7 @@ public protocol ViewFactory: AnyObject {
     ///  - channel: the channel being swiped.
     ///  - offsetX: the offset of the swipe area in the x-axis.
     ///  - buttonWidth: the width of the button (use if you want dynamic width, based on swiping position).
+    ///  - currentChannelId: optional id of the channel being active (swiped).
     ///  - leftButtonTapped: handler when the left button is tapped.
     ///  - rightButtonTapped: handler when the right button is tapped.
     /// - Returns: View displayed in the trailing swipe area of a channel item.
@@ -96,6 +99,7 @@ public protocol ViewFactory: AnyObject {
         channel: ChatChannel,
         offsetX: CGFloat,
         buttonWidth: CGFloat,
+        currentChannelId: Binding<String?>,
         leftButtonTapped: @escaping (ChatChannel) -> Void,
         rightButtonTapped: @escaping (ChatChannel) -> Void
     ) -> TrailingSwipeActionsViewType
@@ -106,12 +110,14 @@ public protocol ViewFactory: AnyObject {
     ///  - channel: the channel being swiped.
     ///  - offsetX: the offset of the swipe area in the x-axis.
     ///  - buttonWidth: the width of the button (use if you want dynamic width, based on swiping position).
+    ///  - currentChannelId: optional id of the channel being active (swiped).
     ///  - buttonTapped: handler when the button is tapped.
     /// - Returns: View displayed in the leading swipe area of a channel item.
     func makeLeadingSwipeActionsView(
         channel: ChatChannel,
         offsetX: CGFloat,
         buttonWidth: CGFloat,
+        currentChannelId: Binding<String?>,
         buttonTapped: @escaping (ChatChannel) -> Void
     ) -> LeadingSwipeActionsViewType
     

--- a/Sources/StreamChatSwiftUI/ViewFactory.swift
+++ b/Sources/StreamChatSwiftUI/ViewFactory.swift
@@ -67,12 +67,12 @@ public protocol ViewFactory: AnyObject {
     /// Creates the more channel actions view.
     /// - Parameters:
     ///  - channel: the channel where the actions are applied.
-    ///  - currentChannelId: optional id of the channel being active (swiped).
+    ///  - swipedChannelId: optional id of the channel being swiped.
     ///  - onDismiss: handler when the more actions view is dismissed.
     ///  - onError: handler when an error happened.
     func makeMoreChannelActionsView(
         for channel: ChatChannel,
-        currentChannelId: Binding<String?>,
+        swipedChannelId: Binding<String?>,
         onDismiss: @escaping () -> Void,
         onError: @escaping (Error) -> Void
     ) -> MoreActionsView
@@ -95,7 +95,7 @@ public protocol ViewFactory: AnyObject {
     ///  - channel: the channel being swiped.
     ///  - offsetX: the offset of the swipe area in the x-axis.
     ///  - buttonWidth: the width of the button (use if you want dynamic width, based on swiping position).
-    ///  - currentChannelId: optional id of the channel being active (swiped).
+    ///  - swipedChannelId: optional id of the channel being swiped.
     ///  - leftButtonTapped: handler when the left button is tapped.
     ///  - rightButtonTapped: handler when the right button is tapped.
     /// - Returns: View displayed in the trailing swipe area of a channel item.
@@ -103,7 +103,7 @@ public protocol ViewFactory: AnyObject {
         channel: ChatChannel,
         offsetX: CGFloat,
         buttonWidth: CGFloat,
-        currentChannelId: Binding<String?>,
+        swipedChannelId: Binding<String?>,
         leftButtonTapped: @escaping (ChatChannel) -> Void,
         rightButtonTapped: @escaping (ChatChannel) -> Void
     ) -> TrailingSwipeActionsViewType
@@ -114,14 +114,14 @@ public protocol ViewFactory: AnyObject {
     ///  - channel: the channel being swiped.
     ///  - offsetX: the offset of the swipe area in the x-axis.
     ///  - buttonWidth: the width of the button (use if you want dynamic width, based on swiping position).
-    ///  - currentChannelId: optional id of the channel being active (swiped).
+    ///  - swipedChannelId: optional id of the channel being active swiped.
     ///  - buttonTapped: handler when the button is tapped.
     /// - Returns: View displayed in the leading swipe area of a channel item.
     func makeLeadingSwipeActionsView(
         channel: ChatChannel,
         offsetX: CGFloat,
         buttonWidth: CGFloat,
-        currentChannelId: Binding<String?>,
+        swipedChannelId: Binding<String?>,
         buttonTapped: @escaping (ChatChannel) -> Void
     ) -> LeadingSwipeActionsViewType
     

--- a/StreamChatSwiftUITests/Tests/ChatChannelList/MoreChannelActionsView_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannelList/MoreChannelActionsView_Tests.swift
@@ -23,7 +23,7 @@ class MoreChannelActionsView_Tests: StreamChatTestCase {
         let view = MoreChannelActionsView(
             channel: channel,
             channelActions: actions,
-            currentChannelId: .constant(nil),
+            swipedChannelId: .constant(nil),
             onDismiss: {}
         )
         .frame(width: defaultScreenSize.width, height: defaultScreenSize.height)

--- a/StreamChatSwiftUITests/Tests/ChatChannelList/MoreChannelActionsView_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannelList/MoreChannelActionsView_Tests.swift
@@ -20,8 +20,13 @@ class MoreChannelActionsView_Tests: StreamChatTestCase {
         )
         
         // When
-        let view = MoreChannelActionsView(channel: channel, channelActions: actions, onDismiss: {})
-            .frame(width: defaultScreenSize.width, height: defaultScreenSize.height)
+        let view = MoreChannelActionsView(
+            channel: channel,
+            channelActions: actions,
+            currentChannelId: .constant(nil),
+            onDismiss: {}
+        )
+        .frame(width: defaultScreenSize.width, height: defaultScreenSize.height)
         
         // Then
         assertSnapshot(matching: view, as: .image)

--- a/StreamChatSwiftUITests/Tests/Utils/ViewFactory_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/Utils/ViewFactory_Tests.swift
@@ -91,6 +91,7 @@ class ViewFactory_Tests: StreamChatTestCase {
         // When
         let view = viewFactory.makeMoreChannelActionsView(
             for: channel,
+            currentChannelId: .constant(nil),
             onDismiss: {},
             onError: { _ in }
         )
@@ -484,6 +485,7 @@ class ViewFactory_Tests: StreamChatTestCase {
             channel: .mockDMChannel(),
             offsetX: 80,
             buttonWidth: 40,
+            currentChannelId: .constant(nil),
             buttonTapped: { _ in }
         )
         
@@ -500,6 +502,7 @@ class ViewFactory_Tests: StreamChatTestCase {
             channel: .mockDMChannel(),
             offsetX: 80,
             buttonWidth: 40,
+            currentChannelId: .constant(nil),
             leftButtonTapped: { _ in },
             rightButtonTapped: { _ in }
         )

--- a/StreamChatSwiftUITests/Tests/Utils/ViewFactory_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/Utils/ViewFactory_Tests.swift
@@ -91,7 +91,7 @@ class ViewFactory_Tests: StreamChatTestCase {
         // When
         let view = viewFactory.makeMoreChannelActionsView(
             for: channel,
-            currentChannelId: .constant(nil),
+            swipedChannelId: .constant(nil),
             onDismiss: {},
             onError: { _ in }
         )
@@ -485,7 +485,7 @@ class ViewFactory_Tests: StreamChatTestCase {
             channel: .mockDMChannel(),
             offsetX: 80,
             buttonWidth: 40,
-            currentChannelId: .constant(nil),
+            swipedChannelId: .constant(nil),
             buttonTapped: { _ in }
         )
         
@@ -502,7 +502,7 @@ class ViewFactory_Tests: StreamChatTestCase {
             channel: .mockDMChannel(),
             offsetX: 80,
             buttonWidth: 40,
-            currentChannelId: .constant(nil),
+            swipedChannelId: .constant(nil),
             leftButtonTapped: { _ in },
             rightButtonTapped: { _ in }
         )

--- a/docusaurus/docs/iOS/swiftui/components/helper-views.md
+++ b/docusaurus/docs/iOS/swiftui/components/helper-views.md
@@ -71,7 +71,7 @@ public func makeChannelListItem(
 ) -> ChatChannelSwipeableListItem<Self> {
     ChatChannelSwipeableListItem(
         factory: self,
-        currentChannelId: swipedChannelId,
+        swipedChannelId: swipedChannelId,
         channel: channel,
         channelName: channelName,
         avatar: avatar,
@@ -137,7 +137,7 @@ public func makeTrailingSwipeActionsView(
     channel: ChatChannel,
     offsetX: CGFloat,
     buttonWidth: CGFloat,
-    currentChannelId: Binding<String?>,
+    swipedChannelId: Binding<String?>,
     leftButtonTapped: @escaping (ChatChannel) -> (),
     rightButtonTapped: @escaping (ChatChannel) -> ()
 ) -> some View {
@@ -160,7 +160,7 @@ func makeLeadingSwipeActionsView(
     channel: ChatChannel,
     offsetX: CGFloat,
     buttonWidth: CGFloat,
-    currentChannelId: Binding<String?>,
+    swipedChannelId: Binding<String?>,
     buttonTapped: @escaping (ChatChannel) -> ()
 ) -> some View {
     HStack {
@@ -176,7 +176,7 @@ func makeLeadingSwipeActionsView(
 }
 ```
 
-In both methods, the `currentChannelId` is provided. This parameter provides binding to the currently swiped channel. You can set this value to nil, in case you want to revert back the channel list item to its original state after performing an action.
+In both methods, the `swipedChannelId` is provided. This parameter provides binding to the currently swiped channel. You can set this value to nil, in case you want to revert back the channel list item to its original state after performing an action.
 
 Finally, you need to inject your custom view factory in your view hierarchy.
 

--- a/docusaurus/docs/iOS/swiftui/components/helper-views.md
+++ b/docusaurus/docs/iOS/swiftui/components/helper-views.md
@@ -137,6 +137,7 @@ public func makeTrailingSwipeActionsView(
     channel: ChatChannel,
     offsetX: CGFloat,
     buttonWidth: CGFloat,
+    currentChannelId: Binding<String?>,
     leftButtonTapped: @escaping (ChatChannel) -> (),
     rightButtonTapped: @escaping (ChatChannel) -> ()
 ) -> some View {
@@ -159,6 +160,7 @@ func makeLeadingSwipeActionsView(
     channel: ChatChannel,
     offsetX: CGFloat,
     buttonWidth: CGFloat,
+    currentChannelId: Binding<String?>,
     buttonTapped: @escaping (ChatChannel) -> ()
 ) -> some View {
     HStack {
@@ -173,6 +175,8 @@ func makeLeadingSwipeActionsView(
     }
 }
 ```
+
+In both methods, the `currentChannelId` is provided. This parameter provides binding to the currently swiped channel. You can set this value to nil, in case you want to revert back the channel list item to its original state after performing an action.
 
 Finally, you need to inject your custom view factory in your view hierarchy.
 


### PR DESCRIPTION
### 🔗 Issue Link
[JIRA](https://stream-io.atlassian.net/browse/SWUI-88?atlOrigin=eyJpIjoiN2Y5MzliMzAxMmNhNDYyODk1YTY2NjE0YmE4ZjdiZGUiLCJwIjoiaiJ9)

### 🎯 Goal

- Have only one swiped channel at any given time.
- Possibility to reset the state manually from third-party swipe view.

### 🛠 Implementation

- Reseting the offset when the channel is not active.
- Exposing the currentChanelId in swipe area creation methods.

### 🧪 Testing

Test by swiping through the channels - only one channel can be swiped at given time

### ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
