### PR TITLE
ChatChannelListView: remove vertical padding

### DIFF
--- a/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListView.swift
@@ -179,7 +179,7 @@ public struct ChatChannelListContentView<Factory: ViewFactory>: View {
     }
     
     public var body: some View {
-        VStack {
+        VStack(spacing: 0) {
             viewFactory.makeChannelListTopView(
                 searchText: $viewModel.searchText
             )


### PR DESCRIPTION
without this, there's padding between the top view/ bottom sticky view in the channel list that a client app can't get rid of
