### PR TITLE
Made the Constructor of PhotoAttachmentCell Public

### DIFF
--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/PhotoAttachmentPickerView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/PhotoAttachmentPickerView.swift
@@ -52,7 +52,7 @@ public struct PhotoAttachmentCell: View {
     @Injected(\.images) private var images
     @Injected(\.fonts) private var fonts
     
-    @StateObject var assetLoader: PhotoAssetLoader
+    @ObservedObject var assetLoader: PhotoAssetLoader
     
     @State private var assetURL: URL?
     @State private var compressing = false
@@ -66,7 +66,21 @@ public struct PhotoAttachmentCell: View {
     private var assetType: AssetType {
         asset.mediaType == .video ? .video : .image
     }
-    
+
+    public init(
+        assetLoader: PhotoAssetLoader, 
+        requestId: PHContentEditingInputRequestID? = nil, 
+        asset: PHAsset, 
+        onImageTap: @escaping (AddedAsset) -> Void, 
+        imageSelected: @escaping (String) -> Bool
+    ) {
+        _assetLoader = ObservedObject(initialValue: assetLoader)
+        self.requestId = requestId
+        self.asset = asset
+        self.onImageTap = onImageTap
+        self.imageSelected = imageSelected
+    }
+ 
     public var body: some View {
         ZStack {
             if let image = assetLoader.loadedImages[asset.localIdentifier] {


### PR DESCRIPTION
### 🔗 Issue Link

https://github.com/GetStream/stream-chat-swiftui/issues/543

### 🎯 Goal

To enable the usage of PhotoAttachmentCell from outside of StreamChatSwiftUI when creating a customized PhotoAttachmentPickerView.

### 🛠 Implementation

- Generated a memberwise initializer and made it public.

### 🧪 Testing

Confirmed that PhotoAttachmentPickerView displays correctly without any issues.

### 🎨 Changes

_Add relevant screenshots or videos showcasing the changes._

### ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
