### PR TITLE
Channel Info:  Only show Add Users button if user has permission to do so

### DIFF
--- a/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/ChatChannelInfoView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/ChatChannelInfoView.swift
@@ -137,7 +137,7 @@ public struct ChatChannelInfoView: View, KeyboardReadable {
             }
 
             ToolbarItem(placement: .navigationBarTrailing) {
-                viewModel.channel.isDirectMessageChannel ? nil :
+                if viewModel.shouldShowAddUserButton {
                     Button {
                         viewModel.addUsersShown = true
                     } label: {
@@ -148,6 +148,7 @@ public struct ChatChannelInfoView: View, KeyboardReadable {
                             .background(colors.tintColor)
                             .clipShape(Circle())
                     }
+                }
             }
         }
         .onReceive(keyboardWillChangePublisher) { visible in

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/ChatChannelInfoViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/ChatChannelInfoViewModel.swift
@@ -48,6 +48,15 @@ public class ChatChannelInfoViewModel: ObservableObject, ChatChannelControllerDe
         channel.ownCapabilities.contains(.updateChannel)
     }
 
+    public var shouldShowAddUserButton: Bool {
+        if channel.isDirectMessageChannel {
+            return false
+        } else {
+            return channel.ownCapabilities.contains(.updateChannelMembers)
+        }
+    }
+
+
     var channelController: ChatChannelController!
     private var memberListController: ChatChannelMemberListController!
     private var loadingUsers = false

--- a/StreamChatSwiftUITests/Tests/ChatChannel/ChannelInfo/ChatChannelInfoViewModel_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/ChannelInfo/ChatChannelInfoViewModel_Tests.swift
@@ -262,6 +262,42 @@ class ChatChannelInfoViewModel_Tests: StreamChatTestCase {
         XCTAssert(leaveButton == false)
     }
 
+    func test_chatChannelInfoVM_addUserButtonShownInGroup() {
+        // Given
+        let channel = mockGroup(with: 5)
+        let viewModel = ChatChannelInfoViewModel(channel: channel)
+
+        // When
+        let leaveButton = viewModel.shouldShowAddUserButton
+
+        // Then
+        XCTAssert(leaveButton == true)
+    }
+
+    func test_chatChannelInfoVM_addUserButtonHiddenInGroup() {
+        // Given
+        let channel = mockGroup(with: 5, updateCapabilities: false)
+        let viewModel = ChatChannelInfoViewModel(channel: channel)
+
+        // When
+        let leaveButton = viewModel.shouldShowAddUserButton
+
+        // Then
+        XCTAssert(leaveButton == false)
+    }
+
+    func test_chatChannelInfoVM_addUserButtonHiddenInDM() {
+        // Given
+        let channel = ChatChannel.mockDMChannel()
+        let viewModel = ChatChannelInfoViewModel(channel: channel)
+
+        // When
+        let leaveButton = viewModel.shouldShowAddUserButton
+
+        // Then
+        XCTAssert(leaveButton == false)
+    }
+
     // MARK: - private
 
     private func mockGroup(with memberCount: Int, updateCapabilities: Bool = true) -> ChatChannel {
@@ -275,6 +311,7 @@ class ChatChannelInfoViewModel_Tests: StreamChatTestCase {
             capabilities.insert(.updateChannel)
             capabilities.insert(.deleteChannel)
             capabilities.insert(.leaveChannel)
+            capabilities.insert(.updateChannelMembers)
         }
         let channel = ChatChannel.mock(
             cid: cid,


### PR DESCRIPTION

### 🔗 Issue Link
_Jira or Github issue link, if applicable._

### 🎯 Goal

Hide the add user button if the action will fail

### 🛠 Implementation

_Provide a description of the implementation._

### 🧪 Testing

Added users tests to ensure DM's and permissions check works

### 🎨 Changes

_Add relevant screenshots or videos showcasing the changes._

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
