### PR TITLE
Typing users did not update reliably in the message list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🔄 Changed
 
+### 🐞 Fixed
+- Typing users did not update reliably in the message list [#591](https://github.com/GetStream/stream-chat-swiftui/pull/591)
+
 # [4.62.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.62.0)
 _August 16, 2024_
 

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelViewModel.swift
@@ -120,9 +120,7 @@ open class ChatChannelViewModel: ObservableObject, MessagesDataSource {
         }
     }
     
-    public var channel: ChatChannel? {
-        channelController.channel
-    }
+    @Published public private(set) var channel: ChatChannel?
     
     public var isMessageThread: Bool {
         messageController != nil
@@ -150,6 +148,7 @@ open class ChatChannelViewModel: ObservableObject, MessagesDataSource {
         }
         channelDataSource.delegate = self
         messages = channelDataSource.messages
+        channel = channelController.channel
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
             if let scrollToMessage, let parentMessageId = scrollToMessage.parentMessageId, messageController == nil {
@@ -445,6 +444,7 @@ open class ChatChannelViewModel: ObservableObject, MessagesDataSource {
         didUpdateChannel channel: EntityChange<ChatChannel>,
         channelController: ChatChannelController
     ) {
+        self.channel = channel.item
         checkReadIndicators(for: channel)
         checkTypingIndicator()
         checkHeaderType()

--- a/StreamChatSwiftUITests/Tests/ChatChannel/ChatChannelViewModel_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/ChatChannelViewModel_Tests.swift
@@ -8,7 +8,27 @@ import SwiftUI
 import XCTest
 
 class ChatChannelViewModel_Tests: StreamChatTestCase {
-
+    func test_chatChannelVM_channelIsUpdated() {
+        // Given
+        let cid = ChannelId.unique
+        let initialChannel = ChatChannel.mock(cid: cid)
+        let channelController = makeChannelController()
+        channelController.channel_mock = initialChannel
+        let viewModel = ChatChannelViewModel(channelController: channelController)
+        XCTAssertEqual(initialChannel, viewModel.channel)
+        
+        // When
+        let updatedChannel = ChatChannel.mock(cid: cid)
+        channelController.channel_mock = updatedChannel
+        channelController.delegate?.channelController(
+            channelController,
+            didUpdateChannel: .update(updatedChannel)
+        )
+        
+        // Then
+        XCTAssertEqual(updatedChannel, viewModel.channel)
+    }
+    
     func test_chatChannelVM_messagesLoaded() {
         // Given
         let channelController = makeChannelController()


### PR DESCRIPTION
### 🔗 Issue Link

Resolves: [PBE-5805](https://stream-io.atlassian.net/browse/PBE-5805)

### 🎯 Goal

- Fix an issue where multiple typing users were not displayed

### 🛠 Implementation

After verifying that LLC correctly propagates the typing users change and ChatChannelController.channel returning multiple users the issue had to be on the view side. The issue is that when channel changes, `ChatChannelViewModel` does not propagate the change and SwiftUI view did not know that it needs to redisplay.

### 🧪 Testing

1. Run the demo app on 3 different simulators/devices
2. Open the same channel on all of the simulators/devices
3. 2 of them are typing
Result: on the third device we see typing indicator saying user x and 1 more are typing

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)


[PBE-5805]: https://stream-io.atlassian.net/browse/PBE-5805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ