### PR TITLE
Scroll to bottom long message bugfix

### DIFF
--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageListView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageListView.swift
@@ -205,7 +205,7 @@ public struct MessageListView<Factory: ViewFactory>: View, KeyboardReadable {
                             }
                         }
                         withAnimation {
-                            scrollView.scrollTo(scrolledId, anchor: .bottom)
+                            scrollView.scrollTo(scrolledId, anchor: .top)
                         }
                     }
                 }


### PR DESCRIPTION


### 🔗 Issue Link
_https://stream-io.atlassian.net/browse/SWUI-177_

### 🎯 Goal

_When pressing the scroll to bottom button, the messages should be scrolled all the way down, even if the messages are very long._

