### PR TITLE
Add the possibility to customize the cornerRadius of the ComposeInputView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Possibility to customize message reactions top padding (for grid-based reaction containers)
 - Custom sorting of reactions
 - Added a configurable separator view for new messages
+- Possibility to customize the cornerRadius of the `ComposerInputView`
 
 # [4.26.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.26.0)
 _January 16, 2023_

--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/ComposerConfig.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/ComposerConfig.swift
@@ -9,6 +9,7 @@ public struct ComposerConfig {
 
     public var inputViewMinHeight: CGFloat
     public var inputViewMaxHeight: CGFloat
+    public var inputViewCornerRadius: CGFloat
     public var inputFont: UIFont
     public var adjustMessageOnSend: (String) -> (String)
     public var adjustMessageOnRead: (String) -> (String)
@@ -16,12 +17,14 @@ public struct ComposerConfig {
     public init(
         inputViewMinHeight: CGFloat = 38,
         inputViewMaxHeight: CGFloat = 76,
+        inputViewCornerRadius: CGFloat = 20,
         inputFont: UIFont = UIFont.preferredFont(forTextStyle: .body),
         adjustMessageOnSend: @escaping (String) -> (String) = { $0 },
         adjustMessageOnRead: @escaping (String) -> (String) = { $0 }
     ) {
         self.inputViewMinHeight = inputViewMinHeight
         self.inputViewMaxHeight = inputViewMaxHeight
+        self.inputViewCornerRadius = inputViewCornerRadius
         self.inputFont = inputFont
         self.adjustMessageOnSend = adjustMessageOnSend
         self.adjustMessageOnRead = adjustMessageOnRead

--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerView.swift
@@ -343,11 +343,11 @@ public struct ComposerInputView<Factory: ViewFactory>: View {
         .padding(.leading, 8)
         .background(composerInputBackground)
         .overlay(
-            RoundedRectangle(cornerRadius: 20)
+            RoundedRectangle(cornerRadius: TextSizeConstants.cornerRadius)
                 .stroke(Color(colors.innerBorder))
         )
         .clipShape(
-            RoundedRectangle(cornerRadius: 20)
+            RoundedRectangle(cornerRadius: TextSizeConstants.cornerRadius)
         )
         .accessibilityIdentifier("ComposerInputView")
     }

--- a/Sources/StreamChatSwiftUI/Utils/Common/InputTextView.swift
+++ b/Sources/StreamChatSwiftUI/Utils/Common/InputTextView.swift
@@ -18,6 +18,10 @@ struct TextSizeConstants {
     static var minThreshold: CGFloat {
         composerConfig.inputViewMinHeight
     }
+
+    static var cornerRadius: CGFloat {
+        composerConfig.inputViewCornerRadius
+    }
 }
 
 class InputTextView: UITextView, AccessibilityView {


### PR DESCRIPTION
### 🎯 Goal

Right now the `cornerRadius` of the `ComposeInputView` is fixed to `20`. This PR allows the configuration of the `cornerRadius` for individual needs.

### 🛠 Implementation

The `ComposerConfig` get extended with a new property `inputViewCornerRadius`. This value will be used to generate the `RoundedRectangle` shape around the `TextInputView`

### 🧪 Testing

This should not bring side effects to the available tests.

### 🎨 Changes

<img src='https://user-images.githubusercontent.com/2777284/217263813-0e031fa7-bf1b-46c6-8343-1757a80b7950.png' width='45%'><img src='https://user-images.githubusercontent.com/2777284/217263831-3835c36f-945e-4f03-bbf9-c40926fbe093.png' width='45%'>


### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
