### PR TITLE
MessageDisplayInfo: make struct initalizable from outside module

### DIFF
--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageContainerView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageContainerView.swift
@@ -315,10 +315,20 @@ struct SendFailureIndicator: View {
 }
 
 public struct MessageDisplayInfo {
-    let message: ChatMessage
-    let frame: CGRect
-    let contentWidth: CGFloat
-    let isFirst: Bool
-    var showsMessageActions: Bool = true
-    var keyboardWasShown: Bool = false
+    public let message: ChatMessage
+    public let frame: CGRect
+    public let contentWidth: CGFloat
+    public let isFirst: Bool
+    public var showsMessageActions: Bool = true
+    public var keyboardWasShown: Bool = false
+
+    public init(message: ChatMessage, frame: CGRect, contentWidth: CGFloat, isFirst: Bool, showsMessageActions: Bool = true, keyboardWasShown: Bool = false) {
+        self.message = message
+        self.frame = frame
+        self.contentWidth = contentWidth
+        self.isFirst = isFirst
+        self.showsMessageActions = showsMessageActions
+        self.keyboardWasShown = keyboardWasShown
+    }
+
 }


### PR DESCRIPTION
This was causing an issue in our app where the makeMessageContainerView
factory method wasn't being picked up
