### PR TITLE
Reduce view updates when computing frame for long press action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### 🐞 Fixed
+- Rare crash when accessing frame of the view [#607](https://github.com/GetStream/stream-chat-swiftui/pull/607)
 
 # [4.63.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.63.0)
 _September 12, 2024_

--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageContainerView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageContainerView.swift
@@ -112,9 +112,7 @@ public struct MessageContainerView<Factory: ViewFactory>: View {
                         GeometryReader { proxy in
                             Rectangle().fill(Color.clear)
                                 .onChange(of: computeFrame, perform: { _ in
-                                    DispatchQueue.main.async {
-                                        frame = proxy.frame(in: .global)
-                                    }
+                                    frame = proxy.frame(in: .global)
                                 })
                         }
                     )
@@ -347,9 +345,8 @@ public struct MessageContainerView<Factory: ViewFactory>: View {
         showsMessageActions: Bool,
         showsBottomContainer: Bool = true
     ) {
-        computeFrame = true
+        computeFrame.toggle()
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            computeFrame = false
             triggerHapticFeedback(style: .medium)
             onLongPress(
                 MessageDisplayInfo(


### PR DESCRIPTION
### 🎯 Goal

Reduce view updates when calculating a frame for the long press action (computing the frame led to a crash in rare cases)

### 🛠 Implementation

- onChange is called just after SwiftUI finishes view updates, therefore accessing the frame should not lead to in SwiftUI view graph calculations
- Update the boolean toggle just once, because it is not important if it stays in true or false (saving view update cycle)

### 🧪 Testing

Try opening a channel, sending messages, opening message actions etc

### 🎨 Changes

_Add relevant screenshots or videos showcasing the changes._

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
