### PR TITLE
Jumping to an unread message did not keep scroll location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🐞 Fixed
 - Smoother and more performant view updates in channel and message lists [#522](https://github.com/GetStream/stream-chat-swiftui/pull/522)
+- Fix scrolling location when jumping to a message not in the currently loaded message list [#533](https://github.com/GetStream/stream-chat-swiftui/pull/533)
 
 # [4.58.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.58.0)
 _June 27, 2024_

--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageListView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageListView.swift
@@ -230,8 +230,8 @@ public struct MessageListView<Factory: ViewFactory>: View, KeyboardReadable {
                             } else if diff < 0 && scrollDirection == .down {
                                 scrollDirection = .up
                             }
+                            utils.messageCachingUtils.scrollOffset = offsetValue
                         }
-                        utils.messageCachingUtils.scrollOffset = offsetValue
                         let scrollButtonShown = offsetValue < -20
                         if scrollButtonShown != showScrollToLatestButton {
                             showScrollToLatestButton = scrollButtonShown


### PR DESCRIPTION
### 🔗 Issue Link
Resolves [PBE-5003](https://stream-io.atlassian.net/browse/PBE-5003)

### 🎯 Goal

Fix an issue where scroll location was not kept after jumping to a message

### 🛠 Implementation

- Set the scroll location to the unread message when the message list has changed (unread message lookup only works on the loaded message list)

Note: In general, the ChatChannelViewModel would benefit from the state layer API a lot since then we would not have cases where we call load more messages, wait for completion handler AND then also need to wait when the delegate callback comes (delay comes from database observer).

### 🧪 Testing

Chewbacca has some test channels useful here.

Verification checks
1. Is scroll to last button shown or hidden correctly?
2. Is the scrolled message visible after jumping to it?
3. Unread messages should be marked as read when reaching the most recent message after jumping to the first unread message.

Case 1: Jumping to unread message
1. Scroll up in a channel and press and hold on a message
4. Mark the message as unread
5. Go to channel list
6. Go back to the channel
7. Tap on the x unread messages button > we should jump to the first unread message

Case 2: Jumping to some other message
1. Scroll to an old message, quote it
2. Open the channel again and tap on the quoted message > we jump to that message

### 🎨 Changes

I marked the message "A" as unread.

| Before | After |
| ------ | ----- |
| ![img](https://github.com/GetStream/stream-chat-swiftui/assets/1469907/5654a7ac-b043-4161-9dd3-5e3a085bce09)   |  ![img](https://github.com/GetStream/stream-chat-swiftui/assets/1469907/3c909bd1-b05d-4daa-8d36-888bf0b4a96e)  |

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)


[PBE-5003]: https://stream-io.atlassian.net/browse/PBE-5003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ