### PR TITLE
Add a shadow for a play icon

### DIFF
--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/VideoAttachmentView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/VideoAttachmentView.swift
@@ -157,6 +157,7 @@ struct VideoAttachmentContentView: View {
                             .customizable()
                             .frame(width: 24)
                             .foregroundColor(.white)
+                            .modifier(ShadowModifier())
                     }
                     .frame(width: width, height: width * ratio)
                     .contentShape(Rectangle())


### PR DESCRIPTION
Hi!
The play icon is not visible enough on white backgrounds. 
Added a shadow.