### PR TITLE
Apply colors from the palette to poll views

### DIFF
--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/Polls/PollAllOptionsView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/Polls/PollAllOptionsView.swift
@@ -31,6 +31,7 @@ struct PollAllOptionsView: View {
                                 viewModel: viewModel,
                                 option: option,
                                 optionFont: fonts.headline,
+                                textColor: Color(colors.text),
                                 alternativeStyle: true,
                                 checkboxButtonSpacing: 8
                             )

--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/Polls/PollAttachmentView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/Polls/PollAttachmentView.swift
@@ -40,6 +40,7 @@ public struct PollAttachmentView<Factory: ViewFactory>: View {
                 HStack {
                     Text(poll.name)
                         .font(fonts.bodyBold)
+                        .foregroundColor(textColor(for: message))
                     Spacer()
                 }
                 
@@ -56,7 +57,8 @@ public struct PollAttachmentView<Factory: ViewFactory>: View {
                     viewModel: viewModel,
                     option: option,
                     optionVotes: poll.voteCount(for: option),
-                    maxVotes: poll.currentMaximumVoteCount
+                    maxVotes: poll.currentMaximumVoteCount,
+                    textColor: textColor(for: message)
                 )
                 .layoutPriority(1) // do not compress long text
             }
@@ -188,6 +190,7 @@ struct PollOptionView: View {
     var optionFont: Font = InjectedValues[\.fonts].body
     var optionVotes: Int?
     var maxVotes: Int?
+    var textColor: Color
     /// If true, only option name and vote count is shown, otherwise votes indicator and avatars appear as well.
     var alternativeStyle: Bool = false
     /// The spacing between the checkbox and the option name.
@@ -211,6 +214,7 @@ struct PollOptionView: View {
                 HStack(alignment: .top) {
                     Text(option.text)
                         .font(optionFont)
+                        .foregroundColor(textColor)
                     Spacer()
                     if !alternativeStyle, viewModel.showVoterAvatars {
                         HStack(spacing: -4) {
@@ -225,6 +229,7 @@ struct PollOptionView: View {
                         }
                     }
                     Text("\(viewModel.poll.voteCountsByOption?[option.id] ?? 0)")
+                        .foregroundColor(textColor)
                 }
                 if !alternativeStyle {
                     PollVotesIndicatorView(

--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/Polls/PollResultsView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/Polls/PollResultsView.swift
@@ -55,6 +55,7 @@ struct PollResultsView: View {
                 Spacer()
             }
         }
+        .background(Color(colors.background).ignoresSafeArea())
         .toolbar {
             ToolbarItem(placement: .principal) {
                 Text(L10n.Message.Polls.Toolbar.resultsTitle)

--- a/Sources/StreamChatSwiftUI/ChatChannel/Polls/CreatePollView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Polls/CreatePollView.swift
@@ -162,6 +162,7 @@ struct CreatePollView: View {
                 Spacer()
                     .modifier(ListRowModifier())
             }
+            .background(Color(colors.background).ignoresSafeArea())
             .listStyle(.plain)
             .id(listId)
             .toolbar {
@@ -229,11 +230,14 @@ struct CreatePollItemModifier: ViewModifier {
 }
 
 struct ListRowModifier: ViewModifier {
-    
+
+    @Injected(\.colors) var colors
+
     func body(content: Content) -> some View {
         if #available(iOS 15.0, *) {
             content
                 .listRowSeparator(.hidden)
+                .listRowBackground(Color(colors.background))
         } else {
             content
         }


### PR DESCRIPTION
### 🔗 Issue Link
_Jira or Github issue link, if applicable._

### 🎯 Goal

Poll views in SwiftUI implementation don't have all the palette colors applied properly to them. Namely "Create Poll", "Poll Results" don't have background color, it's just black. And poll cells, don't have text colors for different user messages applied.

### 🛠 Implementation

I just added corresponding colors from the @Injected(\.colors) var colors

### 🧪 Testing

Try creating a poll with custom color scheme applied to that chat with default cells.

### 🎨 Changes

![simulator_screenshot_428C73BD-1550-4FC6-BC9A-AD40D4ED5E4D](https://github.com/user-attachments/assets/eefacfb9-c317-4112-b5a4-65568acf65eb)
![simulator_screenshot_ADD4FB0E-F581-4C8A-92DB-D77DCB10B691](https://github.com/user-attachments/assets/6a61a7f4-d394-4d39-a56a-0b5bcbf05fe5)
![simulator_screenshot_8A0701ED-F0EA-41F9-A049-7D7935FE6CB1](https://github.com/user-attachments/assets/7d1ef841-34dd-4f6b-9ea4-881d336798bf)

### ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
