### PR TITLE
add isFirstInUsersMessageGroup, isLastInUsersMessageGroup to makeMessageContainerView

### DIFF
--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageContainerView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageContainerView.swift
@@ -23,6 +23,9 @@ public struct MessageContainerView<Factory: ViewFactory>: View {
     var showsAllInfo: Bool
     var isInThread: Bool
     var isLast: Bool
+    var isFirstInUsersMessageGroup: Bool
+    var isLastInUsersMessageGroup: Bool
+
     @Binding var scrolledId: String?
     @Binding var quotedMessage: ChatMessage?
     var onLongPress: (MessageDisplayInfo) -> Void
@@ -45,7 +48,9 @@ public struct MessageContainerView<Factory: ViewFactory>: View {
         isLast: Bool,
         scrolledId: Binding<String?>,
         quotedMessage: Binding<ChatMessage?>,
-        onLongPress: @escaping (MessageDisplayInfo) -> Void
+        onLongPress: @escaping (MessageDisplayInfo) -> Void,
+        isFirstInUsersMessageGroup: Bool,
+        isLastInUsersMessageGroup: Bool
     ) {
         self.factory = factory
         self.channel = channel
@@ -55,6 +60,8 @@ public struct MessageContainerView<Factory: ViewFactory>: View {
         self.isInThread = isInThread
         self.isLast = isLast
         self.onLongPress = onLongPress
+        self.isFirstInUsersMessageGroup = isFirstInUsersMessageGroup
+        self.isLastInUsersMessageGroup = isLastInUsersMessageGroup
         _scrolledId = scrolledId
         _quotedMessage = quotedMessage
     }

--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageListView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageListView.swift
@@ -110,8 +110,11 @@ public struct MessageListView<Factory: ViewFactory>: View, KeyboardReadable {
                     
                     LazyVStack(spacing: 0) {
                         ForEach(messages, id: \.messageId) { message in
-                            var index: Int? = messageListDateUtils.indexForMessageDate(message: message, in: messages)
+                            var index: Int?  = messageListDateUtils.indexForMessageDate(message: message, in: messages)
                             let messageDate: Date? = messageListDateUtils.showMessageDate(for: index, in: messages)
+                            let messageIndex: Int = messages.firstIndex(of: message) ?? 0
+                            let isFirstInUsersMessageGroup: Bool = messages.first == message ? true : messages[messageIndex - 1].author == message.author
+                            let isLastInUsersMessageGroup: Bool = messages.last == message ? true : messages[messageIndex + 1].author == message.author
                             factory.makeMessageContainerView(
                                 channel: channel,
                                 message: message,
@@ -121,7 +124,9 @@ public struct MessageListView<Factory: ViewFactory>: View, KeyboardReadable {
                                 scrolledId: $scrolledId,
                                 quotedMessage: $quotedMessage,
                                 onLongPress: handleLongPress(messageDisplayInfo:),
-                                isLast: message == messages.last
+                                isLast: message == messages.last,
+                                isFirstInUsersMessageGroup: isFirstInUsersMessageGroup,
+                                isLastInUsersMessageGroup: isLastInUsersMessageGroup
                             )
                             .onAppear {
                                 if index == nil {

--- a/Sources/StreamChatSwiftUI/DefaultViewFactory.swift
+++ b/Sources/StreamChatSwiftUI/DefaultViewFactory.swift
@@ -263,7 +263,9 @@ extension ViewFactory {
         scrolledId: Binding<String?>,
         quotedMessage: Binding<ChatMessage?>,
         onLongPress: @escaping (MessageDisplayInfo) -> Void,
-        isLast: Bool
+        isLast: Bool,
+        isFirstInUsersMessageGroup: Bool,
+        isLastInUsersMessageGroup: Bool
     ) -> some View {
         MessageContainerView(
             factory: self,
@@ -275,7 +277,9 @@ extension ViewFactory {
             isLast: isLast,
             scrolledId: scrolledId,
             quotedMessage: quotedMessage,
-            onLongPress: onLongPress
+            onLongPress: onLongPress,
+            isFirstInUsersMessageGroup: isFirstInUsersMessageGroup,
+            isLastInUsersMessageGroup: isLastInUsersMessageGroup
         )
     }
     

--- a/Sources/StreamChatSwiftUI/ViewFactory.swift
+++ b/Sources/StreamChatSwiftUI/ViewFactory.swift
@@ -263,7 +263,9 @@ public protocol ViewFactory: AnyObject {
         scrolledId: Binding<String?>,
         quotedMessage: Binding<ChatMessage?>,
         onLongPress: @escaping (MessageDisplayInfo) -> Void,
-        isLast: Bool
+        isLast: Bool,
+        isFirstInUsersMessageGroup: Bool,
+        isLastInUsersMessageGroup: Bool
     ) -> MessageContainerViewType
     
     associatedtype MessageTextViewType: View


### PR DESCRIPTION
### 🎯 Goal
Usually users send multiple messages in a row and if we want to show author's avatar or author's username near this group of messages we need to know if it is first or last in this group. 
We are adding isFirstInUsersMessageGroup, isLastInUsersMessageGroup properties to makeMessageContainerView to give developers this information.
