### PR TITLE
Use channel type instead of always using ChannelType messaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🐞 Fixed
 - Fixed the text input cursor when a message is being edited
+- Fixed channel list view model always not using passed channel type for deletion
 
 ### ✅ Added
 - Added a factory method for customizing the composer text input view

--- a/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListViewModel.swift
@@ -197,7 +197,7 @@ open class ChatChannelListViewModel: ObservableObject, ChatChannelListController
 
     public func delete(channel: ChatChannel) {
         let controller = chatClient.channelController(
-            for: .init(type: .messaging, id: channel.cid.id)
+            for: .init(type: channel.type, id: channel.cid.id)
         )
 
         controller.deleteChannel { [weak self] error in


### PR DESCRIPTION
### 🔗 Issue Link
#310 

### 🎯 Goal

Use channel's type for deletion instead of hardcoding the `messaging` `ChannelType` 

### 🛠 Implementation

Change the initializer for the channel id in the `ChatChannelListViewModel` delete function to use the channel's type.

### 🧪 Testing

Can be tested with the `test_channelListVM_onDeleteTapped` function

### 🎨 Changes

None

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] Affected documentation updated (docusaurus, tutorial, CMS (task created)
