### PR TITLE
Removed atomic from the codebase

### DIFF
--- a/DemoAppSwiftUI/NewChatViewModel.swift
+++ b/DemoAppSwiftUI/NewChatViewModel.swift
@@ -21,7 +21,8 @@ class NewChatViewModel: ObservableObject, ChatUserSearchControllerDelegate {
     @Published var state: NewChatState = .initial
     @Published var selectedUsers = [ChatUser]() {
         didSet {
-            if _updatingSelectedUsers.compareAndSwap(old: false, new: true) {
+            if !updatingSelectedUsers {
+                updatingSelectedUsers = true
                 if !selectedUsers.isEmpty {
                     do {
                         try makeChannelController()
@@ -40,8 +41,8 @@ class NewChatViewModel: ObservableObject, ChatUserSearchControllerDelegate {
         }
     }
     
-    @Atomic private var loadingNextUsers: Bool = false
-    @Atomic private var updatingSelectedUsers: Bool = false
+    private var loadingNextUsers: Bool = false
+    private var updatingSelectedUsers: Bool = false
     
     var channelController: ChatChannelController?
     
@@ -95,7 +96,8 @@ class NewChatViewModel: ObservableObject, ChatUserSearchControllerDelegate {
             return
         }
         
-        if _loadingNextUsers.compareAndSwap(old: false, new: true) {
+        if !loadingNextUsers {
+            loadingNextUsers = true
             searchController.loadNextUsers(limit: 50) { [weak self] _ in
                 guard let self = self else { return }
                 self.chatUsers = self.searchController.users

--- a/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListViewModel.swift
@@ -33,7 +33,7 @@ open class ChatChannelListViewModel: ObservableObject, ChatChannelListController
     private var timer: Timer?
     
     /// Controls loading the channels.
-    @Atomic private var loadingNextChannels: Bool = false
+    private var loadingNextChannels: Bool = false
     
     /// Published variables.
     @Published public var channels = LazyCachedMapCollection<ChatChannel>() {
@@ -127,7 +127,8 @@ open class ChatChannelListViewModel: ObservableObject, ChatChannelListController
             return
         }
 
-        if _loadingNextChannels.compareAndSwap(old: false, new: true) {
+        if !loadingNextChannels {
+            loadingNextChannels = true
             controller?.loadNextChannels { [weak self] _ in
                 guard let self = self else { return }
                 self.loadingNextChannels = false
@@ -145,7 +146,8 @@ open class ChatChannelListViewModel: ObservableObject, ChatChannelListController
             return
         }
         
-        if _loadingNextChannels.compareAndSwap(old: false, new: true) {
+        if !loadingNextChannels {
+            loadingNextChannels = true
             messageSearchController.loadNextMessages { [weak self] _ in
                 guard let self = self else { return }
                 self.loadingNextChannels = false


### PR DESCRIPTION
### 🔗 Issue Link
[JIRA](https://stream-io.atlassian.net/browse/SWUI-97?atlOrigin=eyJpIjoiZTA3NzY4ZGE3ZmVhNGU0NmE3Y2QxMzliNDExOTFjZWQiLCJwIjoiaiJ9)

### 🎯 Goal

We don't need to use @Atomic, since the properties are accessed from the main thread.

### 🛠 Implementation

Replaced it with regular booleans.

### 🧪 Testing

Check if the channel list and channel creation behave as expected.

### ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
