### PR TITLE
Update access controls to allow customization of ChatChannelInfoView

### DIFF
--- a/Sources/StreamChatSwiftUI/ChatChannel/ChannelControllerFactory.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChannelControllerFactory.swift
@@ -6,7 +6,7 @@ import StreamChat
 import SwiftUI
 
 /// Factory for creating channel controllers.
-class ChannelControllerFactory {
+public class ChannelControllerFactory {
 
     @Injected(\.chatClient) var chatClient
 

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChannelControllerFactory.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChannelControllerFactory.swift
@@ -16,7 +16,7 @@ public class ChannelControllerFactory {
     /// Creates a channel controller with the provided channel id.
     /// - Parameter channelId: the channel's id.
     /// - Returns: `ChatChannelController`
-    func makeChannelController(for channelId: ChannelId) -> ChatChannelController {
+    public func makeChannelController(for channelId: ChannelId) -> ChatChannelController {
         if let currentChannelController = currentChannelController, channelId == currentChannelController.cid {
             return currentChannelController
         }
@@ -30,7 +30,7 @@ public class ChannelControllerFactory {
     ///  - messageId: the message's id.
     ///  - channelId: the channel's id.
     /// - Returns: `ChatMessageController`
-    func makeMessageController(
+    public func makeMessageController(
         for messageId: MessageId,
         channelId: ChannelId
     ) -> ChatMessageController {
@@ -47,7 +47,7 @@ public class ChannelControllerFactory {
     }
 
     /// Clears the current active channel controller.
-    func clearCurrentController() {
+    public func clearCurrentController() {
         currentChannelController = nil
         messageControllers = [:]
     }

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/AddUsersView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/AddUsersView.swift
@@ -6,7 +6,7 @@ import StreamChat
 import SwiftUI
 
 /// View for the add users popup.
-struct AddUsersView: View {
+public struct AddUsersView: View {
 
     @Injected(\.fonts) private var fonts
     @Injected(\.colors) private var colors
@@ -24,9 +24,9 @@ struct AddUsersView: View {
     )
 
     @StateObject private var viewModel: AddUsersViewModel
-    var onUserTap: (ChatUser) -> Void
+    public var onUserTap: (ChatUser) -> Void
 
-    init(
+    public init(
         loadedUserIds: [String],
         onUserTap: @escaping (ChatUser) -> Void
     ) {
@@ -36,7 +36,7 @@ struct AddUsersView: View {
         self.onUserTap = onUserTap
     }
 
-    init(
+    public init(
         viewModel: AddUsersViewModel,
         onUserTap: @escaping (ChatUser) -> Void
     ) {
@@ -46,7 +46,7 @@ struct AddUsersView: View {
         self.onUserTap = onUserTap
     }
 
-    var body: some View {
+    public var body: some View {
         VStack {
             SearchBar(text: $viewModel.searchText)
 

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/AddUsersViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/AddUsersViewModel.swift
@@ -6,7 +6,7 @@ import StreamChat
 import SwiftUI
 
 /// View model for the `AddUsersView`.
-class AddUsersViewModel: ObservableObject {
+public class AddUsersViewModel: ObservableObject {
 
     @Injected(\.chatClient) private var chatClient
 

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/ChatChannelInfoHelperViews.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/ChatChannelInfoHelperViews.swift
@@ -39,11 +39,11 @@ public struct ChatChannelInfoButton: View {
     }
 }
 
-struct ChannelInfoDivider: View {
+public struct ChannelInfoDivider: View {
 
     @Injected(\.colors) private var colors
 
-    var body: some View {
+    public var body: some View {
         Rectangle()
             .fill(Color(colors.innerBorder))
             .frame(height: 8)
@@ -239,14 +239,14 @@ public struct ChannelInfoItemView<TrailingView: View>: View {
     }
 }
 
-struct ChatInfoDirectChannelView: View {
+public struct ChatInfoDirectChannelView: View {
 
     @Injected(\.fonts) private var fonts
     @Injected(\.colors) private var colors
 
     var participant: ParticipantInfo?
 
-    var body: some View {
+    public var body: some View {
         VStack {
             MessageAvatarView(
                 avatarURL: participant?.chatUser.imageURL,

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/ChatChannelInfoHelperViews.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/ChatChannelInfoHelperViews.swift
@@ -240,11 +240,14 @@ public struct ChannelInfoItemView<TrailingView: View>: View {
 }
 
 public struct ChatInfoDirectChannelView: View {
-
     @Injected(\.fonts) private var fonts
     @Injected(\.colors) private var colors
 
     var participant: ParticipantInfo?
+
+    public init(participant: ParticipantInfo? = nil) {
+        self.participant = participant
+    }
 
     public var body: some View {
         VStack {

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/ChatChannelInfoHelperViews.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/ChatChannelInfoHelperViews.swift
@@ -43,6 +43,8 @@ public struct ChannelInfoDivider: View {
 
     @Injected(\.colors) private var colors
 
+    public init() {}
+    
     public var body: some View {
         Rectangle()
             .fill(Color(colors.innerBorder))

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/ChatInfoParticipantsView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/ChatInfoParticipantsView.swift
@@ -11,8 +11,13 @@ public struct ChatInfoParticipantsView: View {
     @Injected(\.fonts) private var fonts
     @Injected(\.colors) private var colors
 
-    var participants: [ParticipantInfo]
-    var onItemAppear: (ParticipantInfo) -> Void
+    public var participants: [ParticipantInfo]
+    public var onItemAppear: (ParticipantInfo) -> Void
+
+    public init(participants: [ParticipantInfo], onItemAppear: @escaping (ParticipantInfo) -> Void) {
+        self.participants = participants
+        self.onItemAppear = onItemAppear
+    }
 
     public var body: some View {
         LazyVStack {

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/ChatInfoParticipantsView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/ChatInfoParticipantsView.swift
@@ -6,7 +6,7 @@ import StreamChat
 import SwiftUI
 
 /// View for the chat info participants.
-struct ChatInfoParticipantsView: View {
+public struct ChatInfoParticipantsView: View {
 
     @Injected(\.fonts) private var fonts
     @Injected(\.colors) private var colors
@@ -14,7 +14,7 @@ struct ChatInfoParticipantsView: View {
     var participants: [ParticipantInfo]
     var onItemAppear: (ParticipantInfo) -> Void
 
-    var body: some View {
+    public var body: some View {
         LazyVStack {
             ForEach(participants) { participant in
                 HStack {

--- a/Sources/StreamChatSwiftUI/ChatChannel/Utils/ChatChannelHelpers.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Utils/ChatChannelHelpers.swift
@@ -81,7 +81,7 @@ public struct BottomLeftView<Content: View>: View {
 }
 
 /// Returns the top most view controller.
-func topVC() -> UIViewController? {
+public func topVC() -> UIViewController? {
     let keyWindow = UIApplication.shared.windows.filter { $0.isKeyWindow }.first
 
     if var topController = keyWindow?.rootViewController {

--- a/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelHelperViews.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelHelperViews.swift
@@ -93,24 +93,24 @@ extension CGSize {
 }
 
 /// Provides access to the the app's tab bar (if present).
-struct TabBarAccessor: UIViewControllerRepresentable {
+public struct TabBarAccessor: UIViewControllerRepresentable {
     var callback: (UITabBar) -> Void
     private let proxyController = ViewController()
 
-    func makeUIViewController(context: UIViewControllerRepresentableContext<TabBarAccessor>) ->
+    public func makeUIViewController(context: UIViewControllerRepresentableContext<TabBarAccessor>) ->
         UIViewController {
         proxyController.callback = callback
         return proxyController
     }
 
-    func updateUIViewController(
+    public func updateUIViewController(
         _ uiViewController: UIViewController,
         context: UIViewControllerRepresentableContext<TabBarAccessor>
     ) {
         // No handling needed.
     }
 
-    typealias UIViewControllerType = UIViewController
+    public typealias UIViewControllerType = UIViewController
 
     private class ViewController: UIViewController {
         var callback: (UITabBar) -> Void = { _ in

--- a/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelHelperViews.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelHelperViews.swift
@@ -97,6 +97,10 @@ public struct TabBarAccessor: UIViewControllerRepresentable {
     var callback: (UITabBar) -> Void
     private let proxyController = ViewController()
 
+    public init(callback: @escaping (UITabBar) -> Void) {
+        self.callback = callback
+    }
+
     public func makeUIViewController(context: UIViewControllerRepresentableContext<TabBarAccessor>) ->
         UIViewController {
         proxyController.callback = callback

--- a/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelHelperViews.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelHelperViews.swift
@@ -126,10 +126,10 @@ struct TabBarAccessor: UIViewControllerRepresentable {
     }
 }
 
-var isIphone: Bool {
+public var isIphone: Bool {
     UIDevice.current.userInterfaceIdiom == .phone
 }
 
-var isIPad: Bool {
+public var isIPad: Bool {
     UIDevice.current.userInterfaceIdiom == .pad
 }

--- a/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListViewModel.swift
@@ -109,7 +109,7 @@ open class ChatChannelListViewModel: ObservableObject, ChatChannelListController
 
     @Published public var loadingSearchResults = false
     @Published public var searchResults = [ChannelSelectionInfo]()
-    @Published var hideTabBar = false
+    @Published public var hideTabBar = false
 
     public var isSearching: Bool {
         !searchText.isEmpty
@@ -232,7 +232,7 @@ open class ChatChannelListViewModel: ObservableObject, ChatChannelListController
         channel.membership != nil
     }
 
-    func checkTabBarAppearance() {
+    public func checkTabBarAppearance() {
         guard #available(iOS 15, *) else { return }
         if hideTabBar != false {
             hideTabBar = false

--- a/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListViewModel.swift
@@ -439,7 +439,7 @@ private let dismissChannel = "io.getstream.dismissChannel"
 
 private let hideTabBarNotification = "io.getstream.hideTabBar"
 
-func notifyChannelDismiss() {
+public func notifyChannelDismiss() {
     NotificationCenter.default.post(name: NSNotification.Name(dismissChannel), object: nil)
 }
 

--- a/Sources/StreamChatSwiftUI/Generated/L10n.swift
+++ b/Sources/StreamChatSwiftUI/Generated/L10n.swift
@@ -5,527 +5,527 @@ import Foundation
 
 // MARK: - Strings
 
-internal enum L10n {
+public enum L10n {
   /// %d of %d
-  internal static func currentSelection(_ p1: Int, _ p2: Int) -> String {
+  public static func currentSelection(_ p1: Int, _ p2: Int) -> String {
     return L10n.tr("Localizable", "current-selection", p1, p2)
   }
 
-  internal enum Alert {
-    internal enum Actions {
+  public enum Alert {
+    public enum Actions {
       /// Cancel
-      internal static var cancel: String { L10n.tr("Localizable", "alert.actions.cancel") }
+      public static var cancel: String { L10n.tr("Localizable", "alert.actions.cancel") }
       /// Delete
-      internal static var delete: String { L10n.tr("Localizable", "alert.actions.delete") }
+      public static var delete: String { L10n.tr("Localizable", "alert.actions.delete") }
       /// Are you sure you want to delete this conversation?
-      internal static var deleteChannelMessage: String { L10n.tr("Localizable", "alert.actions.delete-channel-message") }
+      public static var deleteChannelMessage: String { L10n.tr("Localizable", "alert.actions.delete-channel-message") }
       /// Delete conversation
-      internal static var deleteChannelTitle: String { L10n.tr("Localizable", "alert.actions.delete-channel-title") }
+      public static var deleteChannelTitle: String { L10n.tr("Localizable", "alert.actions.delete-channel-title") }
       /// Discard Changes
-      internal static var discardChanges: String { L10n.tr("Localizable", "alert.actions.discard-changes") }
+      public static var discardChanges: String { L10n.tr("Localizable", "alert.actions.discard-changes") }
       /// End
-      internal static var end: String { L10n.tr("Localizable", "alert.actions.end") }
+      public static var end: String { L10n.tr("Localizable", "alert.actions.end") }
       /// Keep Editing
-      internal static var keepEditing: String { L10n.tr("Localizable", "alert.actions.keep-editing") }
+      public static var keepEditing: String { L10n.tr("Localizable", "alert.actions.keep-editing") }
       /// Leave
-      internal static var leaveGroupButton: String { L10n.tr("Localizable", "alert.actions.leave-group-button") }
+      public static var leaveGroupButton: String { L10n.tr("Localizable", "alert.actions.leave-group-button") }
       /// Are you sure you want to leave this group?
-      internal static var leaveGroupMessage: String { L10n.tr("Localizable", "alert.actions.leave-group-message") }
+      public static var leaveGroupMessage: String { L10n.tr("Localizable", "alert.actions.leave-group-message") }
       /// Leave group
-      internal static var leaveGroupTitle: String { L10n.tr("Localizable", "alert.actions.leave-group-title") }
+      public static var leaveGroupTitle: String { L10n.tr("Localizable", "alert.actions.leave-group-title") }
       /// Are you sure you want to mute this
-      internal static var muteChannelTitle: String { L10n.tr("Localizable", "alert.actions.mute-channel-title") }
+      public static var muteChannelTitle: String { L10n.tr("Localizable", "alert.actions.mute-channel-title") }
       /// OK
-      internal static var ok: String { L10n.tr("Localizable", "alert.actions.ok") }
+      public static var ok: String { L10n.tr("Localizable", "alert.actions.ok") }
       /// Send
-      internal static var send: String { L10n.tr("Localizable", "alert.actions.send") }
+      public static var send: String { L10n.tr("Localizable", "alert.actions.send") }
       /// Are you sure you want to unmute this
-      internal static var unmuteChannelTitle: String { L10n.tr("Localizable", "alert.actions.unmute-channel-title") }
+      public static var unmuteChannelTitle: String { L10n.tr("Localizable", "alert.actions.unmute-channel-title") }
       /// View info
-      internal static var viewInfoTitle: String { L10n.tr("Localizable", "alert.actions.view-info-title") }
+      public static var viewInfoTitle: String { L10n.tr("Localizable", "alert.actions.view-info-title") }
     }
-    internal enum Error {
+    public enum Error {
       /// The operation couldn't be completed.
-      internal static var message: String { L10n.tr("Localizable", "alert.error.message") }
+      public static var message: String { L10n.tr("Localizable", "alert.error.message") }
       /// Something went wrong.
-      internal static var title: String { L10n.tr("Localizable", "alert.error.title") }
+      public static var title: String { L10n.tr("Localizable", "alert.error.title") }
     }
-    internal enum TextField {
+    public enum TextField {
       /// Enter a new option
-      internal static var pollsNewOption: String { L10n.tr("Localizable", "alert.text-field.polls-new-option") }
+      public static var pollsNewOption: String { L10n.tr("Localizable", "alert.text-field.polls-new-option") }
     }
-    internal enum Title {
+    public enum Title {
       /// Add a comment
-      internal static var addComment: String { L10n.tr("Localizable", "alert.title.add-comment") }
+      public static var addComment: String { L10n.tr("Localizable", "alert.title.add-comment") }
       /// Nobody will be able to vote in this poll anymore.
-      internal static var endPoll: String { L10n.tr("Localizable", "alert.title.end-poll") }
+      public static var endPoll: String { L10n.tr("Localizable", "alert.title.end-poll") }
       /// Suggest an option
-      internal static var suggestAnOption: String { L10n.tr("Localizable", "alert.title.suggest-an-option") }
+      public static var suggestAnOption: String { L10n.tr("Localizable", "alert.title.suggest-an-option") }
     }
   }
 
-  internal enum Attachment {
+  public enum Attachment {
     /// Attachment size exceed the limit.
-    internal static var maxSizeExceeded: String { L10n.tr("Localizable", "attachment.max-size-exceeded") }
-    internal enum MaxSize {
+    public static var maxSizeExceeded: String { L10n.tr("Localizable", "attachment.max-size-exceeded") }
+    public enum MaxSize {
       /// Please select a smaller attachment.
-      internal static var message: String { L10n.tr("Localizable", "attachment.max-size.message") }
+      public static var message: String { L10n.tr("Localizable", "attachment.max-size.message") }
       /// Attachment size exceed the limit
-      internal static var title: String { L10n.tr("Localizable", "attachment.max-size.title") }
+      public static var title: String { L10n.tr("Localizable", "attachment.max-size.title") }
     }
   }
 
-  internal enum Channel {
-    internal enum Item {
+  public enum Channel {
+    public enum Item {
       /// Audio
-      internal static var audio: String { L10n.tr("Localizable", "channel.item.audio") }
+      public static var audio: String { L10n.tr("Localizable", "channel.item.audio") }
       /// No messages
-      internal static var emptyMessages: String { L10n.tr("Localizable", "channel.item.empty-messages") }
+      public static var emptyMessages: String { L10n.tr("Localizable", "channel.item.empty-messages") }
       /// Mute
-      internal static var mute: String { L10n.tr("Localizable", "channel.item.mute") }
+      public static var mute: String { L10n.tr("Localizable", "channel.item.mute") }
       /// Channel is muted
-      internal static var muted: String { L10n.tr("Localizable", "channel.item.muted") }
+      public static var muted: String { L10n.tr("Localizable", "channel.item.muted") }
       /// Photo
-      internal static var photo: String { L10n.tr("Localizable", "channel.item.photo") }
+      public static var photo: String { L10n.tr("Localizable", "channel.item.photo") }
       /// %@ created:
-      internal static func pollSomeoneCreated(_ p1: Any) -> String {
+      public static func pollSomeoneCreated(_ p1: Any) -> String {
         return L10n.tr("Localizable", "channel.item.poll-someone-created", String(describing: p1))
       }
       /// %@ voted:
-      internal static func pollSomeoneVoted(_ p1: Any) -> String {
+      public static func pollSomeoneVoted(_ p1: Any) -> String {
         return L10n.tr("Localizable", "channel.item.poll-someone-voted", String(describing: p1))
       }
       /// You created:
-      internal static var pollYouCreated: String { L10n.tr("Localizable", "channel.item.poll-you-created") }
+      public static var pollYouCreated: String { L10n.tr("Localizable", "channel.item.poll-you-created") }
       /// You voted:
-      internal static var pollYouVoted: String { L10n.tr("Localizable", "channel.item.poll-you-voted") }
+      public static var pollYouVoted: String { L10n.tr("Localizable", "channel.item.poll-you-voted") }
       /// are typing ...
-      internal static var typingPlural: String { L10n.tr("Localizable", "channel.item.typing-plural") }
+      public static var typingPlural: String { L10n.tr("Localizable", "channel.item.typing-plural") }
       /// is typing ...
-      internal static var typingSingular: String { L10n.tr("Localizable", "channel.item.typing-singular") }
+      public static var typingSingular: String { L10n.tr("Localizable", "channel.item.typing-singular") }
       /// Unmute
-      internal static var unmute: String { L10n.tr("Localizable", "channel.item.unmute") }
+      public static var unmute: String { L10n.tr("Localizable", "channel.item.unmute") }
       /// Video
-      internal static var video: String { L10n.tr("Localizable", "channel.item.video") }
+      public static var video: String { L10n.tr("Localizable", "channel.item.video") }
       /// Voice Message
-      internal static var voiceMessage: String { L10n.tr("Localizable", "channel.item.voice-message") }
+      public static var voiceMessage: String { L10n.tr("Localizable", "channel.item.voice-message") }
     }
-    internal enum Name {
+    public enum Name {
       /// and
-      internal static var and: String { L10n.tr("Localizable", "channel.name.and") }
+      public static var and: String { L10n.tr("Localizable", "channel.name.and") }
       /// and %@ more
-      internal static func andXMore(_ p1: Any) -> String {
+      public static func andXMore(_ p1: Any) -> String {
         return L10n.tr("Localizable", "channel.name.andXMore", String(describing: p1))
       }
       /// user
-      internal static var directMessage: String { L10n.tr("Localizable", "channel.name.direct-message") }
+      public static var directMessage: String { L10n.tr("Localizable", "channel.name.direct-message") }
       /// group
-      internal static var group: String { L10n.tr("Localizable", "channel.name.group") }
+      public static var group: String { L10n.tr("Localizable", "channel.name.group") }
       /// NoChannel
-      internal static var missing: String { L10n.tr("Localizable", "channel.name.missing") }
+      public static var missing: String { L10n.tr("Localizable", "channel.name.missing") }
     }
-    internal enum NoContent {
+    public enum NoContent {
       /// How about sending your first message to a friend?
-      internal static var message: String { L10n.tr("Localizable", "channel.no-content.message") }
+      public static var message: String { L10n.tr("Localizable", "channel.no-content.message") }
       /// Start a chat
-      internal static var start: String { L10n.tr("Localizable", "channel.no-content.start") }
+      public static var start: String { L10n.tr("Localizable", "channel.no-content.start") }
       /// Let's start chatting
-      internal static var title: String { L10n.tr("Localizable", "channel.no-content.title") }
+      public static var title: String { L10n.tr("Localizable", "channel.no-content.title") }
     }
   }
 
-  internal enum ChatInfo {
-    internal enum Files {
+  public enum ChatInfo {
+    public enum Files {
       /// Files sent in this chat will appear here.
-      internal static var emptyDesc: String { L10n.tr("Localizable", "chat-info.files.empty-desc") }
+      public static var emptyDesc: String { L10n.tr("Localizable", "chat-info.files.empty-desc") }
       /// No files
-      internal static var emptyTitle: String { L10n.tr("Localizable", "chat-info.files.empty-title") }
+      public static var emptyTitle: String { L10n.tr("Localizable", "chat-info.files.empty-title") }
       /// Files
-      internal static var title: String { L10n.tr("Localizable", "chat-info.files.title") }
+      public static var title: String { L10n.tr("Localizable", "chat-info.files.title") }
     }
-    internal enum Media {
+    public enum Media {
       /// Photos or videos sent in this chat will appear here.
-      internal static var emptyDesc: String { L10n.tr("Localizable", "chat-info.media.empty-desc") }
+      public static var emptyDesc: String { L10n.tr("Localizable", "chat-info.media.empty-desc") }
       /// No media
-      internal static var emptyTitle: String { L10n.tr("Localizable", "chat-info.media.empty-title") }
+      public static var emptyTitle: String { L10n.tr("Localizable", "chat-info.media.empty-title") }
       /// Photos & Videos
-      internal static var title: String { L10n.tr("Localizable", "chat-info.media.title") }
+      public static var title: String { L10n.tr("Localizable", "chat-info.media.title") }
     }
-    internal enum Mute {
+    public enum Mute {
       /// Mute Group
-      internal static var group: String { L10n.tr("Localizable", "chat-info.mute.group") }
+      public static var group: String { L10n.tr("Localizable", "chat-info.mute.group") }
       /// Mute User
-      internal static var user: String { L10n.tr("Localizable", "chat-info.mute.user") }
+      public static var user: String { L10n.tr("Localizable", "chat-info.mute.user") }
     }
-    internal enum PinnedMessages {
+    public enum PinnedMessages {
       /// Long-press an important message and choose Pin to conversation.
-      internal static var emptyDesc: String { L10n.tr("Localizable", "chat-info.pinned-messages.empty-desc") }
+      public static var emptyDesc: String { L10n.tr("Localizable", "chat-info.pinned-messages.empty-desc") }
       /// No pinned messages
-      internal static var emptyTitle: String { L10n.tr("Localizable", "chat-info.pinned-messages.empty-title") }
+      public static var emptyTitle: String { L10n.tr("Localizable", "chat-info.pinned-messages.empty-title") }
       /// Pinned Messages
-      internal static var title: String { L10n.tr("Localizable", "chat-info.pinned-messages.title") }
+      public static var title: String { L10n.tr("Localizable", "chat-info.pinned-messages.title") }
     }
-    internal enum Rename {
+    public enum Rename {
       /// NAME
-      internal static var name: String { L10n.tr("Localizable", "chat-info.rename.name") }
+      public static var name: String { L10n.tr("Localizable", "chat-info.rename.name") }
       /// Add a group name
-      internal static var placeholder: String { L10n.tr("Localizable", "chat-info.rename.placeholder") }
+      public static var placeholder: String { L10n.tr("Localizable", "chat-info.rename.placeholder") }
     }
-    internal enum Users {
+    public enum Users {
       /// %@ more
-      internal static func loadMore(_ p1: Any) -> String {
+      public static func loadMore(_ p1: Any) -> String {
         return L10n.tr("Localizable", "chat-info.users.loadMore", String(describing: p1))
       }
     }
   }
 
-  internal enum Composer {
-    internal enum Checkmark {
+  public enum Composer {
+    public enum Checkmark {
       /// Also send in channel
-      internal static var channelReply: String { L10n.tr("Localizable", "composer.checkmark.channel-reply") }
+      public static var channelReply: String { L10n.tr("Localizable", "composer.checkmark.channel-reply") }
       /// Also send as direct message
-      internal static var directMessageReply: String { L10n.tr("Localizable", "composer.checkmark.direct-message-reply") }
+      public static var directMessageReply: String { L10n.tr("Localizable", "composer.checkmark.direct-message-reply") }
     }
-    internal enum Commands {
+    public enum Commands {
       /// Giphy
-      internal static var giphy: String { L10n.tr("Localizable", "composer.commands.giphy") }
+      public static var giphy: String { L10n.tr("Localizable", "composer.commands.giphy") }
       /// Mute
-      internal static var mute: String { L10n.tr("Localizable", "composer.commands.mute") }
+      public static var mute: String { L10n.tr("Localizable", "composer.commands.mute") }
       /// Unmute
-      internal static var unmute: String { L10n.tr("Localizable", "composer.commands.unmute") }
-      internal enum Format {
+      public static var unmute: String { L10n.tr("Localizable", "composer.commands.unmute") }
+      public enum Format {
         /// text
-        internal static var text: String { L10n.tr("Localizable", "composer.commands.format.text") }
+        public static var text: String { L10n.tr("Localizable", "composer.commands.format.text") }
         /// @username
-        internal static var username: String { L10n.tr("Localizable", "composer.commands.format.username") }
+        public static var username: String { L10n.tr("Localizable", "composer.commands.format.username") }
       }
     }
-    internal enum Files {
+    public enum Files {
       /// Add more files
-      internal static var addMore: String { L10n.tr("Localizable", "composer.files.add-more") }
+      public static var addMore: String { L10n.tr("Localizable", "composer.files.add-more") }
     }
-    internal enum Images {
+    public enum Images {
       /// Change in Settings
-      internal static var accessSettings: String { L10n.tr("Localizable", "composer.images.access-settings") }
+      public static var accessSettings: String { L10n.tr("Localizable", "composer.images.access-settings") }
       /// You have not granted access to the photo library.
-      internal static var noAccessLibrary: String { L10n.tr("Localizable", "composer.images.no-access-library") }
+      public static var noAccessLibrary: String { L10n.tr("Localizable", "composer.images.no-access-library") }
     }
-    internal enum Picker {
+    public enum Picker {
       /// Cancel
-      internal static var cancel: String { L10n.tr("Localizable", "composer.picker.cancel") }
+      public static var cancel: String { L10n.tr("Localizable", "composer.picker.cancel") }
       /// File
-      internal static var file: String { L10n.tr("Localizable", "composer.picker.file") }
+      public static var file: String { L10n.tr("Localizable", "composer.picker.file") }
       /// Photo or Video
-      internal static var media: String { L10n.tr("Localizable", "composer.picker.media") }
+      public static var media: String { L10n.tr("Localizable", "composer.picker.media") }
       /// Choose attachment type: 
-      internal static var title: String { L10n.tr("Localizable", "composer.picker.title") }
+      public static var title: String { L10n.tr("Localizable", "composer.picker.title") }
     }
-    internal enum Placeholder {
+    public enum Placeholder {
       /// Search GIFs
-      internal static var giphy: String { L10n.tr("Localizable", "composer.placeholder.giphy") }
+      public static var giphy: String { L10n.tr("Localizable", "composer.placeholder.giphy") }
       /// Send a message
-      internal static var message: String { L10n.tr("Localizable", "composer.placeholder.message") }
+      public static var message: String { L10n.tr("Localizable", "composer.placeholder.message") }
       /// Slow mode ON
-      internal static var slowMode: String { L10n.tr("Localizable", "composer.placeholder.slow-mode") }
+      public static var slowMode: String { L10n.tr("Localizable", "composer.placeholder.slow-mode") }
     }
-    internal enum Polls {
+    public enum Polls {
       /// Are you sure you want to discard your poll?
-      internal static var actionSheetDiscardTitle: String { L10n.tr("Localizable", "composer.polls.action-sheet-discard-title") }
+      public static var actionSheetDiscardTitle: String { L10n.tr("Localizable", "composer.polls.action-sheet-discard-title") }
       /// Add a comment
-      internal static var addComment: String { L10n.tr("Localizable", "composer.polls.add-comment") }
+      public static var addComment: String { L10n.tr("Localizable", "composer.polls.add-comment") }
       /// Add an option
-      internal static var addOption: String { L10n.tr("Localizable", "composer.polls.add-option") }
+      public static var addOption: String { L10n.tr("Localizable", "composer.polls.add-option") }
       /// Anonymous poll
-      internal static var anonymousPoll: String { L10n.tr("Localizable", "composer.polls.anonymous-poll") }
+      public static var anonymousPoll: String { L10n.tr("Localizable", "composer.polls.anonymous-poll") }
       /// Ask a question
-      internal static var askQuestion: String { L10n.tr("Localizable", "composer.polls.askQuestion") }
+      public static var askQuestion: String { L10n.tr("Localizable", "composer.polls.askQuestion") }
       /// Create Poll
-      internal static var createPoll: String { L10n.tr("Localizable", "composer.polls.create-poll") }
+      public static var createPoll: String { L10n.tr("Localizable", "composer.polls.create-poll") }
       /// This is already an option
-      internal static var duplicateOption: String { L10n.tr("Localizable", "composer.polls.duplicate-option") }
+      public static var duplicateOption: String { L10n.tr("Localizable", "composer.polls.duplicate-option") }
       /// Maximum votes per person
-      internal static var maximumVotesPerPerson: String { L10n.tr("Localizable", "composer.polls.maximum-votes-per-person") }
+      public static var maximumVotesPerPerson: String { L10n.tr("Localizable", "composer.polls.maximum-votes-per-person") }
       /// Multiple answers
-      internal static var multipleAnswers: String { L10n.tr("Localizable", "composer.polls.multiple-answers") }
+      public static var multipleAnswers: String { L10n.tr("Localizable", "composer.polls.multiple-answers") }
       /// Options
-      internal static var options: String { L10n.tr("Localizable", "composer.polls.options") }
+      public static var options: String { L10n.tr("Localizable", "composer.polls.options") }
       /// Question
-      internal static var question: String { L10n.tr("Localizable", "composer.polls.question") }
+      public static var question: String { L10n.tr("Localizable", "composer.polls.question") }
       /// Suggest an option
-      internal static var suggestOption: String { L10n.tr("Localizable", "composer.polls.suggest-option") }
+      public static var suggestOption: String { L10n.tr("Localizable", "composer.polls.suggest-option") }
       /// Type a number from 1 and 10
-      internal static var typeNumberFrom1And10: String { L10n.tr("Localizable", "composer.polls.type-number-from-1-and-10") }
+      public static var typeNumberFrom1And10: String { L10n.tr("Localizable", "composer.polls.type-number-from-1-and-10") }
     }
-    internal enum Quoted {
+    public enum Quoted {
       /// Giphy
-      internal static var giphy: String { L10n.tr("Localizable", "composer.quoted.giphy") }
+      public static var giphy: String { L10n.tr("Localizable", "composer.quoted.giphy") }
       /// Photo
-      internal static var photo: String { L10n.tr("Localizable", "composer.quoted.photo") }
+      public static var photo: String { L10n.tr("Localizable", "composer.quoted.photo") }
       /// Video
-      internal static var video: String { L10n.tr("Localizable", "composer.quoted.video") }
+      public static var video: String { L10n.tr("Localizable", "composer.quoted.video") }
     }
-    internal enum Recording {
+    public enum Recording {
       /// Slide to cancel
-      internal static var slideToCancel: String { L10n.tr("Localizable", "composer.recording.slide-to-cancel") }
+      public static var slideToCancel: String { L10n.tr("Localizable", "composer.recording.slide-to-cancel") }
       /// Hold to record, release to send
-      internal static var tip: String { L10n.tr("Localizable", "composer.recording.tip") }
+      public static var tip: String { L10n.tr("Localizable", "composer.recording.tip") }
     }
-    internal enum Suggestions {
-      internal enum Commands {
+    public enum Suggestions {
+      public enum Commands {
         /// Instant Commands
-        internal static var header: String { L10n.tr("Localizable", "composer.suggestions.commands.header") }
+        public static var header: String { L10n.tr("Localizable", "composer.suggestions.commands.header") }
       }
     }
-    internal enum Title {
+    public enum Title {
       /// Edit Message
-      internal static var edit: String { L10n.tr("Localizable", "composer.title.edit") }
+      public static var edit: String { L10n.tr("Localizable", "composer.title.edit") }
       /// Reply to Message
-      internal static var reply: String { L10n.tr("Localizable", "composer.title.reply") }
+      public static var reply: String { L10n.tr("Localizable", "composer.title.reply") }
     }
   }
 
-  internal enum Dates {
+  public enum Dates {
     /// last seen %d days ago
-    internal static func timeAgoDaysPlural(_ p1: Int) -> String {
+    public static func timeAgoDaysPlural(_ p1: Int) -> String {
       return L10n.tr("Localizable", "dates.time-ago-days-plural", p1)
     }
     /// last seen one day ago
-    internal static var timeAgoDaysSingular: String { L10n.tr("Localizable", "dates.time-ago-days-singular") }
+    public static var timeAgoDaysSingular: String { L10n.tr("Localizable", "dates.time-ago-days-singular") }
     /// last seen %d hours ago
-    internal static func timeAgoHoursPlural(_ p1: Int) -> String {
+    public static func timeAgoHoursPlural(_ p1: Int) -> String {
       return L10n.tr("Localizable", "dates.time-ago-hours-plural", p1)
     }
     /// last seen one hour ago
-    internal static var timeAgoHoursSingular: String { L10n.tr("Localizable", "dates.time-ago-hours-singular") }
+    public static var timeAgoHoursSingular: String { L10n.tr("Localizable", "dates.time-ago-hours-singular") }
     /// last seen %d minutes ago
-    internal static func timeAgoMinutesPlural(_ p1: Int) -> String {
+    public static func timeAgoMinutesPlural(_ p1: Int) -> String {
       return L10n.tr("Localizable", "dates.time-ago-minutes-plural", p1)
     }
     /// last seen one minute ago
-    internal static var timeAgoMinutesSingular: String { L10n.tr("Localizable", "dates.time-ago-minutes-singular") }
+    public static var timeAgoMinutesSingular: String { L10n.tr("Localizable", "dates.time-ago-minutes-singular") }
     /// last seen %d months ago
-    internal static func timeAgoMonthsPlural(_ p1: Int) -> String {
+    public static func timeAgoMonthsPlural(_ p1: Int) -> String {
       return L10n.tr("Localizable", "dates.time-ago-months-plural", p1)
     }
     /// last seen one month ago
-    internal static var timeAgoMonthsSingular: String { L10n.tr("Localizable", "dates.time-ago-months-singular") }
+    public static var timeAgoMonthsSingular: String { L10n.tr("Localizable", "dates.time-ago-months-singular") }
     /// last seen %d seconds ago
-    internal static func timeAgoSecondsPlural(_ p1: Int) -> String {
+    public static func timeAgoSecondsPlural(_ p1: Int) -> String {
       return L10n.tr("Localizable", "dates.time-ago-seconds-plural", p1)
     }
     /// last seen just one second ago
-    internal static var timeAgoSecondsSingular: String { L10n.tr("Localizable", "dates.time-ago-seconds-singular") }
+    public static var timeAgoSecondsSingular: String { L10n.tr("Localizable", "dates.time-ago-seconds-singular") }
     /// last seen %d weeks ago
-    internal static func timeAgoWeeksPlural(_ p1: Int) -> String {
+    public static func timeAgoWeeksPlural(_ p1: Int) -> String {
       return L10n.tr("Localizable", "dates.time-ago-weeks-plural", p1)
     }
     /// last seen one week ago
-    internal static var timeAgoWeeksSingular: String { L10n.tr("Localizable", "dates.time-ago-weeks-singular") }
+    public static var timeAgoWeeksSingular: String { L10n.tr("Localizable", "dates.time-ago-weeks-singular") }
     /// Today
-    internal static var today: String { L10n.tr("Localizable", "dates.today") }
+    public static var today: String { L10n.tr("Localizable", "dates.today") }
   }
 
-  internal enum Message {
+  public enum Message {
     /// Message deleted
-    internal static var deletedMessagePlaceholder: String { L10n.tr("Localizable", "message.deleted-message-placeholder") }
+    public static var deletedMessagePlaceholder: String { L10n.tr("Localizable", "message.deleted-message-placeholder") }
     /// Only visible to you
-    internal static var onlyVisibleToYou: String { L10n.tr("Localizable", "message.only-visible-to-you") }
-    internal enum Actions {
+    public static var onlyVisibleToYou: String { L10n.tr("Localizable", "message.only-visible-to-you") }
+    public enum Actions {
       /// Copy Message
-      internal static var copy: String { L10n.tr("Localizable", "message.actions.copy") }
+      public static var copy: String { L10n.tr("Localizable", "message.actions.copy") }
       /// Delete Message
-      internal static var delete: String { L10n.tr("Localizable", "message.actions.delete") }
+      public static var delete: String { L10n.tr("Localizable", "message.actions.delete") }
       /// Edit Message
-      internal static var edit: String { L10n.tr("Localizable", "message.actions.edit") }
+      public static var edit: String { L10n.tr("Localizable", "message.actions.edit") }
       /// Flag Message
-      internal static var flag: String { L10n.tr("Localizable", "message.actions.flag") }
+      public static var flag: String { L10n.tr("Localizable", "message.actions.flag") }
       /// Reply
-      internal static var inlineReply: String { L10n.tr("Localizable", "message.actions.inline-reply") }
+      public static var inlineReply: String { L10n.tr("Localizable", "message.actions.inline-reply") }
       /// Mark Unread
-      internal static var markUnread: String { L10n.tr("Localizable", "message.actions.mark-unread") }
+      public static var markUnread: String { L10n.tr("Localizable", "message.actions.mark-unread") }
       /// Pin to conversation
-      internal static var pin: String { L10n.tr("Localizable", "message.actions.pin") }
+      public static var pin: String { L10n.tr("Localizable", "message.actions.pin") }
       /// Resend
-      internal static var resend: String { L10n.tr("Localizable", "message.actions.resend") }
+      public static var resend: String { L10n.tr("Localizable", "message.actions.resend") }
       /// Thread Reply
-      internal static var threadReply: String { L10n.tr("Localizable", "message.actions.thread-reply") }
+      public static var threadReply: String { L10n.tr("Localizable", "message.actions.thread-reply") }
       /// Unpin from conversation
-      internal static var unpin: String { L10n.tr("Localizable", "message.actions.unpin") }
+      public static var unpin: String { L10n.tr("Localizable", "message.actions.unpin") }
       /// Block User
-      internal static var userBlock: String { L10n.tr("Localizable", "message.actions.user-block") }
+      public static var userBlock: String { L10n.tr("Localizable", "message.actions.user-block") }
       /// Mute User
-      internal static var userMute: String { L10n.tr("Localizable", "message.actions.user-mute") }
+      public static var userMute: String { L10n.tr("Localizable", "message.actions.user-mute") }
       /// Unblock User
-      internal static var userUnblock: String { L10n.tr("Localizable", "message.actions.user-unblock") }
+      public static var userUnblock: String { L10n.tr("Localizable", "message.actions.user-unblock") }
       /// Unmute User
-      internal static var userUnmute: String { L10n.tr("Localizable", "message.actions.user-unmute") }
-      internal enum Delete {
+      public static var userUnmute: String { L10n.tr("Localizable", "message.actions.user-unmute") }
+      public enum Delete {
         /// Are you sure you want to permanently delete this message?
-        internal static var confirmationMessage: String { L10n.tr("Localizable", "message.actions.delete.confirmation-message") }
+        public static var confirmationMessage: String { L10n.tr("Localizable", "message.actions.delete.confirmation-message") }
         /// Delete Message
-        internal static var confirmationTitle: String { L10n.tr("Localizable", "message.actions.delete.confirmation-title") }
+        public static var confirmationTitle: String { L10n.tr("Localizable", "message.actions.delete.confirmation-title") }
       }
-      internal enum Flag {
+      public enum Flag {
         /// Do you want to send a copy of this message to a moderator for further investigation?
-        internal static var confirmationMessage: String { L10n.tr("Localizable", "message.actions.flag.confirmation-message") }
+        public static var confirmationMessage: String { L10n.tr("Localizable", "message.actions.flag.confirmation-message") }
         /// Flag Message
-        internal static var confirmationTitle: String { L10n.tr("Localizable", "message.actions.flag.confirmation-title") }
+        public static var confirmationTitle: String { L10n.tr("Localizable", "message.actions.flag.confirmation-title") }
       }
     }
-    internal enum Bounce {
+    public enum Bounce {
       /// Message was bounced
-      internal static var title: String { L10n.tr("Localizable", "message.bounce.title") }
+      public static var title: String { L10n.tr("Localizable", "message.bounce.title") }
     }
-    internal enum Cell {
+    public enum Cell {
       /// Edited
-      internal static var edited: String { L10n.tr("Localizable", "message.cell.edited") }
+      public static var edited: String { L10n.tr("Localizable", "message.cell.edited") }
       /// Pinned by
-      internal static var pinnedBy: String { L10n.tr("Localizable", "message.cell.pinnedBy") }
+      public static var pinnedBy: String { L10n.tr("Localizable", "message.cell.pinnedBy") }
       /// unknown
-      internal static var unknownPin: String { L10n.tr("Localizable", "message.cell.unknownPin") }
+      public static var unknownPin: String { L10n.tr("Localizable", "message.cell.unknownPin") }
     }
-    internal enum FileAttachment {
+    public enum FileAttachment {
       /// Error occured while previewing the file.
-      internal static var errorPreview: String { L10n.tr("Localizable", "message.file-attachment.error-preview") }
+      public static var errorPreview: String { L10n.tr("Localizable", "message.file-attachment.error-preview") }
     }
-    internal enum Gallery {
+    public enum Gallery {
       /// Photos
-      internal static var photos: String { L10n.tr("Localizable", "message.gallery.photos") }
+      public static var photos: String { L10n.tr("Localizable", "message.gallery.photos") }
     }
-    internal enum GiphyAttachment {
+    public enum GiphyAttachment {
       /// GIPHY
-      internal static var title: String { L10n.tr("Localizable", "message.giphy-attachment.title") }
+      public static var title: String { L10n.tr("Localizable", "message.giphy-attachment.title") }
     }
-    internal enum Polls {
+    public enum Polls {
       /// Anonymous
-      internal static var unknownVoteAuthor: String { L10n.tr("Localizable", "message.polls.unknown-vote-author") }
+      public static var unknownVoteAuthor: String { L10n.tr("Localizable", "message.polls.unknown-vote-author") }
       /// %d votes
-      internal static func votes(_ p1: Int) -> String {
+      public static func votes(_ p1: Int) -> String {
         return L10n.tr("Localizable", "message.polls.votes", p1)
       }
-      internal enum Button {
+      public enum Button {
         /// Add a Comment
-        internal static var addComment: String { L10n.tr("Localizable", "message.polls.button.addComment") }
+        public static var addComment: String { L10n.tr("Localizable", "message.polls.button.addComment") }
         /// End Vote
-        internal static var endVote: String { L10n.tr("Localizable", "message.polls.button.endVote") }
+        public static var endVote: String { L10n.tr("Localizable", "message.polls.button.endVote") }
         /// See %d More Options
-        internal static func seeMoreOptions(_ p1: Int) -> String {
+        public static func seeMoreOptions(_ p1: Int) -> String {
           return L10n.tr("Localizable", "message.polls.button.seeMoreOptions", p1)
         }
         /// Show All
-        internal static var showAll: String { L10n.tr("Localizable", "message.polls.button.show-all") }
+        public static var showAll: String { L10n.tr("Localizable", "message.polls.button.show-all") }
         /// Suggest an Option
-        internal static var suggestAnOption: String { L10n.tr("Localizable", "message.polls.button.suggestAnOption") }
+        public static var suggestAnOption: String { L10n.tr("Localizable", "message.polls.button.suggestAnOption") }
         /// Update Your Comment
-        internal static var updateComment: String { L10n.tr("Localizable", "message.polls.button.updateComment") }
+        public static var updateComment: String { L10n.tr("Localizable", "message.polls.button.updateComment") }
         /// Plural format key: "%#@comments@"
-        internal static func viewNumberOfComments(_ p1: Int) -> String {
+        public static func viewNumberOfComments(_ p1: Int) -> String {
           return L10n.tr("Localizable", "message.polls.button.view-number-of-comments", p1)
         }
         /// View Results
-        internal static var viewResults: String { L10n.tr("Localizable", "message.polls.button.viewResults") }
+        public static var viewResults: String { L10n.tr("Localizable", "message.polls.button.viewResults") }
       }
-      internal enum Subtitle {
+      public enum Subtitle {
         /// Select one
-        internal static var selectOne: String { L10n.tr("Localizable", "message.polls.subtitle.selectOne") }
+        public static var selectOne: String { L10n.tr("Localizable", "message.polls.subtitle.selectOne") }
         /// Select one or more
-        internal static var selectOneOrMore: String { L10n.tr("Localizable", "message.polls.subtitle.selectOneOrMore") }
+        public static var selectOneOrMore: String { L10n.tr("Localizable", "message.polls.subtitle.selectOneOrMore") }
         /// Select up to %d
-        internal static func selectUpTo(_ p1: Int) -> String {
+        public static func selectUpTo(_ p1: Int) -> String {
           return L10n.tr("Localizable", "message.polls.subtitle.selectUpTo", p1)
         }
         /// Vote ended
-        internal static var voteEnded: String { L10n.tr("Localizable", "message.polls.subtitle.voteEnded") }
+        public static var voteEnded: String { L10n.tr("Localizable", "message.polls.subtitle.voteEnded") }
       }
-      internal enum Toolbar {
+      public enum Toolbar {
         /// Poll Comments
-        internal static var commentsTitle: String { L10n.tr("Localizable", "message.polls.toolbar.comments-title") }
+        public static var commentsTitle: String { L10n.tr("Localizable", "message.polls.toolbar.comments-title") }
         /// Poll Options
-        internal static var optionsTitle: String { L10n.tr("Localizable", "message.polls.toolbar.options-title") }
+        public static var optionsTitle: String { L10n.tr("Localizable", "message.polls.toolbar.options-title") }
         /// Poll Results
-        internal static var resultsTitle: String { L10n.tr("Localizable", "message.polls.toolbar.results-title") }
+        public static var resultsTitle: String { L10n.tr("Localizable", "message.polls.toolbar.results-title") }
       }
     }
-    internal enum Reactions {
+    public enum Reactions {
       /// You
-      internal static var currentUser: String { L10n.tr("Localizable", "message.reactions.currentUser") }
+      public static var currentUser: String { L10n.tr("Localizable", "message.reactions.currentUser") }
     }
-    internal enum Search {
+    public enum Search {
       /// Cancel
-      internal static var cancel: String { L10n.tr("Localizable", "message.search.cancel") }
+      public static var cancel: String { L10n.tr("Localizable", "message.search.cancel") }
       /// Plural format key: "%#@results@"
-      internal static func numberOfResults(_ p1: Int) -> String {
+      public static func numberOfResults(_ p1: Int) -> String {
         return L10n.tr("Localizable", "message.search.number-of-results", p1)
       }
       /// Search
-      internal static var title: String { L10n.tr("Localizable", "message.search.title") }
+      public static var title: String { L10n.tr("Localizable", "message.search.title") }
     }
-    internal enum Sending {
+    public enum Sending {
       /// UPLOADING FAILED
-      internal static var attachmentUploadingFailed: String { L10n.tr("Localizable", "message.sending.attachment-uploading-failed") }
+      public static var attachmentUploadingFailed: String { L10n.tr("Localizable", "message.sending.attachment-uploading-failed") }
     }
-    internal enum Threads {
+    public enum Threads {
       /// Plural format key: "%#@replies@"
-      internal static func count(_ p1: Int) -> String {
+      public static func count(_ p1: Int) -> String {
         return L10n.tr("Localizable", "message.threads.count", p1)
       }
       /// Thread Replies
-      internal static var replies: String { L10n.tr("Localizable", "message.threads.replies") }
+      public static var replies: String { L10n.tr("Localizable", "message.threads.replies") }
       /// Thread Reply
-      internal static var reply: String { L10n.tr("Localizable", "message.threads.reply") }
+      public static var reply: String { L10n.tr("Localizable", "message.threads.reply") }
       /// with %@
-      internal static func replyWith(_ p1: Any) -> String {
+      public static func replyWith(_ p1: Any) -> String {
         return L10n.tr("Localizable", "message.threads.replyWith", String(describing: p1))
       }
       /// with messages
-      internal static var subtitle: String { L10n.tr("Localizable", "message.threads.subtitle") }
+      public static var subtitle: String { L10n.tr("Localizable", "message.threads.subtitle") }
     }
-    internal enum Title {
+    public enum Title {
       /// %d members, %d online
-      internal static func group(_ p1: Int, _ p2: Int) -> String {
+      public static func group(_ p1: Int, _ p2: Int) -> String {
         return L10n.tr("Localizable", "message.title.group", p1, p2)
       }
       /// Offline
-      internal static var offline: String { L10n.tr("Localizable", "message.title.offline") }
+      public static var offline: String { L10n.tr("Localizable", "message.title.offline") }
       /// Online
-      internal static var online: String { L10n.tr("Localizable", "message.title.online") }
+      public static var online: String { L10n.tr("Localizable", "message.title.online") }
     }
-    internal enum Unread {
+    public enum Unread {
       /// Plural format key: "%#@unread@"
-      internal static func count(_ p1: Int) -> String {
+      public static func count(_ p1: Int) -> String {
         return L10n.tr("Localizable", "message.unread.count", p1)
       }
     }
   }
 
-  internal enum MessageList {
+  public enum MessageList {
     /// Plural format key: "%#@messages@"
-    internal static func newMessages(_ p1: Int) -> String {
+    public static func newMessages(_ p1: Int) -> String {
       return L10n.tr("Localizable", "messageList.newMessages", p1)
     }
-    internal enum TypingIndicator {
+    public enum TypingIndicator {
       /// Someone is typing
-      internal static var typingUnknown: String { L10n.tr("Localizable", "messageList.typingIndicator.typing-unknown") }
+      public static var typingUnknown: String { L10n.tr("Localizable", "messageList.typingIndicator.typing-unknown") }
       /// Plural format key: "%1$@%2$#@typing@"
-      internal static func users(_ p1: Any, _ p2: Int) -> String {
+      public static func users(_ p1: Any, _ p2: Int) -> String {
         return L10n.tr("Localizable", "messageList.typingIndicator.users", String(describing: p1), p2)
       }
     }
   }
 
-  internal enum Reaction {
-    internal enum Authors {
+  public enum Reaction {
+    public enum Authors {
       /// Plural format key: "%#@reactions@"
-      internal static func numberOfReactions(_ p1: Int) -> String {
+      public static func numberOfReactions(_ p1: Int) -> String {
         return L10n.tr("Localizable", "reaction.authors.number-of-reactions", p1)
       }
     }
   }
 
-  internal enum Recording {
-    internal enum Presentation {
+  public enum Recording {
+    public enum Presentation {
       /// Plural format key: "%#@recording@"
-      internal static func name(_ p1: Int) -> String {
+      public static func name(_ p1: Int) -> String {
         return L10n.tr("Localizable", "recording.presentation.name", p1)
       }
     }
@@ -536,13 +536,13 @@ internal enum L10n {
 
 extension L10n {
 
-  private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {
+  public static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {
      let format = Appearance.localizationProvider(key, table)
      return String(format: format, locale: Locale.current, arguments: args)
   }
 }
 
-private final class BundleToken {
+public final class BundleToken {
   static let bundle: Bundle = .streamChatUI
 }
 

--- a/Sources/StreamChatSwiftUI/Utils.swift
+++ b/Sources/StreamChatSwiftUI/Utils.swift
@@ -56,7 +56,7 @@ public class Utils {
 
     var messageCachingUtils = MessageCachingUtils()
     var messageListDateUtils: MessageListDateUtils
-    var channelControllerFactory = ChannelControllerFactory()
+    public var channelControllerFactory = ChannelControllerFactory()
     
     internal var _audioPlayer: AudioPlaying?
     internal var _audioRecorder: AudioRecording?

--- a/Sources/StreamChatSwiftUI/Utils/KeyboardHandling.swift
+++ b/Sources/StreamChatSwiftUI/Utils/KeyboardHandling.swift
@@ -90,7 +90,7 @@ public func resignFirstResponder() {
 
 public let getStreamFirstResponderNotification = "io.getstream.inputView.becomeFirstResponder"
 
-func becomeFirstResponder() {
+public func becomeFirstResponder() {
     NotificationCenter.default.post(
         name: NSNotification.Name(getStreamFirstResponderNotification),
         object: nil


### PR DESCRIPTION
### 🔗 Issue Link
N/A

### 🎯 Goal

Given my app requirements, I needed to customize ChatChannelInfoView by removing Leave Group and disallowing the manual addition of people to a channel.

### 🛠 Implementation

In order to customize ChatChannelInfoView, I needed to expose certain functions and properties.

### 🧪 Testing

I needed to upgrade some access controls from Internal to Public. I did so until all compiler errors were fixed and my own CustomChatChannelInfoView was written, which works great. No other tests were performed.

### 🎨 Changes

N/A

### ☑️ Checklist

- [ X ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
