### PR TITLE
Reload messages when author name or profile picture changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### 🐞 Fixed
+- Reload messages when author name or profile picture changes [#514](https://github.com/GetStream/stream-chat-swiftui/pull/514)
 
 # [4.57.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.57.0)
 _June 07, 2024_

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelViewModel.swift
@@ -391,6 +391,8 @@ open class ChatChannelViewModel: ObservableObject, MessagesDataSource {
         if !isActive {
             return
         }
+        // Message data can change with every callback
+        utils.messageCachingUtils.clearCache()
         
         let animationState = shouldAnimate(changes: changes)
         if animationState == .animated {

--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageIdBuilder.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageIdBuilder.swift
@@ -23,7 +23,15 @@ public class DefaultMessageIdBuilder: MessageIdBuilder {
         if message.textUpdatedAt != nil {
             statesId = "edited"
         }
-        return message.baseId + statesId + message.reactionScoresId
-            + message.repliesCountId + "\(message.updatedAt)" + message.pinStateId
+        let authorDisplayInfo = message.authorDisplayInfo
+        let author = authorDisplayInfo.name + String(authorDisplayInfo.imageURL?.hashValue ?? 0)
+        
+        return message.baseId +
+            statesId +
+            message.reactionScoresId +
+            message.repliesCountId +
+            "\(message.updatedAt)" +
+            message.pinStateId +
+            author
     }
 }

--- a/StreamChatSwiftUITests/Tests/ChatChannel/ChatChannelViewModel_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/ChatChannelViewModel_Tests.swift
@@ -469,6 +469,47 @@ class ChatChannelViewModel_Tests: StreamChatTestCase {
         // Then
         XCTAssert(shouldJump == false)
     }
+    
+    func test_chatChannelVM_messageAuthorChanged() {
+        // Given
+        let channelId = ChannelId.unique
+        let channelController = makeChannelController(messages: [
+            ChatMessage.mock(
+                id: "1",
+                cid: channelId,
+                text: "A",
+                author: .mock(id: "a1", name: "Name")
+            )
+        ])
+        let viewModel = ChatChannelViewModel(channelController: channelController)
+        let initialMesssageIds = viewModel.messages.map(\.messageId)
+        
+        // When
+        channelController.messages_mock = [
+            ChatMessage.mock(
+                id: "1",
+                cid: channelId,
+                text: "A",
+                author: .mock(id: "a1", name: "Name Updated")
+            )
+        ]
+        let changes = channelController.messages
+            .enumerated()
+            .map {
+                ListChange.update(
+                    $0.element,
+                    index: IndexPath(item: $0.offset, section: 0)
+                )
+            }
+        viewModel.dataSource(
+            channelDataSource: ChatChannelDataSource(controller: channelController),
+            didUpdateMessages: channelController.messages,
+            changes: changes
+        )
+        // Then
+        let updatedMessageIds = viewModel.messages.map(\.messageId)
+        XCTAssertNotEqual(initialMesssageIds, updatedMessageIds, "Message id should not be cached when author changes")
+    }
 
     // MARK: - private
 


### PR DESCRIPTION
### 🔗 Issue Link

Resolves [ios-issues-tracking/issues/861](https://github.com/GetStream/ios-issues-tracking/issues/861)

### 🎯 Goal

Reload messages when changing current user's name or profile picture.

### 🛠 Implementation

* Add author information to the ChatMessage.messageId which is used for reloading views through explicit id
* Reset cache when message list changes since any property of the message can change

### 🧪 Testing

We should play around with channel view a bit to see if things work normally. The reason is that we flush cached values more often.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
