### PR TITLE
InputTextView: make becomeFirstResponder notification name public

### DIFF
--- a/Sources/StreamChatSwiftUI/Utils/Common/InputTextView.swift
+++ b/Sources/StreamChatSwiftUI/Utils/Common/InputTextView.swift
@@ -66,7 +66,7 @@ class InputTextView: UITextView, AccessibilityView {
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(becomeFirstResponder),
-            name: NSNotification.Name(firstResponderNotification),
+            name: NSNotification.Name(GetStream_InputView_BecomeFirstResponder),
             object: nil
         )
     }

--- a/Sources/StreamChatSwiftUI/Utils/KeyboardHandling.swift
+++ b/Sources/StreamChatSwiftUI/Utils/KeyboardHandling.swift
@@ -90,11 +90,11 @@ func resignFirstResponder() {
     )
 }
 
-let firstResponderNotification = "io.getstream.inputView.becomeFirstResponder"
+public let GetStream_InputView_BecomeFirstResponder = "io.getstream.inputView.becomeFirstResponder"
 
 func becomeFirstResponder() {
     NotificationCenter.default.post(
-        name: NSNotification.Name(firstResponderNotification),
+        name: NSNotification.Name(GetStream_InputView_BecomeFirstResponder),
         object: nil
     )
 }


### PR DESCRIPTION
I wasn't sure what the best way to solve this was, but i needed a way to trigger the input text to become the first responder. any ideas on a better public API
