### PR TITLE
Fixed loading of pinned messages in the channel info screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🐞 Fixed
 - Reactions picker for large messages sometimes goes in the safe area
+- Loading of pinned messages in the channel info screen
 
 # [4.50.1](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.50.1)
 _March 14, 2024_

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/ChatChannelInfoHelperViews.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/ChatChannelInfoHelperViews.swift
@@ -88,7 +88,10 @@ public struct ChatInfoOptionsView: View {
                 icon: images.pin,
                 title: L10n.ChatInfo.PinnedMessages.title
             ) {
-                PinnedMessagesView(channel: viewModel.channel)
+                PinnedMessagesView(
+                    channel: viewModel.channel,
+                    channelController: viewModel.channelController
+                )
             }
 
             Divider()

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/ChatChannelInfoViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/ChatChannelInfoViewModel.swift
@@ -45,7 +45,7 @@ public class ChatChannelInfoViewModel: ObservableObject, ChatChannelControllerDe
         channel.ownCapabilities.contains(.updateChannel)
     }
 
-    private var channelController: ChatChannelController!
+    var channelController: ChatChannelController!
     private var memberListController: ChatChannelMemberListController!
     private var loadingUsers = false
 

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/PinnedMessagesView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/PinnedMessagesView.swift
@@ -10,9 +10,12 @@ public struct PinnedMessagesView: View {
 
     @StateObject private var viewModel: PinnedMessagesViewModel
 
-    public init(channel: ChatChannel) {
+    public init(channel: ChatChannel, channelController: ChatChannelController? = nil) {
         _viewModel = StateObject(
-            wrappedValue: PinnedMessagesViewModel(channel: channel)
+            wrappedValue: PinnedMessagesViewModel(
+                channel: channel,
+                channelController: channelController
+            )
         )
     }
 

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/PinnedMessagesViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/PinnedMessagesViewModel.swift
@@ -12,9 +12,32 @@ public class PinnedMessagesViewModel: ObservableObject {
     private let channel: ChatChannel
 
     @Published var pinnedMessages: [ChatMessage]
-
-    public init(channel: ChatChannel) {
+    
+    private var channelController: ChatChannelController?
+    
+    public init(channel: ChatChannel, channelController: ChatChannelController? = nil) {
         self.channel = channel
-        pinnedMessages = channel.pinnedMessages
+        if channelController != nil {
+            pinnedMessages = []
+        } else {
+            pinnedMessages = channel.pinnedMessages
+        }
+        self.channelController = channelController
+        loadPinnedMessages()
+    }
+    
+    private func loadPinnedMessages() {
+        channelController?.loadPinnedMessages(completion: { [weak self] result in
+            switch result {
+            case .success(let messages):
+                withAnimation {
+                    self?.pinnedMessages = messages
+                }
+                log.debug("Successfully loaded pinned messages")
+            case .failure(let error):
+                self?.pinnedMessages = self?.channel.pinnedMessages ?? []
+                log.error("Error loading pinned messages \(error.localizedDescription)")
+            }
+        })
     }
 }

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/PinnedMessagesViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/PinnedMessagesViewModel.swift
@@ -26,15 +26,17 @@ public class PinnedMessagesViewModel: ObservableObject {
         loadPinnedMessages()
     }
     
+    //MARK: - private
+    
     private func loadPinnedMessages() {
         channelController?.loadPinnedMessages(completion: { [weak self] result in
             switch result {
-            case .success(let messages):
+            case let .success(messages):
                 withAnimation {
                     self?.pinnedMessages = messages
                 }
                 log.debug("Successfully loaded pinned messages")
-            case .failure(let error):
+            case let .failure(error):
                 self?.pinnedMessages = self?.channel.pinnedMessages ?? []
                 log.error("Error loading pinned messages \(error.localizedDescription)")
             }

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/PinnedMessagesViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/PinnedMessagesViewModel.swift
@@ -26,7 +26,7 @@ public class PinnedMessagesViewModel: ObservableObject {
         loadPinnedMessages()
     }
     
-    //MARK: - private
+    // MARK: - private
     
     private func loadPinnedMessages() {
         channelController?.loadPinnedMessages(completion: { [weak self] result in

--- a/Sources/StreamChatSwiftUI/ChatChannel/Reactions/ReactionsOverlayView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Reactions/ReactionsOverlayView.swift
@@ -281,7 +281,7 @@ public struct ReactionsOverlayView<Factory: ViewFactory>: View {
             messageDisplayInfo.showsMessageActions ? messageActionsSize : userReactionsPopupHeight
         var originY = messageDisplayInfo.frame.origin.y
         let minOrigin: CGFloat = 100
-        let maxOrigin: CGFloat = screenHeight + topSafeArea - messageContainerHeight - bottomPopupOffset - minOrigin - bottomOffset
+        let maxOrigin: CGFloat = screenHeight - messageContainerHeight - bottomPopupOffset - minOrigin - bottomOffset
         if originY < minOrigin {
             originY = minOrigin
         } else if originY > maxOrigin {


### PR DESCRIPTION
### 🔗 Issue Link
Resolves https://github.com/GetStream/ios-issues-tracking/issues/773.

### 🎯 Goal

Accessing the pinned messages directly from the channel is not reliable, we need to load them from the controller.

### 🛠 Implementation

Pagination is out of scope for this one, we just improve the initial loading.

### 🧪 Testing

Open a channel with pinned messages - loading should be consistent.

### 🎨 Changes

_Add relevant screenshots or videos showcasing the changes._

### ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
