### PR TITLE
Make `MessageActionInfo` attributes public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🐞 Fixed
 - Renaming of a channel in ChannelInfo not persisting extra data
-- Channel list item swipe gesture collision with native gesture 
+- Channel list item swipe gesture collision with native gesture
+- Attributes from `MessageActionInfo` are now public
 
 # [4.24.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.24.0)
 _November 16, 2022_

--- a/Sources/StreamChatSwiftUI/ChatChannel/Reactions/MessageActions/MessageActionsViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Reactions/MessageActions/MessageActionsViewModel.swift
@@ -54,8 +54,8 @@ public struct MessageAction: Identifiable, Equatable {
 
 /// Provides information about a performed `MessageAction`.
 public struct MessageActionInfo {
-    let message: ChatMessage
-    let identifier: String
+    public let message: ChatMessage
+    public let identifier: String
     
     public init(message: ChatMessage, identifier: String) {
         self.message = message


### PR DESCRIPTION
### 🔗 Issue Link
https://github.com/GetStream/stream-chat-swiftui/issues/236

### 🎯 Goal

Having the attributes from `MessageActionInfo` available publicly will allow to customize the behavior in a customized `ChatChannelViewModel`, in the `messageActionExecuted()` function.

### 🛠 Implementation

The attributes simply have the `public` modifier now.

### 🧪 Testing

This should not bring side effects to the available tests.

### 🎨 Changes

No UI changes.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] Affected documentation updated (docusaurus, tutorial, CMS (task created)
