### PR TITLE
Fix markdown links with query parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### 🐞 Fixed
+- Fix markdown links with query parameters [#576](https://github.com/GetStream/stream-chat-swiftui/pull/576)
 
 # [4.61.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.61.0)
 _July 31, 2024_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # Upcoming
 
 ### 🐞 Fixed
-- Fix markdown links with query parameters [#576](https://github.com/GetStream/stream-chat-swiftui/pull/576)
+- Fix markdown links with query parameters [#581](https://github.com/GetStream/stream-chat-swiftui/pull/581)
 
 # [4.61.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.61.0)
 _July 31, 2024_

--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageView.swift
@@ -327,7 +327,8 @@ public struct LinkDetectionTextView: View {
 
             let range = NSRange(location: 0, length: message.adjustedText.utf16.count)
             linkDetector.links(in: message.adjustedText).forEach { textLink in
-                let pattern = "\\[([^\\]]+)\\]\\(\(textLink.originalText)\\)"
+                let escapedOriginalText = NSRegularExpression.escapedPattern(for: textLink.originalText)
+                let pattern = "\\[([^\\]]+)\\]\\(\(escapedOriginalText)\\)"
                 if let regex = try? NSRegularExpression(pattern: pattern) {
                     containsLinks = (regex.firstMatch(
                         in: message.adjustedText,


### PR DESCRIPTION
### 🎯 Goal

Fixes display of markdown links with query params, e.g. [link](https://google.com?google_id=abc)

### 🛠 Implementation

_Provide a description of the implementation._

### 🧪 Testing

_Describe the steps how this change can be tested (or why it can't be tested)._

### 🎨 Changes

_Add relevant screenshots or videos showcasing the changes._

### ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
