### PR TITLE
Voice recording messages now use the standard message modifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🔄 Changed
 - Author name display now depends on number of participants, not channel type
 
+### 🐞 Fixed
+- Voice recording messages now use the standard message modifier
+
 ### 🔄 Changed
 
 # [4.48.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.48.0)

--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/AsyncVoiceMessages/VoiceRecordingContainerView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/AsyncVoiceMessages/VoiceRecordingContainerView.swift
@@ -91,7 +91,15 @@ public struct VoiceRecordingContainerView<Factory: ViewFactory>: View {
         .background(Color(colors.background))
         .cornerRadius(16)
         .padding(.all, 4)
-        .messageBubble(for: message, isFirst: isFirst)
+        .modifier(
+            factory.makeMessageViewModifier(
+                for: 
+                    MessageModifierInfo(
+                        message: message,
+                        isFirst: isFirst
+                    )
+            )
+        )
     }
     
     private func index(for attachment: ChatMessageVoiceRecordingAttachment) -> Int {

--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/AsyncVoiceMessages/VoiceRecordingContainerView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/AsyncVoiceMessages/VoiceRecordingContainerView.swift
@@ -93,11 +93,7 @@ public struct VoiceRecordingContainerView<Factory: ViewFactory>: View {
         .padding(.all, 4)
         .modifier(
             factory.makeMessageViewModifier(
-                for: 
-                    MessageModifierInfo(
-                        message: message,
-                        isFirst: isFirst
-                    )
+                for: MessageModifierInfo(message: message, isFirst: isFirst)
             )
         )
     }


### PR DESCRIPTION
### 🔗 Issue Link
Resolves https://github.com/GetStream/stream-chat-swiftui/issues/440.

### 🎯 Goal

_Describe why we are making this change._

### 🛠 Implementation

_Provide a description of the implementation._

### 🧪 Testing

_Describe the steps how this change can be tested (or why it can't be tested)._

### 🎨 Changes

_Add relevant screenshots or videos showcasing the changes._

### ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
