### PR TITLE
[CI] Improvements

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,10 +1,6 @@
 name: "Publish new release"
 
 on:
-  push:
-    branches:
-      - main
-
   workflow_dispatch:
 
 jobs:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -98,6 +98,10 @@ lane :merge_release do |options|
   merge_release_to_main(author: options[:author])
 end
 
+lane :merge_main do
+  merge_main_to_develop
+end
+
 desc "Publish a new release to GitHub and CocoaPods"
 lane :publish_release do |options|
   release_version = File.read(swift_environment_path).match(/String\s+=\s+"([\d.]+)"/)[1]
@@ -122,7 +126,7 @@ lane :publish_release do |options|
 
   update_spm(version: release_version)
 
-  merge_main_to_develop
+  merge_main
 end
 
 private_lane :appstore_api_key do

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -96,6 +96,7 @@ end
 
 lane :merge_release do |options|
   merge_release_to_main(author: options[:author])
+  sh('gh workflow run release-publish.yml --ref main')
 end
 
 lane :merge_main do


### PR DESCRIPTION
- Extract `merge_main_to_develop` to an indie lane to be able to run it locally
- Trigger `release_publish.yml` workflow via `gh` instead of `push` event that did not work