### PR TITLE
Resolve multiple matches for ChatChannelView accessibility identifier

### DIFF
--- a/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelView.swift
@@ -179,6 +179,7 @@ public struct ChatChannelView<Factory: ViewFactory>: View, KeyboardReadable {
         )
         .padding(.bottom, keyboardShown || !tabBarAvailable || generatingSnapshot ? 0 : bottomPadding)
         .ignoresSafeArea(.container, edges: tabBarAvailable ? .bottom : [])
+        .accessibilityElement(children: .contain)
         .accessibilityIdentifier("ChatChannelView")
     }
 

--- a/StreamChatSwiftUITestsAppTests/Pages/MessageListPage.swift
+++ b/StreamChatSwiftUITestsAppTests/Pages/MessageListPage.swift
@@ -24,7 +24,7 @@ class MessageListPage {
     }
 
     static var list: XCUIElement {
-        app.scrollViews.matching(NSPredicate(format: "identifier LIKE 'ChatChannelView' or identifier LIKE 'MessageListScrollView'")).firstMatch
+        app.scrollViews.matching(NSPredicate(format: "identifier LIKE 'MessageListView' or identifier LIKE 'MessageListScrollView'")).firstMatch
     }
 
     static var typingIndicator: XCUIElement {


### PR DESCRIPTION
### 🔗 Issue Link

Resolves https://github.com/GetStream/stream-chat-swiftui/issues/317
Resolves https://github.com/GetStream/stream-chat-swiftui/pull/318

### 🎯 Goal

Resolve multiple matches for ChatChannelView accessibility identifier

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
