### PR TITLE
Do not access local state when updating the state in sink()

### DIFF
--- a/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelDataSource.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelDataSource.swift
@@ -24,7 +24,7 @@ protocol MessagesDataSource: AnyObject {
     ///  - channel: the updated channel.
     @MainActor func dataSource(
         channelDataSource: ChannelDataSource,
-        didUpdateChannel channel: EntityChange<ChatChannel>
+        didUpdateChannel channel: ChatChannel
     )
 }
 
@@ -117,7 +117,7 @@ class ChatChannelDataSource: ChannelDataSource {
             if let channel {
                 delegate?.dataSource(
                     channelDataSource: self,
-                    didUpdateChannel: .update(channel)
+                    didUpdateChannel: channel
                 )
             }
         }
@@ -178,12 +178,11 @@ class MessageThreadDataSource: ChannelDataSource {
         Task { @MainActor in
             self.messageState = try await chat.makeMessageState(for: messageId)
             self.messageState?.$replies
-                .receive(on: RunLoop.main)
                 .sink(receiveValue: { [weak self] messages in
                 guard let self else { return }
                 delegate?.dataSource(
                     channelDataSource: self,
-                    didUpdateMessages: StreamCollection(messages)
+                    didUpdateMessages: messages
                 )
             })
             .store(in: &cancellables)
@@ -201,12 +200,11 @@ class MessageThreadDataSource: ChannelDataSource {
         self.messageState = messageState
         Task { @MainActor in
             self.messageState?.$replies
-                .receive(on: RunLoop.main)
                 .sink(receiveValue: { [weak self] messages in
                 guard let self else { return }
                 delegate?.dataSource(
                     channelDataSource: self,
-                    didUpdateMessages: StreamCollection(messages)
+                    didUpdateMessages: messages
                 )
             })
             .store(in: &cancellables)

--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerViewModel.swift
@@ -231,7 +231,7 @@ import SwiftUI
         completion: @escaping () -> Void
     ) {
         defer {
-            checkChannelCooldown()
+            checkChannelCooldown(for: chat.state.channel)
         }
         
         if let composerCommand = composerCommand, composerCommand.id != "instantCommands" {
@@ -626,19 +626,19 @@ import SwiftUI
     }
     
     private func listenToCooldownUpdates() {
-        chat.state.$channel.sink { [weak self] value in
+        chat.state.$channel.sink { [weak self] channel in
             guard self?.isSlowModeDisabled == false else { return }
-            let cooldownDuration = value?.cooldownDuration ?? 0
+            let cooldownDuration = channel?.cooldownDuration ?? 0
             if self?.cooldownPeriod == cooldownDuration {
                 return
             }
             self?.cooldownPeriod = cooldownDuration
-            self?.checkChannelCooldown()
+            self?.checkChannelCooldown(for: channel)
         }
         .store(in: &cancellables)
     }
     
-    private func checkChannelCooldown() {
+    private func checkChannelCooldown(for channel: ChatChannel?) {
         let duration = chat.state.channel?.cooldownDuration ?? 0
         if duration > 0 && timer == nil && !isSlowModeDisabled {
             cooldownDuration = duration

--- a/Sources/StreamChatSwiftUI/ChatChannel/Reactions/ReactionsOverlayViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Reactions/ReactionsOverlayViewModel.swift
@@ -32,7 +32,6 @@ open class ReactionsOverlayViewModel: ObservableObject {
         Task { @MainActor in
             self.messageState = try await chat.makeMessageState(for: message.id)
             self.messageState?.$message
-                .receive(on: RunLoop.main)
                 .sink(receiveValue: { [weak self] message in
                     withAnimation {
                         self?.message = message

--- a/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListViewModel.swift
@@ -233,7 +233,6 @@ import UIKit
     
     private func subscribeToChannelListChanges() {
         channelList?.state.$channels
-            .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] channels in
             self?.handleChannelListChanges(channels)
         })

--- a/StreamChatSwiftUITests/Tests/ChatChannel/ChatChannelDataSource_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/ChatChannelDataSource_Tests.swift
@@ -177,7 +177,7 @@ class ChatChannelDataSource_Tests: StreamChatTestCase {
 
         func dataSource(
             channelDataSource: ChannelDataSource,
-            didUpdateChannel channel: EntityChange<ChatChannel>
+            didUpdateChannel channel: ChatChannel
         ) {
             updateChannelCalled = true
         }


### PR DESCRIPTION
### 🔗 Issue Link

Related: [#728](https://github.com/GetStream/ios-issues-tracking/issues/728)

### 🎯 Goal

`sink()` is triggered when the observed property calls willSet (@Published property wrapper's default behaviour), therefore we should use the received value for state updates.

### 🛠 Implementation

Other alternatives: 
- use `receive(on)` for delaying the update
- assign the observed value to a local property first (used in some cases)

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
