### PR TITLE
Wrap UIAlertController for showing alert with text field on iOS 14

### DIFF
--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/Polls/PollAttachmentView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/Polls/PollAttachmentView.swift
@@ -177,21 +177,16 @@ struct SuggestOptionModifier: ViewModifier {
     var submit: () -> Void
     
     func body(content: Content) -> some View {
-        if #available(iOS 15.0, *) {
-            content
-                .alert(title, isPresented: $showingAlert) {
-                    TextField(L10n.Alert.TextField.pollsNewOption, text: $text)
-                    Button(L10n.Alert.Actions.cancel) {
-                        showingAlert = false
-                    }
-                    Button(L10n.Alert.Actions.add, action: submit)
-                } message: {
-                    Text("")
-                }
-        } else {
-            // TODO: Add for iOS < 15.
-            content
-        }
+        content
+            .uiAlert(
+                title: title,
+                isPresented: $showingAlert,
+                text: $text,
+                placeholder: L10n.Alert.TextField.pollsNewOption,
+                cancel: L10n.Alert.Actions.cancel,
+                accept: L10n.Alert.Actions.add,
+                action: submit
+            )
     }
 }
 

--- a/Sources/StreamChatSwiftUI/Utils/SwiftUI+UIAlertController.swift
+++ b/Sources/StreamChatSwiftUI/Utils/SwiftUI+UIAlertController.swift
@@ -1,0 +1,105 @@
+//
+// Copyright © 2024 Stream.io Inc. All rights reserved.
+//
+
+import SwiftUI
+
+extension View {
+    /// Presents an alert with a text field for entering text.
+    ///
+    /// - Note: iOS 14 lacks alert with text field support.
+    func uiAlert(
+        title: String,
+        isPresented: Binding<Bool>,
+        message: String = "",
+        text: Binding<String>,
+        placeholder: String,
+        cancel: String,
+        accept: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        ZStack {
+            UIAlertControllerView(
+                isPresented: isPresented,
+                title: title,
+                message: message,
+                text: text,
+                placeholder: placeholder,
+                cancel: cancel,
+                accept: accept,
+                action: action
+            )
+            .frame(height: 0)
+            self
+        }
+    }
+}
+
+private struct UIAlertControllerView: UIViewControllerRepresentable {
+    @Binding var isPresented: Bool
+    let title: String
+    let message: String
+    @Binding var text: String
+    let placeholder: String
+    let cancel: String
+    let accept: String
+    let action: () -> Void
+    
+    func makeUIViewController(context: Context) -> UIViewController {
+        UIViewController()
+    }
+    
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
+        if isPresented && uiViewController.presentedViewController == nil {
+            let alert = UIAlertController(
+                title: title,
+                message: message,
+                preferredStyle: .alert
+            )
+            context.coordinator.alertController = alert
+            alert.addTextField { textField in
+                textField.font = .preferredFont(forTextStyle: .body)
+                textField.placeholder = placeholder
+                textField.text = text
+            }
+            alert.addAction(
+                UIAlertAction(title: cancel, style: .cancel) { _ in
+                    isPresented = false
+                }
+            )
+            let textField = alert.textFields?.first
+            alert.addAction(
+                UIAlertAction(title: accept, style: .default) { _ in
+                    text = textField?.text ?? ""
+                    isPresented = false
+                    action()
+                }
+            )
+            DispatchQueue.main.async {
+                uiViewController.present(alert, animated: true)
+            }
+        }
+        if !isPresented {
+            context.coordinator.alertController?.dismiss(animated: true)
+        }
+    }
+    
+    static func dismantleUIViewController(_ uiViewController: UIViewController, coordinator: Coordinator) {
+        coordinator.alertController?.dismiss(animated: true)
+        coordinator.alertController = nil
+    }
+    
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+}
+
+private extension UIAlertControllerView {
+    final class Coordinator: NSObject, UITextFieldDelegate {
+        var alertController: UIAlertController?
+        
+        init(alertController: UIAlertController? = nil) {
+            self.alertController = alertController
+        }
+    }
+}

--- a/StreamChatSwiftUI.xcodeproj/project.pbxproj
+++ b/StreamChatSwiftUI.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		402C54482B6AAC0100672BFB /* StreamChatSwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8465FBB52746873A00AF091E /* StreamChatSwiftUI.framework */; };
 		402C54492B6AAC0100672BFB /* StreamChatSwiftUI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8465FBB52746873A00AF091E /* StreamChatSwiftUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		4F198FDD2C0480EC00148F49 /* Publisher+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F198FDC2C0480EC00148F49 /* Publisher+Extensions.swift */; };
+		4FEAB3182BFF71F70057E511 /* SwiftUI+UIAlertController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FEAB3172BFF71F70057E511 /* SwiftUI+UIAlertController.swift */; };
 		8205B4142AD41CC700265B84 /* StreamSwiftTestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 8205B4132AD41CC700265B84 /* StreamSwiftTestHelpers */; };
 		8205B4182AD4267200265B84 /* StreamSwiftTestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 8205B4172AD4267200265B84 /* StreamSwiftTestHelpers */; };
 		820A61A029D6D78E002257FB /* QuotedReply_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 820A619F29D6D78E002257FB /* QuotedReply_Tests.swift */; };
@@ -559,6 +560,7 @@
 /* Begin PBXFileReference section */
 		4A65451E274BA170003C5FA8 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		4F198FDC2C0480EC00148F49 /* Publisher+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+Extensions.swift"; sourceTree = "<group>"; };
+		4FEAB3172BFF71F70057E511 /* SwiftUI+UIAlertController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SwiftUI+UIAlertController.swift"; sourceTree = "<group>"; };
 		820A619F29D6D78E002257FB /* QuotedReply_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuotedReply_Tests.swift; sourceTree = "<group>"; };
 		825AADF3283CCDB000237498 /* ThreadPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadPage.swift; sourceTree = "<group>"; };
 		829AB4D128578ACF002DC629 /* StreamTestCase+Tags.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StreamTestCase+Tags.swift"; sourceTree = "<group>"; };
@@ -1774,6 +1776,7 @@
 				847CEFED27C38ABE00606257 /* MessageCachingUtils.swift */,
 				84733EC527FDBF82006926E0 /* NetworkReachability.swift */,
 				84F130C02AEAA957006E7B52 /* StreamLazyImage.swift */,
+				4FEAB3172BFF71F70057E511 /* SwiftUI+UIAlertController.swift */,
 				842ADEA828EB018C00F2BE36 /* LazyImageExtensions.swift */,
 				8465FD382746A95600AF091E /* Common */,
 			);
@@ -2528,6 +2531,7 @@
 				8465FDC02746A95700AF091E /* ChatChannelList.swift in Sources */,
 				82D64B682AD7E5AC00C5C79E /* ObjcAssociatedWeakObject.swift in Sources */,
 				82FA42442AE67FF900C7390B /* SystemEnvironment+Version.swift in Sources */,
+				4FEAB3182BFF71F70057E511 /* SwiftUI+UIAlertController.swift in Sources */,
 				82D64BE02AD7E5B700C5C79E /* LazyImage.swift in Sources */,
 				82D64C052AD7E5B700C5C79E /* Deprecated.swift in Sources */,
 				84DEC8EC27611CAE00172876 /* SendInChannelView.swift in Sources */,


### PR DESCRIPTION
Merging to **polls** branch.

### 🎯 Goal

iOS 14 lacks support for showing alerts with text fields.

### 🛠 Implementation

Wrapped `UIAlertController` which visually looks the same as what SwiftUI provides.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
