### PR TITLE
[New state] Set the initial state for read, typing and online indicators

### DIFF
--- a/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelDataSource.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelDataSource.swift
@@ -80,7 +80,14 @@ class ChatChannelDataSource: ChannelDataSource {
     private var cancellables = Set<AnyCancellable>()
 
     let chat: Chat
-    weak var delegate: MessagesDataSource?
+    @MainActor weak var delegate: MessagesDataSource? {
+        didSet {
+            cancellables.removeAll()
+            guard delegate != nil else { return }
+            subscribeForMessageUpdates()
+            subscribeForChannelUpdates()
+        }
+    }
     
     @MainActor var messages: StreamCollection<ChatMessage> {
         chat.state.messages
@@ -96,8 +103,6 @@ class ChatChannelDataSource: ChannelDataSource {
 
     @MainActor init(chat: Chat) {
         self.chat = chat
-        subscribeForMessageUpdates()
-        subscribeForChannelUpdates()
     }
     
     @MainActor private func subscribeForMessageUpdates() {

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelViewModel.swift
@@ -185,9 +185,6 @@ import SwiftUI
         }
                 
         channelName = channel?.name ?? ""
-        if let channel {
-            checkHeaderType(for: channel)
-        }
         checkUnreadCount()
     }
     


### PR DESCRIPTION
### 🔗 Issue Link
Related: [#728](https://github.com/GetStream/ios-issues-tracking/issues/728)

### 🎯 Goal

Fix "If you open the channel when participant was typing, you won’t see typing indicator"

### 🛠 Implementation

We are not setting the initial state correctly.

```swift
  channelDataSource = ChatChannelDataSource(chat: chat)
}
channelDataSource.delegate = self
```

```swift
@MainActor init(chat: Chat) {
        self.chat = chat
        subscribeForMessageUpdates()
        subscribeForChannelUpdates()
    }

 @MainActor private func subscribeForChannelUpdates() {
        self.chat.state.$channel.sink { [weak self] (channel: ChatChannel?) in
            guard let self else { return }
            if let channel {
                delegate?.dataSource(
                    channelDataSource: self,
                    didUpdateChannel: channel
                )
            }
        }
        .store(in: &cancellables)
    }
```
Here we create the data source, start observing it, but since delegate is nil, the initial delegate callback does not happen and we miss the initial state.


### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
