### PR TITLE
fix header flickering

### DIFF
--- a/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelView.swift
@@ -76,10 +76,7 @@ public struct ChatChannelView<Factory: ViewFactory>: View, KeyboardReadable {
                         .if(viewModel.reactionsShown, transform: { view in
                             view.navigationBarHidden(true)
                         })
-                        .if(viewModel.channelHeaderType == .regular) { view in
-                            view.modifier(factory.makeChannelHeaderViewModifier(for: channel))
-                        }
-                        .if(viewModel.channelHeaderType == .typingIndicator) { view in
+                        .if(viewModel.channelHeaderType == .regular || viewModel.channelHeaderType == .typingIndicator) { view in
                             view.modifier(factory.makeChannelHeaderViewModifier(for: channel))
                         }
                         .if(viewModel.channelHeaderType == .messageThread) { view in


### PR DESCRIPTION
Bug: Header flickers

STR's: 
1. open a channel
2. receive many messages from channel participant
3. sometimes you will see header redrawing 

https://user-images.githubusercontent.com/102264702/183126227-13b6691a-df0c-46d7-b6d2-5a53aa13ee12.mp4

this change should fix header flickering 