### PR TITLE
Disable caching for author in message list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Smoother and more performant view updates in channel and message lists [#522](https://github.com/GetStream/stream-chat-swiftui/pull/522)
 - Fix scrolling location when jumping to a message not in the currently loaded message list [#533](https://github.com/GetStream/stream-chat-swiftui/pull/533)
 - Fix display of the most votes icon in Polls [#538](https://github.com/GetStream/stream-chat-swiftui/pull/538)
+- Fix message author information not reflecting the latest state [#540](https://github.com/GetStream/stream-chat-swiftui/pull/540)
 
 # [4.58.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.58.0)
 _June 27, 2024_

--- a/Sources/StreamChatSwiftUI/Utils/MessageCachingUtils.swift
+++ b/Sources/StreamChatSwiftUI/Utils/MessageCachingUtils.swift
@@ -12,7 +12,6 @@ class MessageCachingUtils {
 
     private var messageAuthorMapping = [String: String]()
     private var messageAuthors = [String: UserDisplayInfo]()
-    private var messageAttachments = [String: Bool]()
     private var checkedMessageIds = Set<String>()
     private var quotedMessageMapping = [String: ChatMessage]()
 
@@ -101,7 +100,6 @@ class MessageCachingUtils {
         messageThreadShown = false
         messageAuthorMapping = [String: String]()
         messageAuthors = [String: UserDisplayInfo]()
-        messageAttachments = [String: Bool]()
         checkedMessageIds = Set<String>()
         quotedMessageMapping = [String: ChatMessage]()
     }
@@ -109,6 +107,16 @@ class MessageCachingUtils {
     // MARK: - private
 
     private func userDisplayInfo(for message: ChatMessage) -> UserDisplayInfo? {
+        if StreamRuntimeCheck._isDatabaseObserverItemReusingEnabled {
+            let user = message.author
+            return UserDisplayInfo(
+                id: user.id,
+                name: user.name ?? user.id,
+                imageURL: user.imageURL,
+                role: user.userRole
+            )
+        }
+        
         if let userId = messageAuthorMapping[message.id],
            let userDisplayInfo = messageAuthors[userId] {
             return userDisplayInfo
@@ -129,12 +137,6 @@ class MessageCachingUtils {
         messageAuthors[user.id] = userDisplayInfo
 
         return userDisplayInfo
-    }
-
-    private func checkAttachments(for message: ChatMessage) -> Bool {
-        let hasAttachments = !message.attachmentCounts.isEmpty
-        messageAttachments[message.id] = hasAttachments
-        return hasAttachments
     }
 }
 

--- a/StreamChatSwiftUITests/Tests/ChatChannel/MessageCachingUtils_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/MessageCachingUtils_Tests.swift
@@ -179,10 +179,49 @@ class MessageCachingUtils_Tests: StreamChatTestCase {
         // Then
         XCTAssert(userDisplayInfo == nil)
     }
+    
+    func test_messageCachingUtils_userDisplayInfoWithoutCaching() {
+        // Given
+        StreamRuntimeCheck._isDatabaseObserverItemReusingEnabled = true
+        let utils = MessageCachingUtils()
+        let authorId: String = .unique
+        let messageId: MessageId = .unique
+        let cid: ChannelId = .unique
+        let url1 = URL(string: "https://imageurl.com")
+        let author1 = ChatUser.mock(id: authorId, name: "Martin", imageURL: url1)
+        let message1 = ChatMessage.mock(
+            id: messageId,
+            cid: cid,
+            text: "Test message",
+            author: author1
+        )
+        let url2 = URL(string: "https://anotherimageurl.com")
+        let author2 = ChatUser.mock(id: authorId, name: "Toomas", imageURL: url2)
+        let message2 = ChatMessage.mock(
+            id: messageId,
+            cid: cid,
+            text: "Test message",
+            author: author2
+        )
+        
+        // When
+        let authorInfo1 = utils.authorInfo(from: message1)
+        let authorInfo2 = utils.authorInfo(from: message2)
+        
+        // Then
+        // Accessing the same message returns updated author information
+        XCTAssertEqual("Martin", authorInfo1.name)
+        XCTAssertEqual(url1, authorInfo1.imageURL)
+        XCTAssertEqual("Toomas", authorInfo2.name)
+        XCTAssertEqual(url2, authorInfo2.imageURL)
+    }
 }
 
 extension UserDisplayInfo: Equatable {
     public static func == (lhs: UserDisplayInfo, rhs: UserDisplayInfo) -> Bool {
-        lhs.id == rhs.id && lhs.name == rhs.name && lhs.imageURL == rhs.imageURL
+        lhs.id == rhs.id &&
+            lhs.name == rhs.name &&
+            lhs.imageURL == rhs.imageURL &&
+            lhs.role == rhs.role
     }
 }


### PR DESCRIPTION
### 🔗 Issue Link
Related [PBE-4291](https://stream-io.atlassian.net/browse/PBE-4291)

### 🎯 Goal

We have list reusing and background mapping enabled on the LLC side. Therefore, it not needed to cache the access to author. Caching had side effects like avatars and names not updating when accessed through `ChatMessage` `userDisplayInfo(from:)`.
Profiled it and author access did not show up as expected.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)


[PBE-4291]: https://stream-io.atlassian.net/browse/PBE-4291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ