### PR TITLE
fix: https://github.com/GetStream/stream-chat-swiftui/issues/317

### DIFF
--- a/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelView.swift
@@ -179,6 +179,7 @@ public struct ChatChannelView<Factory: ViewFactory>: View, KeyboardReadable {
         )
         .padding(.bottom, keyboardShown || !tabBarAvailable || generatingSnapshot ? 0 : bottomPadding)
         .ignoresSafeArea(.container, edges: tabBarAvailable ? .bottom : [])
+        .accessibilityElement(children: .contain)
         .accessibilityIdentifier("ChatChannelView")
     }
 


### PR DESCRIPTION
apply accessibility identifier to container view

### 🔗 Issue Link
https://github.com/GetStream/stream-chat-swiftui/issues/317

### 🎯 Goal

Fix multiple views have same accessibility identifier

### 🛠 Implementation

use `.accessibilityElement(children: .contain)`

### 🧪 Testing

UI Test

### 🎨 Changes



### ☑️ Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] Changelog is updated with client-facing changes
- [X] New code is covered by unit tests
- [X] Affected documentation updated (docusaurus, tutorial, CMS (task created)
