### PR TITLE
Editing quoted messages did not refresh the message list

### DIFF
--- a/Sources/StreamChatSwiftUI/Utils/MessageCachingUtils.swift
+++ b/Sources/StreamChatSwiftUI/Utils/MessageCachingUtils.swift
@@ -64,6 +64,10 @@ class MessageCachingUtils {
     }
 
     func quotedMessage(for message: ChatMessage) -> ChatMessage? {
+        if StreamRuntimeCheck._isDatabaseObserverItemReusingEnabled {
+            return message.quotedMessage
+        }
+        
         if checkedMessageIds.contains(message.id) {
             return nil
         }

--- a/StreamChatSwiftUI.xcodeproj/project.pbxproj
+++ b/StreamChatSwiftUI.xcodeproj/project.pbxproj
@@ -3704,7 +3704,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/GetStream/stream-chat-swift.git";
 			requirement = {
-				branch = "fix/swiftui-model-diffing";
+				branch = develop;
 				kind = branch;
 			};
 		};

--- a/StreamChatSwiftUI.xcodeproj/project.pbxproj
+++ b/StreamChatSwiftUI.xcodeproj/project.pbxproj
@@ -3704,7 +3704,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/GetStream/stream-chat-swift.git";
 			requirement = {
-				branch = develop;
+				branch = "fix/swiftui-model-diffing";
 				kind = branch;
 			};
 		};

--- a/StreamChatSwiftUITests/Tests/ChatChannel/MessageCachingUtils_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/MessageCachingUtils_Tests.swift
@@ -25,6 +25,17 @@ class MessageCachingUtils_Tests: StreamChatTestCase {
             author: author
         )
     )
+    
+    private var initialReusingState = false
+    
+    override func setUpWithError() throws {
+        initialReusingState = StreamRuntimeCheck._isDatabaseObserverItemReusingEnabled
+        StreamRuntimeCheck._isDatabaseObserverItemReusingEnabled = false
+    }
+    
+    override func tearDownWithError() throws {
+        StreamRuntimeCheck._isDatabaseObserverItemReusingEnabled = initialReusingState
+    }
 
     func test_messageCachingUtils_authorId() {
         // Given


### PR DESCRIPTION
### 🔗 Issue Link
Related [PBE-4291](https://stream-io.atlassian.net/browse/PBE-4291)

### 🎯 Goal

Redisplay quoted message after edit.

### 🛠 Implementation

Disable caching and use LLC's ChatMessage equality changes.

### 🧪 Testing

1. Send a message
2. Quote the sent message
3. Edit the initial message > second message redisplays

### 🎨 Changes

| Before | After |
| ------ | ----- |
| ![img](https://github.com/GetStream/stream-chat-swiftui/assets/1469907/0a5004fc-30ad-46d9-885c-e9a2cd91696c) | ![img](https://github.com/GetStream/stream-chat-swiftui/assets/1469907/135c39f2-f68b-46a7-8f18-e666e5a8125d) |

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)


[PBE-4291]: https://stream-io.atlassian.net/browse/PBE-4291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ