### PR TITLE
MessageView: make text edge insets injectable

### DIFF
--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageView.swift
@@ -111,16 +111,19 @@ public struct MessageTextView<Factory: ViewFactory>: View {
     @Injected(\.fonts) private var fonts
     @Injected(\.utils) private var utils
     
-    var factory: Factory
-    var message: ChatMessage
-    var isFirst: Bool
+    private let factory: Factory
+    private let message: ChatMessage
+    private let isFirst: Bool
+    private let textEdgeInsets: EdgeInsets
+
     @Binding var scrolledId: String?
 
-    public init(factory: Factory, message: ChatMessage, isFirst: Bool, scrolledId: Binding<String?>) {
+    public init(factory: Factory, message: ChatMessage, isFirst: Bool, textEdgeInsets: EdgeInsets = StandardPaddingModifier.standardInsets, scrolledId: Binding<String?>) {
         self.factory = factory
         self.message = message
         self.isFirst = isFirst
-        _scrolledId = scrolledId
+        self.textEdgeInsets = textEdgeInsets
+        self._scrolledId = scrolledId
     }
     
     public var body: some View {
@@ -138,7 +141,7 @@ public struct MessageTextView<Factory: ViewFactory>: View {
             }
             
             Text(message.text)
-                .standardPadding()
+                .padding(textEdgeInsets)
                 .fixedSize(horizontal: false, vertical: true)
                 .foregroundColor(textColor(for: message))
                 .font(fonts.body)

--- a/Sources/StreamChatSwiftUI/Utils/Modifiers.swift
+++ b/Sources/StreamChatSwiftUI/Utils/Modifiers.swift
@@ -34,11 +34,12 @@ struct ShadowModifier: ViewModifier {
 }
 
 /// View modifier that applies default padding to elements.
-struct StandardPaddingModifier: ViewModifier {
-    func body(content: Content) -> some View {
+public struct StandardPaddingModifier: ViewModifier {
+    public static let standardInsets: EdgeInsets = EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16)
+
+    public func body(content: Content) -> some View {
         content
-            .padding(.horizontal, 16)
-            .padding(.vertical, 8)
+            .padding(Self.standardInsets)
     }
 }
 


### PR DESCRIPTION
For messages that have a quoted reply above the message text, we wanted to reduce the padding
