### PR TITLE
Fixed visibility of comments button for anon polls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Dismiss the channel when leaving a group [#519](https://github.com/GetStream/stream-chat-swiftui/pull/519)
 - Dismiss keyboard when tapping on the empty message list [#513](https://github.com/GetStream/stream-chat-swiftui/pull/513)
 - Reset composer text when there is provisional text (e.g. Japanese - kana keyboard) but the text is reset to empty string [#512](https://github.com/GetStream/stream-chat-swiftui/pull/512)
+- Visibility of the comments button in anonymous polls [#524](https://github.com/GetStream/stream-chat-swiftui/pull/524)
 
 ### 🔄 Changed
 - Show inline alert banner when encountering a failure while interacting with polls [#504](https://github.com/GetStream/stream-chat-swiftui/pull/504)

--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/Polls/PollAttachmentViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/Polls/PollAttachmentViewModel.swift
@@ -85,11 +85,11 @@ public class PollAttachmentViewModel: ObservableObject, PollControllerDelegate {
     
     /// If true, add comment button is visible under votes, otherwise hidden.
     public var showAddCommentButton: Bool {
+        let addCommentAvailable = !poll.isClosed && poll.allowAnswers
         if poll.votingVisibility == .anonymous {
-            return true
+            return addCommentAvailable
         }
-        return !poll.isClosed
-            && poll.allowAnswers == true
+        return addCommentAvailable
             && (
                 poll.latestAnswers.filter {
                     $0.user?.id == chatClient.currentUserId && $0.isAnswer


### PR DESCRIPTION
### 🔗 Issue Link
Resolves https://stream-io.atlassian.net/browse/PBE-4790.

### 🎯 Goal

Add comments was always visible for anon. polls.

### 🛠 Implementation

_Provide a description of the implementation._

### 🧪 Testing

_Describe the steps how this change can be tested (or why it can't be tested)._

### 🎨 Changes

_Add relevant screenshots or videos showcasing the changes._

### ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
