### PR TITLE
Fix crash when opening message overlay in iPad with a TabBar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### 🐞 Fixed
+-Fix crash when opening message overlay in iPad with a TabBar [#627](https://github.com/GetStream/stream-chat-swiftui/pull/627)
 
 # [4.65.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.65.0)
 _October 18, 2024_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # Upcoming
 
 ### 🐞 Fixed
--Fix crash when opening message overlay in iPad with a TabBar [#627](https://github.com/GetStream/stream-chat-swiftui/pull/627)
+- Fix crash when opening message overlay in iPad with a TabBar [#627](https://github.com/GetStream/stream-chat-swiftui/pull/627)
 
 # [4.65.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.65.0)
 _October 18, 2024_

--- a/Sources/StreamChatSwiftUI/ChatChannel/Reactions/ReactionsOverlayView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Reactions/ReactionsOverlayView.swift
@@ -71,7 +71,7 @@ public struct ReactionsOverlayView<Factory: ViewFactory>: View {
                         currentSnapshot: currentSnapshot,
                         popInAnimationInProgress: !popIn
                     )
-                    .offset(y: spacing > 0 ? screenHeight - currentSnapshot.size.height : 0)
+                    .offset(y: overlayOffsetY)
                 } else {
                     Color.gray.opacity(0.4)
                 }
@@ -290,7 +290,16 @@ public struct ReactionsOverlayView<Factory: ViewFactory>: View {
         
         return originY - spacing
     }
-    
+
+    private var overlayOffsetY: CGFloat {
+        if isIPad && UITabBar.appearance().isHidden == false {
+            // When using iPad with TabBar, this hard coded value makes
+            // sure that the overlay is in the correct position.
+            return 20
+        }
+        return spacing > 0 ? screenHeight - currentSnapshot.size.height : 0
+    }
+
     private var spacing: CGFloat {
         let divider: CGFloat = isIPad ? 2 : 1
         let spacing = (UIScreen.main.bounds.height - screenHeight) / divider

--- a/Sources/StreamChatSwiftUI/ChatChannel/Utils/ChatChannelHelpers.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Utils/ChatChannelHelpers.swift
@@ -82,6 +82,9 @@ public struct BottomLeftView<Content: View>: View {
 
 /// Returns the top most view controller.
 func topVC() -> UIViewController? {
+    // TODO: Refactor ReactionsOverlayView to use a background blur, instead of a snapshot.
+    /// Since the current approach is too error-prone and dependent of the app's hierarchy,
+
     let keyWindow = UIApplication.shared.windows.filter { $0.isKeyWindow }.first
 
     if var topController = keyWindow?.rootViewController {
@@ -92,10 +95,16 @@ func topVC() -> UIViewController? {
         if UIDevice.current.userInterfaceIdiom == .pad {
             let children = topController.children
             if !children.isEmpty {
-                let splitVC = children[0]
-                let sideVCs = splitVC.children
-                if sideVCs.count > 1 {
-                    topController = sideVCs[1]
+                if let splitVC = children[0] as? UISplitViewController,
+                   let contentVC = splitVC.viewControllers.last {
+                    topController = contentVC
+                    return topController
+                } else if let tabVC = children[0] as? UITabBarController,
+                          let selectedVC = tabVC.selectedViewController {
+                    // If the selectedVC is split view, we need to grab the content view of it
+                    // other wise, the selectedVC is already the content view.
+                    let selectedContentVC = selectedVC.children.first?.children.last?.children.first
+                    topController = selectedContentVC ?? selectedVC
                     return topController
                 }
             }

--- a/Sources/StreamChatSwiftUI/Utils/SnapshotCreator.swift
+++ b/Sources/StreamChatSwiftUI/Utils/SnapshotCreator.swift
@@ -28,15 +28,9 @@ public class DefaultSnapshotCreator: SnapshotCreator {
     }
 
     func makeSnapshot(from view: UIView) -> UIImage {
-        let currentSnapshot: UIImage?
-        UIGraphicsBeginImageContext(view.frame.size)
-        if let currentGraphicsContext = UIGraphicsGetCurrentContext() {
-            view.layer.render(in: currentGraphicsContext)
-            currentSnapshot = UIGraphicsGetImageFromCurrentImageContext()
-        } else {
-            currentSnapshot = images.snapshot
+        let renderer = UIGraphicsImageRenderer(size: view.bounds.size)
+        return renderer.image { _ in
+            view.drawHierarchy(in: view.bounds, afterScreenUpdates: true)
         }
-        UIGraphicsEndImageContext()
-        return currentSnapshot ?? images.snapshot
     }
 }


### PR DESCRIPTION
### 🔗 Issue Link
Resolves https://stream-io.atlassian.net/browse/PBE-6263

### 🎯 Goal

Fix crash when opening message overlay in iPad with a TabBar

### 🛠 Implementation

**Current Solution:**
- Uses `UIGraphicsImageRenderer`, which does not crash when providing a `CGSize.zero`
- Changes `topVC()` so that it accounts for a tab bar controller

**Shortcomings:**
- The only problem at the moment is that the navigation bar is not part of the screenshot. I'm not 100% sure why the navigation bar is not being captured by the snapshot yet, but for now, this works as a workaround.

**Ideal solution:**
- We need to refactor the whole Overlay view to use a background blur overlay instead of a snapshot. The snapshot is too dependent on the app hierarchy, which ofc is error-prone and not scalable. 

I created a ticket so that we can tackle this in the future: https://stream-io.atlassian.net/browse/PBE-6270


### 🧪 Testing

1. Open the app with iPad
2. Open a channel
3. Long press a message
4. It should not crash and it should show the message actions overlay view.

### 🎨 Changes

<img width="70%" alt="image" src="https://github.com/user-attachments/assets/61556b5c-86c8-4e6b-9d7c-975ab482bf3b">

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)