### PR TITLE
Fix a bug with photo attachment picker not displaying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Fix crash when opening message overlay in iPad with a TabBar [#627](https://github.com/GetStream/stream-chat-swiftui/pull/627)
 - Only show Leave Group option if the user has leave-channel permission [#633](https://github.com/GetStream/stream-chat-swiftui/pull/633)
+- Fix a bug with photo attachment picker indicator not displaying [#640](https://github.com/GetStream/stream-chat-swiftui/pull/640)
 
 # [4.65.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.65.0)
 _October 18, 2024_

--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/PhotoAttachmentPickerView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/PhotoAttachmentPickerView.swift
@@ -58,6 +58,7 @@ public struct PhotoAttachmentCell: View {
     @State private var compressing = false
     @State private var loading = false
     @State var requestId: PHContentEditingInputRequestID?
+    @State var idOverlay = UUID()
     
     var asset: PHAsset
     var onImageTap: (AddedAsset) -> Void
@@ -113,6 +114,7 @@ public struct PhotoAttachmentCell: View {
                                             )
                                         )
                                     }
+                                    idOverlay = UUID()
                                 }
                             }
                     }
@@ -150,6 +152,7 @@ public struct PhotoAttachmentCell: View {
                     )
                 }
             }
+            .id(idOverlay)
         )
         .onAppear {
             self.loading = false


### PR DESCRIPTION
### 🎯 Goal

Seems like on iOS 18 the overlay updates are triggered differently, causing the checkmark in the photo picker not to display when tapping.

### 🛠 Implementation

Added an `id` identifier to be explicit about this.

### 🧪 Testing

Open the photo picker and tap on some images.

### 🎨 Changes

_Add relevant screenshots or videos showcasing the changes._

### ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
