### PR TITLE
Add token class to dynamically determine when SwiftUI SDK is used

### DIFF
--- a/Sources/StreamChatSwiftUI/SDKIdentifier.swift
+++ b/Sources/StreamChatSwiftUI/SDKIdentifier.swift
@@ -1,8 +1,5 @@
 //
-//  SDKIdentifier.swift
-//  StreamChatSwiftUI
-//
-//  Created by Pol Quintana on 31/5/22.
+// Copyright © 2022 Stream.io Inc. All rights reserved.
 //
 
 import Foundation

--- a/Sources/StreamChatSwiftUI/SDKIdentifier.swift
+++ b/Sources/StreamChatSwiftUI/SDKIdentifier.swift
@@ -1,0 +1,11 @@
+//
+//  SDKIdentifier.swift
+//  StreamChatSwiftUI
+//
+//  Created by Pol Quintana on 31/5/22.
+//
+
+import Foundation
+
+/// Used to dynamically find which frameworks are linked to an app using NSClassFromString
+class SDKIdentifier: NSObject {}

--- a/StreamChatSwiftUI.xcodeproj/project.pbxproj
+++ b/StreamChatSwiftUI.xcodeproj/project.pbxproj
@@ -334,6 +334,7 @@
 		91B763A6283EB39600B458A9 /* MoreChannelActionsFullScreenWrappingView_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91B763A5283EB39600B458A9 /* MoreChannelActionsFullScreenWrappingView_Tests.swift */; };
 		91CC203A283C3E7F0049A146 /* URLExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91CC2039283C3E7F0049A146 /* URLExtensions.swift */; };
 		91CC203C283C4C250049A146 /* URLUtils_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91CC203B283C4C250049A146 /* URLUtils_Tests.swift */; };
+		C14A465B284665B100EF498E /* SDKIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14A465A284665B100EF498E /* SDKIdentifier.swift */; };
 		E3A1C01C282BAC66002D1E26 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = E3A1C01B282BAC66002D1E26 /* Sentry */; };
 /* End PBXBuildFile section */
 
@@ -706,6 +707,7 @@
 		91B763A5283EB39600B458A9 /* MoreChannelActionsFullScreenWrappingView_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoreChannelActionsFullScreenWrappingView_Tests.swift; sourceTree = "<group>"; };
 		91CC2039283C3E7F0049A146 /* URLExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLExtensions.swift; sourceTree = "<group>"; };
 		91CC203B283C4C250049A146 /* URLUtils_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLUtils_Tests.swift; sourceTree = "<group>"; };
+		C14A465A284665B100EF498E /* SDKIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDKIdentifier.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -902,6 +904,7 @@
 				8465FD5D2746A95700AF091E /* README.md */,
 				8465FD602746A95700AF091E /* StreamChatSwiftUI.h */,
 				8465FD682746A95700AF091E /* Info.plist */,
+				C14A465A284665B100EF498E /* SDKIdentifier.swift */,
 			);
 			path = StreamChatSwiftUI;
 			sourceTree = "<group>";
@@ -1642,6 +1645,7 @@
 				84BB4C4C2841104700CBE004 /* MessageListDateUtils.swift in Sources */,
 				8465FD742746A95700AF091E /* ViewFactory.swift in Sources */,
 				8465FDC12746A95700AF091E /* NoChannelsView.swift in Sources */,
+				C14A465B284665B100EF498E /* SDKIdentifier.swift in Sources */,
 				8465FDA32746A95700AF091E /* ViewExtensions.swift in Sources */,
 				8465FDA22746A95700AF091E /* ChatChannelViewModel.swift in Sources */,
 				8465FD982746A95700AF091E /* ReactionsOverlayView.swift in Sources */,


### PR DESCRIPTION
Needed for this PR: https://github.com/GetStream/stream-chat-swift/pull/2035

### 🎯 Goal

We were trying to know the linked SDKs by using canImport. This only works for built/statically linked frameworks. That's why it was working in the Demo app, which uses SPM, but not in the integration apps when using CocoaPods and Carthage.

### 🛠 Implementation

We will dynamically look for the availability of token classes added to both UIKit and SwiftUI SDKs, named SDKIdentifier, to determine if those libraries are linked or not.