### PR TITLE
ChatChannelListView navigation did not trigger when using a custom container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🐞 Fixed
 - Rare crash when accessing frame of the view [#607](https://github.com/GetStream/stream-chat-swiftui/pull/607)
+- `ChatChannelListView` navigation did not trigger when using a custom container and its body reloaded [#609](https://github.com/GetStream/stream-chat-swiftui/pull/609)
 
 # [4.63.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.63.0)
 _September 12, 2024_


### PR DESCRIPTION
### 🔗 Issue Link
Resolves: [PBE-6081](https://stream-io.atlassian.net/browse/PBE-6081)

### 🎯 Goal

- Fix an issue where embedding the `ChatChannelListView` breaks its navigation after the embedded view reloads its body
- Added documentation to the `ChatChannelListView.init`

### 🛠 Implementation

The default `onTapHandler` captures the view model instance created within the view, not the one stored in the @StateObject property. When view reloads, `onTapHandler` captures the incorrect instance.

### 🧪 Testing

1. Open `DemoAppSwiftUIApp.swift`
2. Replace `case .loggedIn:` implementation with:
```swift
NavigationView {
    VStack {
        Button(!isBroken ? "Break" : "Broken") {
            isBroken.toggle()
        }
        ChatChannelListView(
            viewFactory: DemoAppFactory.shared,
            channelListController: channelListController,
            embedInNavigationView: false
        )
    }
}
```
and add
`@State private var isBroken = false`
to the `DemoAppSwiftUIApp` type
3. Launch the demo app
4. Tap on any of the items and verify that the tapped channel is opened
5. Navigate back to the channel list, tap on the "Break" button and verify that navigation is still possible.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)


[PBE-6081]: https://stream-io.atlassian.net/browse/PBE-6081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ