### PR TITLE
Use max file size for validating attachments in Stream Dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### ✅ Added
+- Use max file size for validating attachments defined in Stream's Dashboard [#490](https://github.com/GetStream/stream-chat-swiftui/pull/490)
 
 # [4.56.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.56.0)
 _May 21, 2024_

--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerViewModel.swift
@@ -678,7 +678,7 @@ open class MessageComposerViewModel: ObservableObject {
         
         do {
             let fileSize = try AttachmentFile(url: url).size
-            let canAdd = fileSize < chatClient.config.maxAttachmentSize
+            let canAdd = fileSize < chatClient.maxAttachmentSize(for: url)
             attachmentSizeExceeded = !canAdd
             return canAdd
         } catch {

--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/PhotoAssetsUtils.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/PhotoAssetsUtils.swift
@@ -56,7 +56,7 @@ public class PhotoAssetLoader: NSObject, ObservableObject {
         _ = url?.startAccessingSecurityScopedResource()
         if let assetURL = url,
            let file = try? AttachmentFile(url: assetURL),
-           file.size >= chatClient.config.maxAttachmentSize {
+           file.size >= chatClient.maxAttachmentSize(for: assetURL) {
             return true
         } else {
             return false

--- a/Sources/StreamChatSwiftUI/Utils/Common/ChatClient+Extensions.swift
+++ b/Sources/StreamChatSwiftUI/Utils/Common/ChatClient+Extensions.swift
@@ -1,0 +1,29 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import StreamChat
+
+extension ChatClient {
+    /// The maximum attachment size for the file URL.
+    ///
+    /// The max attachment size can be set from the Stream's Dashboard App Settings.
+    ///
+    /// - Parameter fileURL: The file URL of the attachment.
+    /// - Returns: The maximum allowed size for the attachment in bytes.
+    func maxAttachmentSize(for fileURL: URL) -> Int64 {
+        let attachmentType = AttachmentType(fileExtension: fileURL.pathExtension)
+        let maxAttachmentSize: Int64?
+        switch attachmentType {
+        case .image:
+            maxAttachmentSize = appSettings?.imageUploadConfig.sizeLimitInBytes
+        default:
+            maxAttachmentSize = appSettings?.fileUploadConfig.sizeLimitInBytes
+        }
+        if let maxAttachmentSize, maxAttachmentSize > 0 {
+            return maxAttachmentSize
+        } else {
+            return config.maxAttachmentSize
+        }
+    }
+}

--- a/StreamChatSwiftUI.xcodeproj/project.pbxproj
+++ b/StreamChatSwiftUI.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		402C54482B6AAC0100672BFB /* StreamChatSwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8465FBB52746873A00AF091E /* StreamChatSwiftUI.framework */; };
 		402C54492B6AAC0100672BFB /* StreamChatSwiftUI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8465FBB52746873A00AF091E /* StreamChatSwiftUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		4F7DD9A02BFC7C6100599AA6 /* ChatClient+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F7DD99F2BFC7C6100599AA6 /* ChatClient+Extensions.swift */; };
+		4F7DD9A22BFCB2EF00599AA6 /* ChatClientExtensions_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F7DD9A12BFCB2EF00599AA6 /* ChatClientExtensions_Tests.swift */; };
 		8205B4142AD41CC700265B84 /* StreamSwiftTestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 8205B4132AD41CC700265B84 /* StreamSwiftTestHelpers */; };
 		8205B4182AD4267200265B84 /* StreamSwiftTestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 8205B4172AD4267200265B84 /* StreamSwiftTestHelpers */; };
 		820A61A029D6D78E002257FB /* QuotedReply_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 820A619F29D6D78E002257FB /* QuotedReply_Tests.swift */; };
@@ -546,6 +548,8 @@
 
 /* Begin PBXFileReference section */
 		4A65451E274BA170003C5FA8 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		4F7DD99F2BFC7C6100599AA6 /* ChatClient+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatClient+Extensions.swift"; sourceTree = "<group>"; };
+		4F7DD9A12BFCB2EF00599AA6 /* ChatClientExtensions_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatClientExtensions_Tests.swift; sourceTree = "<group>"; };
 		820A619F29D6D78E002257FB /* QuotedReply_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuotedReply_Tests.swift; sourceTree = "<group>"; };
 		825AADF3283CCDB000237498 /* ThreadPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadPage.swift; sourceTree = "<group>"; };
 		829AB4D128578ACF002DC629 /* StreamTestCase+Tags.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StreamTestCase+Tags.swift"; sourceTree = "<group>"; };
@@ -1733,23 +1737,24 @@
 			isa = PBXGroup;
 			children = (
 				8465FD392746A95600AF091E /* AutoLayoutHelpers.swift */,
-				8465FD3A2746A95600AF091E /* DateFormatter+Extensions.swift */,
-				8465FD3C2746A95600AF091E /* UIFont+Extensions.swift */,
-				8465FD3D2746A95600AF091E /* ImageCDN.swift */,
-				8465FD3E2746A95600AF091E /* UIColor+Extensions.swift */,
-				8465FD3F2746A95600AF091E /* UIImage+Extensions.swift */,
-				8465FD402746A95600AF091E /* DateUtils.swift */,
+				8465FD452746A95600AF091E /* Cache.swift */,
 				8465FD412746A95600AF091E /* ChatChannelNamer.swift */,
+				4F7DD99F2BFC7C6100599AA6 /* ChatClient+Extensions.swift */,
+				8465FD442746A95600AF091E /* ChatMessage+Extensions.swift */,
+				8465FD472746A95600AF091E /* ChatMessageReactionAppeareance.swift */,
 				91B79FD6284E21E0005B6E4F /* ChatUserNamer.swift */,
+				8465FD3A2746A95600AF091E /* DateFormatter+Extensions.swift */,
+				8465FD402746A95600AF091E /* DateUtils.swift */,
+				8465FD3D2746A95600AF091E /* ImageCDN.swift */,
+				8465FD482746A95600AF091E /* ImageMerger.swift */,
 				8465FD422746A95600AF091E /* InputTextView.swift */,
 				8465FD432746A95600AF091E /* NSLayoutConstraint+Extensions.swift */,
-				8465FD442746A95600AF091E /* ChatMessage+Extensions.swift */,
-				8465FD452746A95600AF091E /* Cache.swift */,
-				8465FD462746A95600AF091E /* VideoPreviewLoader.swift */,
-				8465FD472746A95600AF091E /* ChatMessageReactionAppeareance.swift */,
-				8465FD482746A95600AF091E /* ImageMerger.swift */,
 				8465FD492746A95600AF091E /* NukeImageProcessor.swift */,
+				8465FD3E2746A95600AF091E /* UIColor+Extensions.swift */,
+				8465FD3C2746A95600AF091E /* UIFont+Extensions.swift */,
+				8465FD3F2746A95600AF091E /* UIImage+Extensions.swift */,
 				A3D7B0DE2840E23100E308B3 /* UIView+AccessibilityIdentifier.swift */,
+				8465FD462746A95600AF091E /* VideoPreviewLoader.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -1976,6 +1981,7 @@
 		84C94D52275A135F007FE2B9 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				4F7DD9A12BFCB2EF00599AA6 /* ChatClientExtensions_Tests.swift */,
 				91CC203B283C4C250049A146 /* URLUtils_Tests.swift */,
 				84C94D53275A1380007FE2B9 /* DateUtils_Tests.swift */,
 				84C94D55275A1AE1007FE2B9 /* StringExtensions_Tests.swift */,
@@ -2587,6 +2593,7 @@
 				8465FD8A2746A95700AF091E /* DiscardAttachmentButton.swift in Sources */,
 				8482094E2ACFFCD900EF3261 /* Throttler.swift in Sources */,
 				84EADEBD2B28C2EC0046B50C /* RecordingState.swift in Sources */,
+				4F7DD9A02BFC7C6100599AA6 /* ChatClient+Extensions.swift in Sources */,
 				82D64C1B2AD7E5B700C5C79E /* ImageCaching.swift in Sources */,
 				82D64C062AD7E5B700C5C79E /* Graphics.swift in Sources */,
 				8465FDCB2746A95700AF091E /* ChatChannelListView.swift in Sources */,
@@ -2688,6 +2695,7 @@
 				84E0478C284A444E00BAFA17 /* TestRequest.swift in Sources */,
 				84CAD77B284E5AAA00F28C17 /* MessageListViewLastGroupHeader_Tests.swift in Sources */,
 				84779C772AEBCA6E000A6A68 /* ReactionsIconProvider_Tests.swift in Sources */,
+				4F7DD9A22BFCB2EF00599AA6 /* ChatClientExtensions_Tests.swift in Sources */,
 				91CC203C283C4C250049A146 /* URLUtils_Tests.swift in Sources */,
 				84B2B5DA281985DA00479CEE /* FileAttachmentsView_Tests.swift in Sources */,
 				848399F227601231003075E4 /* ReactionsOverlayView_Tests.swift in Sources */,

--- a/StreamChatSwiftUITests/Infrastructure/TestTools/ChatClient_Mock.swift
+++ b/StreamChatSwiftUITests/Infrastructure/TestTools/ChatClient_Mock.swift
@@ -4,23 +4,25 @@
 
 import Foundation
 @testable import StreamChat
+@testable import StreamChatTestTools
 
 public extension ChatClient {
     /// Create a new instance of mock `ChatClient`
     static func mock(
         isLocalStorageEnabled: Bool = false,
         customCDNClient: CDNClient? = nil
-    ) -> ChatClient {
+    ) -> ChatClient_Mock {
         var config = ChatClientConfig(apiKey: .init("--== Mock ChatClient ==--"))
         config.customCDNClient = customCDNClient
         config.isLocalStorageEnabled = isLocalStorageEnabled
         config.isClientInActiveMode = false
         config.maxAttachmentCountPerMessage = 10
 
-        return .init(
+        return ChatClient_Mock(
             config: config,
+            workerBuilders: [],
             environment: .init(
-                apiClientBuilder: APIClient_Mock.init,
+                apiClientBuilder: APIClient_Spy.init,
                 webSocketClientBuilder: {
                     WebSocketClient_Mock(
                         sessionConfiguration: $0,
@@ -52,22 +54,5 @@ extension ChatClient {
             environment: environment,
             factory: ChatClientFactory(config: config, environment: environment)
         )
-    }
-}
-
-// ===== TEMP =====
-
-class APIClient_Mock: APIClient {
-    override func request<Response>(
-        endpoint: Endpoint<Response>,
-        completion: @escaping (Result<Response, Error>) -> Void
-    ) where Response: Decodable {
-        // Do nothing for now
-    }
-}
-
-class WebSocketClient_Mock: WebSocketClient {
-    override func connect() {
-        // Do nothing for now
     }
 }

--- a/StreamChatSwiftUITests/Tests/ChatChannel/MessageComposerViewModel_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/MessageComposerViewModel_Tests.swift
@@ -4,6 +4,7 @@
 
 @testable import StreamChat
 @testable import StreamChatSwiftUI
+@testable import StreamChatTestTools
 import XCTest
 
 class MessageComposerViewModel_Tests: StreamChatTestCase {
@@ -481,6 +482,24 @@ class MessageComposerViewModel_Tests: StreamChatTestCase {
         CDNClient_Mock.maxAttachmentSize = 5
         let client = ChatClient.mock(customCDNClient: cdnClient)
         streamChat = StreamChat(chatClient: client)
+        
+        // When
+        let newAsset = defaultAsset
+        viewModel.imageTapped(newAsset) // will not be added because of small max attachment size.
+        let alertShown = viewModel.attachmentSizeExceeded
+        
+        // Then
+        XCTAssert(viewModel.addedAssets.isEmpty)
+        XCTAssert(alertShown == true)
+    }
+    
+    func test_messageComposerVM_maxSizeExceededWithAppSettingsConfiguration() {
+        // Given
+        let expectedValue: Int64 = 5
+        chatClient.mockedAppSettings = .mock(imageUploadConfig: .mock(
+            sizeLimitInBytes: expectedValue
+        ))
+        let viewModel = makeComposerViewModel()
         
         // When
         let newAsset = defaultAsset

--- a/StreamChatSwiftUITests/Tests/StreamChatTestCase.swift
+++ b/StreamChatSwiftUITests/Tests/StreamChatTestCase.swift
@@ -4,7 +4,7 @@
 
 @testable import StreamChat
 @testable import StreamChatSwiftUI
-@_exported import StreamChatTestTools
+@_exported @testable import StreamChatTestTools
 @_exported import StreamSwiftTestHelpers
 import XCTest
 
@@ -13,7 +13,7 @@ open class StreamChatTestCase: XCTestCase {
 
     public static var currentUserId: String = .unique
 
-    public var chatClient: ChatClient = {
+    public var chatClient: ChatClient_Mock = {
         let client = ChatClient.mock(isLocalStorageEnabled: false)
         let tokenValue =
             "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoibHVrZV9za3l3YWxrZXIifQ.b6EiC8dq2AHk0JPfI-6PN-AM9TVzt8JV-qB1N9kchlI"

--- a/StreamChatSwiftUITests/Tests/Utils/ChatClientExtensions_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/Utils/ChatClientExtensions_Tests.swift
@@ -1,0 +1,38 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+@testable import StreamChatSwiftUI
+@testable import StreamChatTestTools
+import XCTest
+
+final class ChatClientExtensions_Tests: StreamChatTestCase {
+    func test_maxAttachmentSize_file() {
+        // Given
+        let expectedValue: Int64 = 512
+        chatClient.mockedAppSettings = .mock(fileUploadConfig: .mock(
+            sizeLimitInBytes: expectedValue
+        ))
+        
+        // When
+        let size = chatClient.maxAttachmentSize(for: .localYodaQuote)
+        
+        // Then
+        XCTAssertEqual(size, expectedValue)
+    }
+    
+    func test_maxAttachmentSize_image() {
+        // Given
+        let expectedValue: Int64 = 256
+        chatClient.mockedAppSettings = .mock(imageUploadConfig: .mock(
+            sizeLimitInBytes: expectedValue
+        ))
+        
+        // When
+        let size = chatClient.maxAttachmentSize(for: .localYodaImage)
+        
+        // Then
+        XCTAssertEqual(size, expectedValue)
+    }
+}


### PR DESCRIPTION
### 🎯 Goal

* Use `ChatClient.appSettings` for validating attachment file sizes

### 🛠 Implementation

Consume LLC provided app settings when checking for max size.

### 🧪 Testing

N/A

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
