### PR TITLE
Only show Leave Group options if user has "leave-channel" permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add support for Channel Search in the Channel List [#628](https://github.com/GetStream/stream-chat-swiftui/pull/628)
 ### 🐞 Fixed
 - Fix crash when opening message overlay in iPad with a TabBar [#627](https://github.com/GetStream/stream-chat-swiftui/pull/627)
+- Only show Leave Group option if the user has leave-channel permission [#633](https://github.com/GetStream/stream-chat-swiftui/pull/633)
 
 # [4.65.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.65.0)
 _October 18, 2024_

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/ChatChannelInfoViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/ChatChannelInfoViewModel.swift
@@ -37,8 +37,11 @@ public class ChatChannelInfoViewModel: ObservableObject, ChatChannelControllerDe
     @Published public var addUsersShown = false
 
     public var shouldShowLeaveConversationButton: Bool {
-        channel.ownCapabilities.contains(.deleteChannel)
-            || !channel.isDirectMessageChannel
+        if channel.isDirectMessageChannel {
+            return channel.ownCapabilities.contains(.deleteChannel)
+        } else {
+            return channel.ownCapabilities.contains(.leaveChannel)
+        }
     }
 
     public var canRenameChannel: Bool {

--- a/Sources/StreamChatSwiftUI/ChatChannelList/DefaultChannelActions.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannelList/DefaultChannelActions.swift
@@ -25,7 +25,7 @@ extension ChannelAction {
 
         actions.append(viewInfo)
 
-        if !channel.isDirectMessageChannel, let userId = chatClient.currentUserId {
+        if !channel.isDirectMessageChannel, channel.ownCapabilities.contains(.leaveChannel), let userId = chatClient.currentUserId {
             let leaveGroup = leaveGroup(
                 for: channel,
                 chatClient: chatClient,

--- a/StreamChatSwiftUI.xcodeproj/project.pbxproj
+++ b/StreamChatSwiftUI.xcodeproj/project.pbxproj
@@ -3818,10 +3818,10 @@
 		};
 		84E95A75284A486600699FD3 /* XCRemoteSwiftPackageReference "stream-chat-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/GetStream/stream-chat-swift.git";
+			repositoryURL = "https://github.com/bpollman/stream-chat-swift.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 4.65.0;
+				branch = "update-dm-mocks";
+				kind = branch;
 			};
 		};
 		E3A1C01A282BAC66002D1E26 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {

--- a/StreamChatSwiftUI.xcodeproj/project.pbxproj
+++ b/StreamChatSwiftUI.xcodeproj/project.pbxproj
@@ -3820,7 +3820,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/bpollman/stream-chat-swift.git";
 			requirement = {
-				branch = "update-dm-mocks";
+				branch = develop;
 				kind = branch;
 			};
 		};

--- a/StreamChatSwiftUITests/Tests/ChatChannel/ChannelInfo/ChatChannelInfoViewModel_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/ChannelInfo/ChatChannelInfoViewModel_Tests.swift
@@ -236,8 +236,9 @@ class ChatChannelInfoViewModel_Tests: StreamChatTestCase {
 
     func test_chatChannelInfoVM_leaveButtonShownInDM() {
         // Given
-        let channel = ChatChannel.mockDMChannel(
-            name: "Test",
+        let cidDM = ChannelId(type: .messaging, id: "!members" + .newUniqueId)
+        let channel = ChatChannel.mock(
+            cid: cidDM,
             ownCapabilities: [.deleteChannel]
         )
         let viewModel = ChatChannelInfoViewModel(channel: channel)

--- a/StreamChatSwiftUITests/Tests/ChatChannel/ChannelInfo/ChatChannelInfoViewModel_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/ChannelInfo/ChatChannelInfoViewModel_Tests.swift
@@ -222,10 +222,21 @@ class ChatChannelInfoViewModel_Tests: StreamChatTestCase {
         XCTAssert(leaveButton == true)
     }
 
+    func test_chatChannelInfoVM_leaveButtonHiddenInGroup() {
+        // Given
+        let channel = mockGroup(with: 5, updateCapabilities: false)
+        let viewModel = ChatChannelInfoViewModel(channel: channel)
+
+        // When
+        let leaveButton = viewModel.shouldShowLeaveConversationButton
+
+        // Then
+        XCTAssert(leaveButton == false)
+    }
+
     func test_chatChannelInfoVM_leaveButtonShownInDM() {
         // Given
-        let channel = ChatChannel.mock(
-            cid: .unique,
+        let channel = ChatChannel.mockDMChannel(
             name: "Test",
             ownCapabilities: [.deleteChannel]
         )
@@ -262,6 +273,7 @@ class ChatChannelInfoViewModel_Tests: StreamChatTestCase {
         if updateCapabilities {
             capabilities.insert(.updateChannel)
             capabilities.insert(.deleteChannel)
+            capabilities.insert(.leaveChannel)
         }
         let channel = ChatChannel.mock(
             cid: cid,

--- a/StreamChatSwiftUITests/Tests/ChatChannel/ChannelInfo/ChatChannelInfoView_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/ChannelInfo/ChatChannelInfoView_Tests.swift
@@ -103,7 +103,7 @@ class ChatChannelInfoView_Tests: StreamChatTestCase {
         let group = ChatChannel.mock(
             cid: .unique,
             name: "Test Group",
-            ownCapabilities: [.deleteChannel, .updateChannel],
+            ownCapabilities: [.leaveChannel, .updateChannel],
             lastActiveMembers: members,
             memberCount: members.count
         )
@@ -151,7 +151,7 @@ class ChatChannelInfoView_Tests: StreamChatTestCase {
         let group = ChatChannel.mock(
             cid: .unique,
             name: "Test Group",
-            ownCapabilities: [.deleteChannel, .updateChannel],
+            ownCapabilities: [.updateChannel, .leaveChannel],
             lastActiveMembers: members,
             memberCount: members.count
         )


### PR DESCRIPTION
### 🎯 Goal

> Hide the " Leave Group" button/actions if the user doesnt have the permissions.

Original PR: https://github.com/GetStream/stream-chat-swiftui/pull/630 by @bpollman 

Moved to this new branch in order for CI to run.

### 🛠 Implementation

NOTE: Depends on update to mocks main swift rep: https://github.com/GetStream/stream-chat-swift/pull/3478

The code checks for"delete-channel" but not "leave-channel"

This new code 

```
    public var shouldShowLeaveConversationButton: Bool {
        if channel.isDirectMessageChannel {
            return channel.ownCapabilities.contains(.deleteChannel)
        } else {
            return channel.ownCapabilities.contains(.leaveChannel)
        }
    }
```  

properly reflect the existing logic that sets the leave/delete title here.

```
    public var leaveButtonTitle: String {
        if channel.isDirectMessageChannel {
            return L10n.Alert.Actions.deleteChannelTitle
        } else {
            return L10n.Alert.Actions.leaveGroupTitle
        }
    }
```


### 🧪 Testing

_Describe the steps how this change can be tested (or why it can't be tested)._

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
