### PR TITLE
Only show "Flag message" Action if user has permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🔄 Changed
 - Improved subtitle info in pinned messages view [#594](https://github.com/GetStream/stream-chat-swiftui/pull/594)
 - The `image(for channel: ChatChannel)` in `ChannelHeaderLoader` is now open [#595](https://github.com/GetStream/stream-chat-swiftui/pull/595) 
+- FlagMessage Action is now only shown if user has permission to perform action [#599](https://github.com/GetStream/stream-chat-swiftui/pull/599) 
 
 ### 🐞 Fixed
 - Typing users did not update reliably in the message list [#591](https://github.com/GetStream/stream-chat-swiftui/pull/591)

--- a/Sources/StreamChatSwiftUI/ChatChannel/Reactions/MessageActions/DefaultMessageActions.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Reactions/MessageActions/DefaultMessageActions.swift
@@ -142,15 +142,17 @@ extension MessageAction {
                 messageActions.append(markUnreadAction)
             }
             
-            let flagAction = flagMessageAction(
-                for: message,
-                channel: channel,
-                chatClient: chatClient,
-                onFinish: onFinish,
-                onError: onError
-            )
-
-            messageActions.append(flagAction)
+            if channel.canFlagMessage {
+                let flagAction = flagMessageAction(
+                    for: message,
+                    channel: channel,
+                    chatClient: chatClient,
+                    onFinish: onFinish,
+                    onError: onError
+                )
+                
+                messageActions.append(flagAction)
+            }
 
             if channel.config.mutesEnabled {
                 let author = message.author


### PR DESCRIPTION
### 🔗 Issue Link


### 🎯 Goal

User shouldn't see Flag Message action if they cant use it

### 🛠 Implementation

Simple capability check before adding Message action

### 🧪 Testing

Change user permissions and verify that the action can or cannot be seen 

### 🎨 Changes

![image](https://github.com/user-attachments/assets/7921cab2-2c2e-481b-8f50-44e0137866a7)
### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Affected documentation updated (docusaurus, tutorial, CMS (task created)
