### PR TITLE
ViewFactory: add variant of makeMessageListContainerModifier with channel

### DIFF
--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageListView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageListView.swift
@@ -304,6 +304,7 @@ public struct MessageListView<Factory: ViewFactory>: View, KeyboardReadable {
                 ) : nil
         )
         .modifier(factory.makeMessageListContainerModifier())
+        .modifier(factory.makeMessageListContainerModifier(channel: channel))
         .modifier(HideKeyboardOnTapGesture(shouldAdd: keyboardShown))
         .onDisappear {
             messageRenderingUtil.update(previousTopMessage: nil)

--- a/Sources/StreamChatSwiftUI/DefaultViewFactory.swift
+++ b/Sources/StreamChatSwiftUI/DefaultViewFactory.swift
@@ -235,6 +235,10 @@ extension ViewFactory {
         EmptyViewModifier()
     }
     
+    public func makeMessageListContainerModifier(channel: ChatChannel) -> some ViewModifier {
+        EmptyViewModifier()
+    }
+    
     public func makeMessageViewModifier(for messageModifierInfo: MessageModifierInfo) -> some ViewModifier {
         MessageBubbleModifier(
             message: messageModifierInfo.message,

--- a/Sources/StreamChatSwiftUI/ViewFactory.swift
+++ b/Sources/StreamChatSwiftUI/ViewFactory.swift
@@ -228,6 +228,10 @@ public protocol ViewFactory: AnyObject {
     /// Returns a view modifier applied to the message list container.
     func makeMessageListContainerModifier() -> MessageListContainerModifier
 
+    associatedtype MessageListContainerWithChannelModifier: ViewModifier
+    /// Returns a view modifier applied to the message list container.
+    func makeMessageListContainerModifier(channel: ChatChannel) -> MessageListContainerWithChannelModifier
+    
     associatedtype MessageViewModifier: ViewModifier
     /// Returns a view modifier applied to the message view.
     /// - Parameter messageModifierInfo: the message modifier info, that will be applied to the message.


### PR DESCRIPTION
i've just added a new view factory function with a channel param. shouldn't be a breaking change

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
