### PR TITLE
Dismiss keyboard when tapping on the empty message list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### ✅ Added
 - Thread replies shown in channel indicator [#518](https://github.com/GetStream/stream-chat-swiftui/pull/518)
 
+### 🐞 Fixed
+- Dismiss keyboard when tapping on the empty message list [#513](https://github.com/GetStream/stream-chat-swiftui/pull/513)
+
 # [4.57.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.57.0)
 _June 07, 2024_
 

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/ChatChannelInfoView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/ChatChannelInfoView.swift
@@ -154,9 +154,7 @@ public struct ChatChannelInfoView: View, KeyboardReadable {
         .onReceive(keyboardWillChangePublisher) { visible in
             viewModel.keyboardShown = visible
         }
-        .modifier(
-            HideKeyboardOnTapGesture(shouldAdd: viewModel.keyboardShown)
-        )
+        .dismissKeyboardOnTap(enabled: viewModel.keyboardShown)
         .background(Color(colors.background).edgesIgnoringSafeArea(.bottom))
     }
 }

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelView.swift
@@ -76,6 +76,7 @@ public struct ChatChannelView<Factory: ViewFactory>: View, KeyboardReadable {
                     } else {
                         ZStack {
                             factory.makeEmptyMessagesView(for: channel, colors: colors)
+                                .dismissKeyboardOnTap(enabled: keyboardShown)
                             if viewModel.shouldShowTypingIndicator {
                                 factory.makeTypingIndicatorBottomView(
                                     channel: channel,

--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageListView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageListView.swift
@@ -304,7 +304,7 @@ public struct MessageListView<Factory: ViewFactory>: View, KeyboardReadable {
                 ) : nil
         )
         .modifier(factory.makeMessageListContainerModifier())
-        .modifier(HideKeyboardOnTapGesture(shouldAdd: keyboardShown))
+        .dismissKeyboardOnTap(enabled: keyboardShown)
         .onDisappear {
             messageRenderingUtil.update(previousTopMessage: nil)
         }

--- a/Sources/StreamChatSwiftUI/Utils/KeyboardHandling.swift
+++ b/Sources/StreamChatSwiftUI/Utils/KeyboardHandling.swift
@@ -57,6 +57,16 @@ extension KeyboardReadable {
     }
 }
 
+extension View {
+    /// Dismisses the keyboard when tapping on the view.
+    /// - Parameters:
+    ///   - enabled: If true, tapping on the view dismisses the view, otherwise keyboard stays visible.
+    ///   - onTapped: A closure which is triggered when keyboard is dismissed after tapping the view.
+    func dismissKeyboardOnTap(enabled: Bool, onKeyboardDismissed: (() -> Void)? = nil) -> some View {
+        modifier(HideKeyboardOnTapGesture(shouldAdd: enabled))
+    }
+}
+
 /// View modifier for hiding the keyboard on tap.
 public struct HideKeyboardOnTapGesture: ViewModifier {
     var shouldAdd: Bool

--- a/StreamChatSwiftUITestsAppTests/Pages/MessageListPage.swift
+++ b/StreamChatSwiftUITestsAppTests/Pages/MessageListPage.swift
@@ -26,6 +26,10 @@ class MessageListPage {
     static var list: XCUIElement {
         app.scrollViews.matching(NSPredicate(format: "identifier LIKE 'MessageListView' or identifier LIKE 'MessageListScrollView'")).firstMatch
     }
+    
+    static var listEmpty: XCUIElement {
+        app.otherElements.matching(identifier: "EmptyMessagesView").firstMatch
+    }
 
     static var typingIndicator: XCUIElement {
         app.staticTexts["TypingIndicatorBottomView"].firstMatch

--- a/StreamChatSwiftUITestsAppTests/Robots/UserRobot.swift
+++ b/StreamChatSwiftUITestsAppTests/Robots/UserRobot.swift
@@ -235,6 +235,12 @@ extension UserRobot {
     }
 
     @discardableResult
+    func tapOnComposerTextView() -> Self {
+        MessageListPage.Composer.textView.wait().safeTap()
+        return self
+    }
+    
+    @discardableResult
     func tapOnMessage(at messageCellIndex: Int? = 0) -> Self {
         let messageCell = messageCell(withIndex: messageCellIndex)
         return tapOnMessage(messageCell)
@@ -249,6 +255,12 @@ extension UserRobot {
     @discardableResult
     func tapOnMessageList() -> Self {
         MessageListPage.list.safeTap()
+        return self
+    }
+    
+    @discardableResult
+    func tapOnEmptyMessageList() -> Self {
+        MessageListPage.listEmpty.safeTap()
         return self
     }
 

--- a/StreamChatSwiftUITestsAppTests/Tests/MessageList_Tests.swift
+++ b/StreamChatSwiftUITestsAppTests/Tests/MessageList_Tests.swift
@@ -331,6 +331,20 @@ final class MessageList_Tests: StreamTestCase {
             userRobot.assertMessage(message)
         }
     }
+    
+    func test_emptyViewDismissesKeyboard() throws {
+        GIVEN("user opens the channel") {
+            userRobot.login().openChannel()
+        }
+        WHEN("keyboard is open") {
+            userRobot.tapOnComposerTextView()
+            userRobot.assertKeyboard(isVisible: true)
+            userRobot.tapOnEmptyMessageList()
+        }
+        THEN("keyboard is dismissed") {
+            userRobot.assertKeyboard(isVisible: false)
+        }
+    }
 }
 
 // MARK: Scroll to bottom


### PR DESCRIPTION
### 🔗 Issue Link

Resolves [ios-issues-tracking/issues/860](https://github.com/GetStream/ios-issues-tracking/issues/860)

### 🎯 Goal

When there are no messages, users can't dismiss the keyboard.

### 🛠 Implementation

Add a dismiss keyboard modifier to all the empty views.

### 🧪 Testing

1. Open an empty channel (no messages)
2. Tap on the input field which reveals the keyboard
3. Tap on the empty area

Expected: keyboard is dismissed

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
