### PR TITLE
Skip pod lint when targeting a branch for stream-chat-swift

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -15,7 +15,7 @@ derived_data_path = 'derived_data'
 source_packages_path = 'spm_cache'
 buildcache_xcargs = 'CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++'
 is_localhost = !is_ci
-project_package_resolved = './../StreamChatSwiftUI.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved'
+project_package_resolved = "#{xcode_project}/project.xcworkspace/xcshareddata/swiftpm/Package.resolved"
 @force_check = false
 
 before_all do |lane|

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -127,7 +127,7 @@ end
 
 lane :pod_lint do
   dependencies = Dir.chdir('..') { JSON.parse(File.read(project_package_resolved)) }
-  is_branch = dependencies["pins"].find { |dependency| dependency['identity'] == 'stream-chat-swift' && dependency['state']['branch'] }
+  is_branch = dependencies['pins'].find { |dependency| dependency['identity'] == 'stream-chat-swift' && dependency['state']['branch'] }
   if is_branch.nil?
     pod_lib_lint(podspec: 'StreamChatSwiftUI.podspec', allow_warnings: true)
   else

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -126,7 +126,7 @@ private_lane :appstore_api_key do
 end
 
 lane :pod_lint do
-  dependencies = JSON.parse(File.read(project_package_resolved))
+  dependencies = Dir.chdir('..') { JSON.parse(File.read(project_package_resolved)) }
   is_branch = dependencies["pins"].find { |dependency| dependency['identity'] == 'stream-chat-swift' && dependency['state']['branch'] }
   if is_branch.nil?
     pod_lib_lint(podspec: 'StreamChatSwiftUI.podspec', allow_warnings: true)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -15,6 +15,7 @@ derived_data_path = 'derived_data'
 source_packages_path = 'spm_cache'
 buildcache_xcargs = 'CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++'
 is_localhost = !is_ci
+project_package_resolved = './../StreamChatSwiftUI.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved'
 @force_check = false
 
 before_all do |lane|
@@ -125,7 +126,13 @@ private_lane :appstore_api_key do
 end
 
 lane :pod_lint do
-  pod_lib_lint(podspec: 'StreamChatSwiftUI.podspec', allow_warnings: true)
+  dependencies = JSON.parse(File.read(project_package_resolved))
+  is_branch = dependencies["pins"].find { |dependency| dependency['identity'] == 'stream-chat-swift' && dependency['state']['branch'] }
+  if is_branch.nil?
+    pod_lib_lint(podspec: 'StreamChatSwiftUI.podspec', allow_warnings: true)
+  else
+    UI.important('Pod linting skipped: stream-chat-swift targets a development branch')
+  end
 end
 
 desc "If `readonly: true` (by default), installs all Certs and Profiles necessary for development and ad-hoc.\nIf `readonly: false`, recreates all Profiles necessary for development and ad-hoc, updates them locally and remotely."

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -126,6 +126,7 @@ private_lane :appstore_api_key do
 end
 
 lane :pod_lint do
+  Dir.chdir('..') { sh("xcodebuild -resolvePackageDependencies -clonedSourcePackagesDirPath #{source_packages_path}") }
   dependencies = Dir.chdir('..') { JSON.parse(File.read(project_package_resolved)) }
   is_branch = dependencies['pins'].find { |dependency| dependency['identity'] == 'stream-chat-swift' && dependency['state']['branch'] }
   if is_branch.nil?

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -126,10 +126,14 @@ private_lane :appstore_api_key do
 end
 
 lane :pod_lint do
-  Dir.chdir('..') { sh("xcodebuild -resolvePackageDependencies -clonedSourcePackagesDirPath #{source_packages_path}") }
-  dependencies = Dir.chdir('..') { JSON.parse(File.read(project_package_resolved)) }
-  is_branch = dependencies['pins'].find { |dependency| dependency['identity'] == 'stream-chat-swift' && dependency['state']['branch'] }
-  if is_branch.nil?
+  lint_required = true
+  Dir.chdir('..') do
+    sh("xcodebuild -resolvePackageDependencies -clonedSourcePackagesDirPath #{source_packages_path}")
+    dependencies = JSON.parse(File.read(project_package_resolved))
+    lint_required = dependencies['pins'].none? { |dependency| dependency['identity'] == 'stream-chat-swift' && dependency['state']['branch'] }
+  end
+
+  if lint_required
     pod_lib_lint(podspec: 'StreamChatSwiftUI.podspec', allow_warnings: true)
   else
     UI.important('Pod linting skipped: stream-chat-swift targets a development branch')


### PR DESCRIPTION
### 🎯 Goal

Keep pod linting green on CI when targeting a branch during development.

### 🛠 Implementation

Often we use StreamChat's develop branch in development. This triggers CI errors when linting the pod file. Skip linting if we target a branch.

Example: [CI fails](https://github.com/GetStream/stream-chat-swiftui/actions/runs/9773393802/job/26979475151?pr=534)

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
