### PR TITLE
Fix Channel List stuck in Empty View State in rare conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Fix crash when opening message overlay in iPad with a TabBar [#627](https://github.com/GetStream/stream-chat-swiftui/pull/627)
 - Only show Leave Group option if the user has leave-channel permission [#633](https://github.com/GetStream/stream-chat-swiftui/pull/633)
+- Fix Channel List stuck in Empty View State in rare conditions [#639](https://github.com/GetStream/stream-chat-swiftui/pull/639)
 
 # [4.65.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.65.0)
 _October 18, 2024_

--- a/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListViewModel.swift
@@ -310,9 +310,7 @@ open class ChatChannelListViewModel: ObservableObject, ChatChannelListController
 
         updateChannels()
 
-        if channels.isEmpty {
-            loading = networkReachability.isNetworkAvailable()
-        }
+        loading = channels.isEmpty
 
         controller?.synchronize { [weak self] error in
             guard let self = self else { return }

--- a/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListViewModel.swift
@@ -320,9 +320,7 @@ open class ChatChannelListViewModel: ObservableObject, ChatChannelListController
                 self.channelAlertType = .error
             } else {
                 // access channels
-                if self.selectedChannel == nil {
-                    self.updateChannels()
-                }
+                self.updateChannels()
                 self.checkForDeeplinks()
             }
         }


### PR DESCRIPTION
### 🔗 Issue Link
Resolves https://stream-io.atlassian.net/browse/PBE-6291

### 🎯 Goal

Fix the Channel List stuck in Empty View State in rare conditions.

### 🛠 Implementation

- Fix the Channel List stuck in Empty View State in rare conditions. When a customer selected a channel, before opening the channel, the empty view would not disappear.
- Fixes the loading view not showing in rare scenarios, like in the simulator, since the `NetworkReachibility` won't work well in the simulator. Either way, the loading view should only depend on whether there is an available local cache or not, not if there is a network available since this could cause unpredictable behaviour.

### 🧪 Testing
N/A. Not really testable in the Demo App, but the customer confirmed the solution works.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
