### PR TITLE
Fix reactions picker for large messages sometimes goes in the safe area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### 🐞 Fixed
+- Reactions picker for large messages sometimes goes in the safe area
 
 # [4.50.1](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.50.1)
 _March 14, 2024_

--- a/Sources/StreamChatSwiftUI/ChatChannel/Reactions/ReactionsOverlayView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Reactions/ReactionsOverlayView.swift
@@ -258,7 +258,7 @@ public struct ReactionsOverlayView<Factory: ViewFactory>: View {
     }
 
     private var messageContainerHeight: CGFloat {
-        let maxAllowed = screenHeight / 2
+        let maxAllowed = screenHeight / 2 - topSafeArea
         let containerHeight = messageDisplayInfo.frame.height
         return containerHeight > maxAllowed ? maxAllowed : containerHeight
     }
@@ -281,7 +281,7 @@ public struct ReactionsOverlayView<Factory: ViewFactory>: View {
             messageDisplayInfo.showsMessageActions ? messageActionsSize : userReactionsPopupHeight
         var originY = messageDisplayInfo.frame.origin.y
         let minOrigin: CGFloat = 100
-        let maxOrigin: CGFloat = screenHeight - messageContainerHeight - bottomPopupOffset - minOrigin - bottomOffset
+        let maxOrigin: CGFloat = screenHeight + topSafeArea - messageContainerHeight - bottomPopupOffset - minOrigin - bottomOffset
         if originY < minOrigin {
             originY = minOrigin
         } else if originY > maxOrigin {


### PR DESCRIPTION
### 🔗 Issue Link
https://github.com/GetStream/ios-issues-tracking/issues/771

### 🎯 Goal

Fix an issue when sometimes the reactions picker goes into the safe area.

### 🛠 Implementation

Include the top safe area in the equation.

### 🧪 Testing

- Test with large message by long pressing somewhere near its top.
- Other reactions should be unaffected.

### 🎨 Changes

_Add relevant screenshots or videos showcasing the changes._

### ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
