### PR TITLE
Fix an issue where new messages are marked read in background

### DIFF
--- a/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelView.swift
@@ -13,8 +13,6 @@ public struct ChatChannelView<Factory: ViewFactory>: View, KeyboardReadable {
 
     @StateObject private var viewModel: ChatChannelViewModel
 
-    @Environment(\.presentationMode) var presentationMode
-
     @State private var messageDisplayInfo: MessageDisplayInfo?
     @State private var keyboardShown = false
     @State private var tabBarAvailable: Bool = false
@@ -164,13 +162,6 @@ public struct ChatChannelView<Factory: ViewFactory>: View, KeyboardReadable {
         .onDisappear {
             viewModel.onViewDissappear()
         }
-        .onChange(of: presentationMode.wrappedValue, perform: { newValue in
-            if newValue.isPresented == false {
-                viewModel.onViewDissappear()
-            } else {
-                viewModel.setActive()
-            }
-        })
         .background(
             isIphone ?
                 Color.clear.background(


### PR DESCRIPTION
### 🔗 Issue Link

https://github.com/GetStream/stream-chat-swiftui/issues/399

### 🎯 Goal

Prevent new messages being marked read while app is backgrounded.

### 🛠 Implementation

Replace `presentationMode` with the `NotificationCenter`-based application notifications -- `willEnterForegroundNotification` & `didEnterBackgroundNotification`.

### 🧪 Testing

1. Open a chat thread.
2. Background app.
3. Receive a new chat message to the chat thread.
4. Verify the app icon shows unread badge and the badge doesn't clear until user opens the  app.

### 🎨 Changes

_Add relevant screenshots or videos showcasing the changes._

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
