### PR TITLE
Jump to first unread message button in the message list was not possible to close in some cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Typing users did not update reliably in the message list [#591](https://github.com/GetStream/stream-chat-swiftui/pull/591)
 - Channel was sometimes marked as read when the first unread message was one of the first not visible messages [#593](https://github.com/GetStream/stream-chat-swiftui/pull/593)
+- Jump to first unread message button in the message list was not possible to close in some cases [#600](https://github.com/GetStream/stream-chat-swiftui/pull/600)
 
 # [4.62.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.62.0)
 _August 16, 2024_

--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageListView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageListView.swift
@@ -36,6 +36,7 @@ public struct MessageListView<Factory: ViewFactory>: View, KeyboardReadable {
     @State private var pendingKeyboardUpdate: Bool?
     @State private var scrollDirection = ScrollDirection.up
     @State private var unreadMessagesBannerShown = false
+    @State private var unreadButtonDismissed = false
 
     private var messageRenderingUtil = MessageRenderingUtil.shared
     private var skipRenderingMessageIds = [String]()
@@ -293,7 +294,7 @@ public struct MessageListView<Factory: ViewFactory>: View, KeyboardReadable {
             }
         })
         .overlay(
-            (channel.unreadCount.messages > 0 && !unreadMessagesBannerShown && !isMessageThread) ?
+            (channel.unreadCount.messages > 0 && !unreadMessagesBannerShown && !isMessageThread && !unreadButtonDismissed) ?
                 factory.makeJumpToUnreadButton(
                     channel: channel,
                     onJumpToMessage: {
@@ -301,6 +302,7 @@ public struct MessageListView<Factory: ViewFactory>: View, KeyboardReadable {
                     },
                     onClose: {
                         firstUnreadMessageId = nil
+                        unreadButtonDismissed = true
                     }
                 ) : nil
         )


### PR DESCRIPTION
### 🔗 Issue Link
Resolves: [PBE-5957](https://stream-io.atlassian.net/browse/PBE-5957)

### 🎯 Goal

Always close the jump to unread message button when tapping on the x button on it.

### 🛠 Implementation

Closing the jump to unread message button relies on an API call which marks all the messages as read. API call can timeout or take a long time depending on the internet connection. This change will hide the button as soon as it is tapped.

### 🧪 Testing

1. Open a channel with unread messges
2. Tap on the x button on the unread message count button at the top of the message list

### 🎨 Changes

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)


[PBE-5957]: https://stream-io.atlassian.net/browse/PBE-5957?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ