### PR TITLE
Fixed bug with scrolling of text input field

### DIFF
--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerView.swift
@@ -188,7 +188,7 @@ public struct ComposerInputView<Factory: ViewFactory>: View {
     
     var textFieldHeight: CGFloat {
         let minHeight: CGFloat = 34
-        let maxHeight: CGFloat = 70
+        let maxHeight: CGFloat = 76
             
         if textHeight < minHeight {
             return minHeight

--- a/Sources/StreamChatSwiftUI/Utils/Common/InputTextView.swift
+++ b/Sources/StreamChatSwiftUI/Utils/Common/InputTextView.swift
@@ -24,7 +24,7 @@ class InputTextView: UITextView {
     /// The maximum height of the text view.
     /// When the content in the text view is greater than this height, scrolling will be enabled and the text view's height will be restricted to this value
     open var maximumHeight: CGFloat {
-        70.0
+        76.0
     }
         
     override open func didMoveToSuperview() {
@@ -71,7 +71,7 @@ class InputTextView: UITextView {
         
         heightConstraint = heightAnchor.constraint(equalToConstant: minimumHeight)
         heightConstraint?.isActive = true
-        isScrollEnabled = true
+        isScrollEnabled = false
     }
 
     /// Sets the given text in the current caret position.
@@ -109,13 +109,7 @@ class InputTextView: UITextView {
         }
 
         heightConstraint?.constant = heightToSet
+        isScrollEnabled = heightToSet > minimumHeight
         layoutIfNeeded()
-
-        // This is due to bug in UITextView where the scroll sometimes disables
-        // when a very long text is pasted in it.
-        // Doing this ensures that it doesn't happen
-        // Reference: https://stackoverflow.com/a/33194525/3825788
-        isScrollEnabled = false
-        isScrollEnabled = true
     }
 }


### PR DESCRIPTION
### 🔗 Issue Link
[GitHub](https://github.com/GetStream/stream-chat-swiftui/issues/18)

### 🎯 Goal

Fix for bug when opening the text field.

### 🛠 Implementation

Disabled the scrolling on initial start.

### 🧪 Testing

Just open the text field, there shouldn't be a glitch anymore.

### ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
