### PR TITLE
Fixed an issue in the demo app when switching users

### DIFF
--- a/DemoAppSwiftUI/CustomChannelHeader.swift
+++ b/DemoAppSwiftUI/CustomChannelHeader.swift
@@ -79,7 +79,7 @@ struct CustomChannelModifier: ChannelListHeaderViewModifier {
                     message: Text("Are you sure you want to sign out?"),
                     primaryButton: .destructive(Text("Sign out")) {
                         withAnimation {
-                            chatClient.disconnect {
+                            chatClient.logout {
                                 UnsecureRepository.shared.removeCurrentUser()
                                 DispatchQueue.main.async {
                                     AppState.shared.userState = .notLoggedIn

--- a/DemoAppSwiftUI/DemoAppSwiftUIApp.swift
+++ b/DemoAppSwiftUI/DemoAppSwiftUIApp.swift
@@ -70,6 +70,7 @@ class AppState: ObservableObject {
             }
         }
     }
+    
     var channelListController: ChatChannelListController?
 
     static let shared = AppState()

--- a/DemoAppSwiftUI/DemoAppSwiftUIApp.swift
+++ b/DemoAppSwiftUI/DemoAppSwiftUIApp.swift
@@ -15,8 +15,10 @@ struct DemoAppSwiftUIApp: App {
     @ObservedObject var appState = AppState.shared
     @ObservedObject var notificationsHandler = NotificationsHandler.shared
     
-    @State var channelListController: ChatChannelListController?
-
+    var channelListController: ChatChannelListController? {
+        appState.channelListController
+    }
+    
     var body: some Scene {
         WindowGroup {
             switch appState.userState {
@@ -51,11 +53,9 @@ struct DemoAppSwiftUIApp: App {
                             .init(key: .updatedAt)
                         ]
                     )
-                    channelListController = chatClient.channelListController(query: channelListQuery)
+                    appState.channelListController = chatClient.channelListController(query: channelListQuery)
                 }
                 notificationsHandler.setupRemoteNotifications()
-            } else if newValue == .notLoggedIn {
-                channelListController = nil
             }
         }
     }
@@ -63,7 +63,14 @@ struct DemoAppSwiftUIApp: App {
 
 class AppState: ObservableObject {
 
-    @Published var userState: UserState = .launchAnimation
+    @Published var userState: UserState = .launchAnimation {
+        willSet {
+            if newValue == .notLoggedIn && userState == .loggedIn {
+                channelListController = nil
+            }
+        }
+    }
+    var channelListController: ChatChannelListController?
 
     static let shared = AppState()
 

--- a/DemoAppSwiftUI/DemoAppSwiftUIApp.swift
+++ b/DemoAppSwiftUI/DemoAppSwiftUIApp.swift
@@ -54,6 +54,8 @@ struct DemoAppSwiftUIApp: App {
                     channelListController = chatClient.channelListController(query: channelListQuery)
                 }
                 notificationsHandler.setupRemoteNotifications()
+            } else if newValue == .notLoggedIn {
+                channelListController = nil
             }
         }
     }


### PR DESCRIPTION
### 🎯 Goal

When we logout, we should set the channel list controller to nil, it's causing a caching issue on the SwiftUI view otherwise.

### 🛠 Implementation

_Provide a description of the implementation._

### 🧪 Testing

_Describe the steps how this change can be tested (or why it can't be tested)._

### 🎨 Changes

_Add relevant screenshots or videos showcasing the changes._

### ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
