### PR TITLE
Only show "Add Users" button in ChannelInfoView if user has permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🔄 Changed
 - Message composer now uses `.uploadFile` capability when showing attachment picker icon [#646](https://github.com/GetStream/stream-chat-swiftui/pull/646)
+- `ChannelInfoView` now uses `.updateChannelMembers` capability to show "Add Users" button [#651](https://github.com/GetStream/stream-chat-swiftui/pull/651)
 
 # [4.66.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.66.0)
 _November 06, 2024_

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/ChatChannelInfoView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/ChatChannelInfoView.swift
@@ -137,7 +137,7 @@ public struct ChatChannelInfoView: View, KeyboardReadable {
             }
 
             ToolbarItem(placement: .navigationBarTrailing) {
-                viewModel.channel.isDirectMessageChannel ? nil :
+                if viewModel.shouldShowAddUserButton {
                     Button {
                         viewModel.addUsersShown = true
                     } label: {
@@ -148,6 +148,7 @@ public struct ChatChannelInfoView: View, KeyboardReadable {
                             .background(colors.tintColor)
                             .clipShape(Circle())
                     }
+                }
             }
         }
         .onReceive(keyboardWillChangePublisher) { visible in

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/ChatChannelInfoViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/ChatChannelInfoViewModel.swift
@@ -48,6 +48,15 @@ public class ChatChannelInfoViewModel: ObservableObject, ChatChannelControllerDe
         channel.ownCapabilities.contains(.updateChannel)
     }
 
+    public var shouldShowAddUserButton: Bool {
+        if channel.isDirectMessageChannel {
+            return false
+        } else {
+            return channel.ownCapabilities.contains(.updateChannelMembers)
+        }
+    }
+
+
     var channelController: ChatChannelController!
     private var memberListController: ChatChannelMemberListController!
     private var loadingUsers = false

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/ChatChannelInfoViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/ChatChannelInfoViewModel.swift
@@ -56,7 +56,6 @@ public class ChatChannelInfoViewModel: ObservableObject, ChatChannelControllerDe
         }
     }
 
-
     var channelController: ChatChannelController!
     private var memberListController: ChatChannelMemberListController!
     private var loadingUsers = false

--- a/StreamChatSwiftUITests/Tests/ChatChannel/ChannelInfo/ChatChannelInfoViewModel_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/ChannelInfo/ChatChannelInfoViewModel_Tests.swift
@@ -262,6 +262,42 @@ class ChatChannelInfoViewModel_Tests: StreamChatTestCase {
         XCTAssert(leaveButton == false)
     }
 
+    func test_chatChannelInfoVM_addUserButtonShownInGroup() {
+        // Given
+        let channel = mockGroup(with: 5)
+        let viewModel = ChatChannelInfoViewModel(channel: channel)
+
+        // When
+        let leaveButton = viewModel.shouldShowAddUserButton
+
+        // Then
+        XCTAssert(leaveButton == true)
+    }
+
+    func test_chatChannelInfoVM_addUserButtonHiddenInGroup() {
+        // Given
+        let channel = mockGroup(with: 5, updateCapabilities: false)
+        let viewModel = ChatChannelInfoViewModel(channel: channel)
+
+        // When
+        let leaveButton = viewModel.shouldShowAddUserButton
+
+        // Then
+        XCTAssert(leaveButton == false)
+    }
+
+    func test_chatChannelInfoVM_addUserButtonHiddenInDM() {
+        // Given
+        let channel = ChatChannel.mockDMChannel()
+        let viewModel = ChatChannelInfoViewModel(channel: channel)
+
+        // When
+        let leaveButton = viewModel.shouldShowAddUserButton
+
+        // Then
+        XCTAssert(leaveButton == false)
+    }
+
     // MARK: - private
 
     private func mockGroup(with memberCount: Int, updateCapabilities: Bool = true) -> ChatChannel {
@@ -275,6 +311,7 @@ class ChatChannelInfoViewModel_Tests: StreamChatTestCase {
             capabilities.insert(.updateChannel)
             capabilities.insert(.deleteChannel)
             capabilities.insert(.leaveChannel)
+            capabilities.insert(.updateChannelMembers)
         }
         let channel = ChatChannel.mock(
             cid: cid,

--- a/StreamChatSwiftUITests/Tests/ChatChannel/ChannelInfo/ChatChannelInfoView_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/ChannelInfo/ChatChannelInfoView_Tests.swift
@@ -151,7 +151,7 @@ class ChatChannelInfoView_Tests: StreamChatTestCase {
         let group = ChatChannel.mock(
             cid: .unique,
             name: "Test Group",
-            ownCapabilities: [.updateChannel, .leaveChannel],
+            ownCapabilities: [.updateChannel, .leaveChannel, .updateChannelMembers],
             lastActiveMembers: members,
             memberCount: members.count
         )


### PR DESCRIPTION
### 🔗 Issue Link
https://github.com/GetStream/stream-chat-swiftui/pull/650

### 🎯 Goal
Only show "Add Users" button in ChannelInfoView if user has permissions

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
