### PR TITLE
Create poll button did nothing after creating a new group

### DIFF
--- a/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelViewModel.swift
@@ -428,6 +428,7 @@ open class ChatChannelViewModel: ObservableObject, MessagesDataSource {
     
     public func onViewAppear() {
         setActive()
+        utils.channelControllerFactory.currentChannelController = channelController
         messages = channelDataSource.messages
         firstUnreadMessageId = channelDataSource.firstUnreadMessageId
         checkNameChange()


### PR DESCRIPTION
Merging to **polls** branch.

### 🎯 Goal

Create poll did nothing because chatController is nil. Only happens if you create a new group and then try to create a poll right away.

### 🛠 Implementation

Set current chat controller every single time ChatChannelView's onAppear is triggered.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
