### PR TITLE
Channel was sometimes not marked as read when tapping the x on the unread message pill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Rare crash when accessing frame of the view [#607](https://github.com/GetStream/stream-chat-swiftui/pull/607)
 - `ChatChannelListView` navigation did not trigger when using a custom container and its body reloaded [#609](https://github.com/GetStream/stream-chat-swiftui/pull/609)
+- Channel was sometimes not marked as read when tapping the x on the unread message pill in the message list [#610](https://github.com/GetStream/stream-chat-swiftui/pull/610)
 
 # [4.63.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.63.0)
 _September 12, 2024_

--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageListView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageListView.swift
@@ -301,7 +301,7 @@ public struct MessageListView<Factory: ViewFactory>: View, KeyboardReadable {
                         _ = onJumpToMessage?(firstUnreadMessageId ?? .unknownMessageId)
                     },
                     onClose: {
-                        firstUnreadMessageId = nil
+                        chatClient.channelController(for: channel.cid).markRead()
                         unreadButtonDismissed = true
                     }
                 ) : nil


### PR DESCRIPTION
### 🔗 Issue Link
Resolves: [PBE-6007](https://stream-io.atlassian.net/browse/PBE-6007)

### 🎯 Goal

Fix an issue where markRead was not triggered if there were a lot of unread messages in the channel and user tapped on the x button (grey pill at the top of the message list).

### 🛠 Implementation

`firstUnreadMessageId` depends on the currently loaded messages. If the unread message is part of the message page not currently loaded, setting it to nil does not mark the channel as read.

### 🧪 Testing

1. Open a channel with 100 unread messages
2. Tap on the x button
Result: Channel is marked as read and navigating back to the channel list shows that all the messages are read for that channel.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)


[PBE-6007]: https://stream-io.atlassian.net/browse/PBE-6007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ