### PR TITLE
InputTextView: make becomeFirstResponder notification name public

### DIFF
--- a/Sources/StreamChatSwiftUI/Utils/Common/InputTextView.swift
+++ b/Sources/StreamChatSwiftUI/Utils/Common/InputTextView.swift
@@ -66,7 +66,7 @@ class InputTextView: UITextView, AccessibilityView {
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(becomeFirstResponder),
-            name: NSNotification.Name(firstResponderNotification),
+            name: NSNotification.Name(getStreamFirstResponderNotification),
             object: nil
         )
     }

--- a/Sources/StreamChatSwiftUI/Utils/KeyboardHandling.swift
+++ b/Sources/StreamChatSwiftUI/Utils/KeyboardHandling.swift
@@ -90,11 +90,11 @@ func resignFirstResponder() {
     )
 }
 
-let firstResponderNotification = "io.getstream.inputView.becomeFirstResponder"
+public let getStreamFirstResponderNotification = "io.getstream.inputView.becomeFirstResponder"
 
 func becomeFirstResponder() {
     NotificationCenter.default.post(
-        name: NSNotification.Name(firstResponderNotification),
+        name: NSNotification.Name(getStreamFirstResponderNotification),
         object: nil
     )
 }


### PR DESCRIPTION
related to https://github.com/GetStream/stream-chat-swiftui/pull/135

we've removed our custom `InputTextView`, using the default one instead
