### PR TITLE
MessageDisplayOptions: make showing avatars configurable between DMs or groups

### DIFF
--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageContainerView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageContainerView.swift
@@ -67,7 +67,12 @@ public struct MessageContainerView<Factory: ViewFactory>: View {
                 if message.isSentByCurrentUser {
                     MessageSpacer(spacerWidth: spacerWidth)
                 } else {
-                    if messageListConfig.messageDisplayOptions.showAvatars {
+                    if messageListConfig.messageDisplayOptions.showAvatarsInDirectMessages && channel.isDirectMessageChannel {
+                        factory.makeMessageAvatarView(
+                            for: utils.messageCachingUtils.authorInfo(from: message)
+                        )
+                        .opacity(showsAllInfo ? 1 : 0)
+                    } else if messageListConfig.messageDisplayOptions.showAvatarsInGroups && !channel.isDirectMessageChannel {
                         factory.makeMessageAvatarView(
                             for: utils.messageCachingUtils.authorInfo(from: message)
                         )

--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageListConfig.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageListConfig.swift
@@ -74,7 +74,8 @@ public enum DateIndicatorPlacement {
 /// Used to show and hide different helper views around the message.
 public struct MessageDisplayOptions {
         
-    public let showAvatars: Bool
+    public let showAvatarsInDirectMessages: Bool
+    public let showAvatarsInGroups: Bool
     public let showMessageDate: Bool
     public let showAuthorName: Bool
     public let animateChanges: Bool
@@ -88,7 +89,8 @@ public struct MessageDisplayOptions {
     public let spacerWidth: (CGFloat) -> CGFloat
     
     public init(
-        showAvatars: Bool = true,
+        showAvatarsInDirectMessages: Bool = true,
+        showAvatarsInGroups: Bool = true,
         showMessageDate: Bool = true,
         showAuthorName: Bool = true,
         animateChanges: Bool = true,
@@ -102,11 +104,12 @@ public struct MessageDisplayOptions {
             .defaultLinkDisplay,
         spacerWidth: @escaping (CGFloat) -> CGFloat = MessageDisplayOptions.defaultSpacerWidth
     ) {
-        self.showAvatars = showAvatars
+        self.showAvatarsInDirectMessages = showAvatarsInDirectMessages
+        self.showAvatarsInGroups = showAvatarsInGroups
         self.showAuthorName = showAuthorName
         self.showMessageDate = showMessageDate
         self.animateChanges = animateChanges
-        dateLabelSize = overlayDateLabelSize
+        self.dateLabelSize = overlayDateLabelSize
         self.minimumSwipeGestureDistance = minimumSwipeGestureDistance
         self.currentUserMessageTransition = currentUserMessageTransition
         self.otherUserMessageTransition = otherUserMessageTransition

--- a/Sources/StreamChatSwiftUI/ChatChannel/Reactions/ReactionsOverlayView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Reactions/ReactionsOverlayView.swift
@@ -67,7 +67,8 @@ public struct ReactionsOverlayView<Factory: ViewFactory>: View {
                 }
             
             if !messageDisplayInfo.message.isSentByCurrentUser &&
-                utils.messageListConfig.messageDisplayOptions.showAvatars {
+                ((utils.messageListConfig.messageDisplayOptions.showAvatarsInDirectMessages && channel.isDirectMessageChannel) ||
+                 (utils.messageListConfig.messageDisplayOptions.showAvatarsInGroups && !channel.isDirectMessageChannel)) {
                 factory.makeMessageAvatarView(
                     for: utils.messageCachingUtils.authorInfo(from: messageDisplayInfo.message)
                 )


### PR DESCRIPTION
we wanted to show avatars in group chats, but not DMs
