### PR TITLE
Added message actions for user blocking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+### ✅ Added
+- Added message actions for user blocking [#532](https://github.com/GetStream/stream-chat-swiftui/pull/532)
+
 ### 🐞 Fixed
 - Smoother and more performant view updates in channel and message lists [#522](https://github.com/GetStream/stream-chat-swiftui/pull/522)
 

--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageListConfig.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageListConfig.swift
@@ -30,7 +30,8 @@ public struct MessageListConfig {
         uniqueReactionsEnabled: Bool = false,
         localLinkDetectionEnabled: Bool = true,
         isMessageEditedLabelEnabled: Bool = true,
-        markdownSupportEnabled: Bool = true
+        markdownSupportEnabled: Bool = true,
+        userBlockingEnabled: Bool = false
     ) {
         self.messageListType = messageListType
         self.typingIndicatorPlacement = typingIndicatorPlacement
@@ -54,6 +55,7 @@ public struct MessageListConfig {
         self.localLinkDetectionEnabled = localLinkDetectionEnabled
         self.isMessageEditedLabelEnabled = isMessageEditedLabelEnabled
         self.markdownSupportEnabled = markdownSupportEnabled
+        self.userBlockingEnabled = userBlockingEnabled
     }
 
     public let messageListType: MessageListType
@@ -78,6 +80,7 @@ public struct MessageListConfig {
     public let localLinkDetectionEnabled: Bool
     public let isMessageEditedLabelEnabled: Bool
     public let markdownSupportEnabled: Bool
+    public let userBlockingEnabled: Bool
 }
 
 /// Contains information about the message paddings.

--- a/Sources/StreamChatSwiftUI/ChatChannel/Reactions/MessageActions/DefaultMessageActions.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Reactions/MessageActions/DefaultMessageActions.swift
@@ -178,6 +178,32 @@ extension MessageAction {
                     messageActions.append(muteAction)
                 }
             }
+            
+            if InjectedValues[\.utils].messageListConfig.userBlockingEnabled {
+                let userController = chatClient.currentUserController()
+                let blockedUserIds = userController.dataStore.currentUser()?.blockedUserIds ?? []
+                if blockedUserIds.contains(message.author.id) {
+                    let unblockAction = unblockUserAction(
+                        for: message,
+                        channel: channel,
+                        chatClient: chatClient,
+                        userToUnblock: message.author,
+                        onFinish: onFinish,
+                        onError: onError
+                    )
+                    messageActions.append(unblockAction)
+                } else {
+                    let blockAction = blockUserAction(
+                        for: message,
+                        channel: channel,
+                        chatClient: chatClient,
+                        userToBlock: message.author,
+                        onFinish: onFinish,
+                        onError: onError
+                    )
+                    messageActions.append(blockAction)
+                }
+            }
         }
 
         return messageActions
@@ -519,6 +545,46 @@ extension MessageAction {
 
         return muteUser
     }
+    
+    private static func blockUserAction(
+        for message: ChatMessage,
+        channel: ChatChannel,
+        chatClient: ChatClient,
+        userToBlock: ChatUser,
+        onFinish: @escaping (MessageActionInfo) -> Void,
+        onError: @escaping (Error) -> Void
+    ) -> MessageAction {
+        let blockController = chatClient.userController(userId: userToBlock.id)
+        let blockAction = {
+            blockController.block { error in
+                if let error = error {
+                    onError(error)
+                } else {
+                    onFinish(
+                        MessageActionInfo(
+                            message: message,
+                            identifier: "block"
+                        )
+                    )
+                }
+            }
+        }
+
+        let blockUser = MessageAction(
+            id: MessageActionId.block,
+            title: L10n.Message.Actions.userBlock,
+            iconName: "circle.slash",
+            action: blockAction,
+            confirmationPopup: ConfirmationPopup(
+                title: L10n.Message.Actions.userBlock,
+                message: L10n.Message.Actions.UserBlock.confirmationMessage,
+                buttonTitle: L10n.Alert.Actions.ok
+            ),
+            isDestructive: true
+        )
+
+        return blockUser
+    }
 
     private static func unmuteAction(
         for message: ChatMessage,
@@ -554,6 +620,46 @@ extension MessageAction {
         )
 
         return unmuteUser
+    }
+    
+    private static func unblockUserAction(
+        for message: ChatMessage,
+        channel: ChatChannel,
+        chatClient: ChatClient,
+        userToUnblock: ChatUser,
+        onFinish: @escaping (MessageActionInfo) -> Void,
+        onError: @escaping (Error) -> Void
+    ) -> MessageAction {
+        let blockController = chatClient.userController(userId: userToUnblock.id)
+        let unblockAction = {
+            blockController.unblock { error in
+                if let error = error {
+                    onError(error)
+                } else {
+                    onFinish(
+                        MessageActionInfo(
+                            message: message,
+                            identifier: "unblock"
+                        )
+                    )
+                }
+            }
+        }
+
+        let unblockUser = MessageAction(
+            id: MessageActionId.unblock,
+            title: L10n.Message.Actions.userUnblock,
+            iconName: "circle.slash",
+            action: unblockAction,
+            confirmationPopup: ConfirmationPopup(
+                title: L10n.Message.Actions.userUnblock,
+                message: L10n.Message.Actions.UserUnblock.confirmationMessage,
+                buttonTitle: L10n.Alert.Actions.ok
+            ),
+            isDestructive: false
+        )
+
+        return unblockUser
     }
 
     private static func resendMessageAction(
@@ -669,4 +775,6 @@ public enum MessageActionId {
     public static let unpin = "unpin_message_action"
     public static let resend = "resend_message_action"
     public static let markUnread = "mark_unread_action"
+    public static let block = "block_user_action"
+    public static let unblock = "unblock_user_action"
 }

--- a/Sources/StreamChatSwiftUI/Generated/L10n.swift
+++ b/Sources/StreamChatSwiftUI/Generated/L10n.swift
@@ -371,6 +371,14 @@ internal enum L10n {
         /// Flag Message
         internal static var confirmationTitle: String { L10n.tr("Localizable", "message.actions.flag.confirmation-title") }
       }
+      internal enum UserBlock {
+        /// Are you sure you want to block this user?
+        internal static var confirmationMessage: String { L10n.tr("Localizable", "message.actions.user-block.confirmation-message") }
+      }
+      internal enum UserUnblock {
+        /// Are you sure you want to unblock this user?
+        internal static var confirmationMessage: String { L10n.tr("Localizable", "message.actions.user-unblock.confirmation-message") }
+      }
     }
     internal enum Bounce {
       /// Message was bounced

--- a/Sources/StreamChatSwiftUI/Resources/en.lproj/Localizable.strings
+++ b/Sources/StreamChatSwiftUI/Resources/en.lproj/Localizable.strings
@@ -40,6 +40,8 @@
 "message.actions.mark-unread" = "Mark Unread";
 "message.actions.flag.confirmation-title" = "Flag Message";
 "message.actions.flag.confirmation-message" = "Do you want to send a copy of this message to a moderator for further investigation?";
+"message.actions.user-block.confirmation-message" = "Are you sure you want to block this user?";
+"message.actions.user-unblock.confirmation-message" = "Are you sure you want to unblock this user?";
 
 "messageList.typingIndicator.typing-unknown" = "Someone is typing";
 

--- a/StreamChatSwiftUI.xcodeproj/project.pbxproj
+++ b/StreamChatSwiftUI.xcodeproj/project.pbxproj
@@ -3704,8 +3704,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/GetStream/stream-chat-swift.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 4.58.0;
+				branch = develop;
+				kind = branch;
 			};
 		};
 		E3A1C01A282BAC66002D1E26 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {

--- a/StreamChatSwiftUITests/Tests/ChatChannel/MessageActions_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/MessageActions_Tests.swift
@@ -72,6 +72,44 @@ class MessageActions_Tests: StreamChatTestCase {
         XCTAssert(messageActions[5].title == "Flag Message")
         XCTAssert(messageActions[6].title == "Mute User")
     }
+    
+    func test_messageActions_otherUserDefaultBlockingEnabled() {
+        // Given
+        streamChat = StreamChat(
+            chatClient: chatClient,
+            utils: .init(messageListConfig: .init(userBlockingEnabled: true))
+        )
+        let channel = ChatChannel.mockDMChannel()
+        let message = ChatMessage.mock(
+            id: .unique,
+            cid: channel.cid,
+            text: "Test",
+            author: .mock(id: .unique),
+            isSentByCurrentUser: false
+        )
+        let factory = DefaultViewFactory.shared
+
+        // When
+        let messageActions = MessageAction.defaultActions(
+            factory: factory,
+            for: message,
+            channel: channel,
+            chatClient: chatClient,
+            onFinish: { _ in },
+            onError: { _ in }
+        )
+
+        // Then
+        XCTAssert(messageActions.count == 8)
+        XCTAssert(messageActions[0].title == "Reply")
+        XCTAssert(messageActions[1].title == "Thread Reply")
+        XCTAssert(messageActions[2].title == "Pin to conversation")
+        XCTAssert(messageActions[3].title == "Copy Message")
+        XCTAssert(messageActions[4].title == "Mark Unread")
+        XCTAssert(messageActions[5].title == "Flag Message")
+        XCTAssert(messageActions[6].title == "Mute User")
+        XCTAssert(messageActions[7].title == "Block User")
+    }
 
     func test_messageActions_currentUserPinned() {
         // Given


### PR DESCRIPTION
### 🔗 Issue Link
Resolves https://stream-io.atlassian.net/browse/PBE-4990.

### 🎯 Goal

Expose message action for user blocking.

### 🛠 Implementation

Provide user blocking in the message actions.

### 🧪 Testing

You need to set `userBlockingEnabled` to true in the `MessageListConfig`.

### 🎨 Changes

_Add relevant screenshots or videos showcasing the changes._

### ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
