### PR TITLE
Set the preferred color range to standard when scaling images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### 🐞 Fixed
+- Creating merged channel avatars logged a console warning when the source image uses extended color range [#484](https://github.com/GetStream/stream-chat-swiftui/pull/484)
 
 # [4.55.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.55.0)
 _May 14, 2024_

--- a/Sources/StreamChatSwiftUI/Utils/Common/NukeImageProcessor.swift
+++ b/Sources/StreamChatSwiftUI/Utils/Common/NukeImageProcessor.swift
@@ -45,7 +45,9 @@ open class NukeImageProcessor: ImageProcessor {
         )
 
         // Draw and return the resized UIImage
-        let renderer = UIGraphicsImageRenderer(size: scaledImageSize)
+        let format = UIGraphicsImageRendererFormat()
+        format.preferredRange = .standard
+        let renderer = UIGraphicsImageRenderer(size: scaledImageSize, format: format)
 
         let scaledImage = renderer.image { _ in
             image.draw(in: CGRect(origin: .zero, size: scaledImageSize))


### PR DESCRIPTION
### 🎯 Goal

Fix the warning in console when generating merged avatars (`CGBitmapContextInfoCreate: CGColorSpace which uses extended range requires floating point or CIF10 bitmap context`)

### 🛠 Implementation

* Set the color range to standard when scaling images which avoids the warning

Note: It seems like it is an issue when processing images with Nuke multiple times (resize + crop). I think it comes from the fact how Nuke uses color spaces. 

### 🧪 Testing

Launch the demo app and observe the console log

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
