### PR TITLE
move navigation link out of the ForEach loop

### DIFF
--- a/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelList.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelList.swift
@@ -137,6 +137,17 @@ struct ChannelsLazyVStack<Factory: ViewFactory>: View {
     }
     
     public var body: some View {
+        if let channel = selectedChannel?.channel {
+            NavigationLink(
+                tag: channel.channelSelectionInfo,
+                selection: $selectedChannel
+            ) {
+                LazyView(channelDestination(channel.channelSelectionInfo))
+            } label: {
+                EmptyView()
+            }
+        }
+
         LazyVStack(spacing: 0) {
             ForEach(channels) { channel in
                 factory.makeChannelListItem(

--- a/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelNavigatableListItem.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelNavigatableListItem.swift
@@ -48,15 +48,6 @@ public struct ChatChannelNavigatableListItem<ChannelDestination: View>: View {
                 disabled: disabled,
                 onItemTap: onItemTap
             )
-                                    
-            NavigationLink(
-                tag: channel.channelSelectionInfo,
-                selection: $selectedChannel
-            ) {
-                LazyView(channelDestination(channel.channelSelectionInfo))
-            } label: {
-                EmptyView()
-            }
         }
         .id("\(channel.id)-navigatable")
     }


### PR DESCRIPTION
This PR is fixing booting out from the channel issue. It is hard to reproduce it on default stream test due to different chat members rights. 

Possible STR's: 
- Be In a group you did not create
- Rename group to something else
- Go back into group and remove the name of the group leaving an empty string
- Save and go back to the group
- Open Settings

The idea is to move `NavigationLInk` out of `ForEach` loop on ChatChannelList.swift:152.
This is suggested solution. Maybe there is better one. 

How I came to this solution: [stackoverflow question](https://stackoverflow.com/questions/66017531/swiftui-navigationlink-bug-swiftui-encountered-an-issue-when-pushing-anavigatio/67626758#67626758)