### PR TITLE
Update .spi.yml

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -4,3 +4,4 @@ builder:
   - platform: ios
     documentation_targets: [StreamChatSwiftUI]
     scheme: StreamChatSwiftUI
+    swift_version: 5.8


### PR DESCRIPTION
We're about to switch documentation generation to 5.9 by default. Our regression test suite is flagging a doc gen failure for stream-chat-swiftui when running with 5.9:

```
SwiftDocC/DocumentationContext.swift:1206: Fatal error: Symbol with identifier 's:10StreamChat19MessageReactionTypeV0aB7SwiftUIE2idSSvp' has no reference. A symbol will always have at least one reference.
Command CompileDocumentation failed with a nonzero exit code
```

This change pins the documentation generation to 5.8 for now.

Steps to reproduce:

Either just via Product → Build Documentation in Xcode 15 or as follows (which is essentially what we do to generate docs):

```
git clone https://github.com/GetStream/stream-chat-swiftui/
cd stream-chat-swiftui/
git checkout 4.37.0
env DEVELOPER_DIR=/Applications/Xcode-15.0.0.app xcrun \
            xcodebuild \
            -IDEClonedSourcePackagesDirPathOverride="$PWD/.dependencies" \
            -derivedDataPath "$PWD/.derivedData" \
            docbuild \
            OTHER_DOCC_FLAGS=--emit-digest \
            -scheme StreamChatSwiftUI \
            -destination 'generic/platform=ios'
```