### PR TITLE
Fix poor message search performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # Upcoming
 
 ### 🔄 Changed
+- Fix poor message search performance [#680](https://github.com/GetStream/stream-chat-swiftui/pull/680)
 
 # [4.68.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.68.0)
 _December 03, 2024_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-⚡ Performance
+### ⚡ Performance
 - Improve message search performance [#680](https://github.com/GetStream/stream-chat-swiftui/pull/680)
 
 # [4.68.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.68.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
-- Fix poor message search performance [#680](https://github.com/GetStream/stream-chat-swiftui/pull/680)
+⚡ Performance
+- Improve message search performance [#680](https://github.com/GetStream/stream-chat-swiftui/pull/680)
 
 # [4.68.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.68.0)
 _December 03, 2024_

--- a/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListViewModel.swift
@@ -365,7 +365,6 @@ open class ChatChannelListViewModel: ObservableObject, ChatChannelListController
             messageSearchController.loadNextMessages { [weak self] _ in
                 guard let self = self else { return }
                 self.loadingNextChannels = false
-                self.updateMessageSearchResults()
             }
         }
     }

--- a/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListViewModel.swift
@@ -419,10 +419,10 @@ open class ChatChannelListViewModel: ObservableObject, ChatChannelListController
             return
         }
 
-        queue.async {
+        queue.async { [weak self] in
             let results: [ChannelSelectionInfo] = messageSearchController.messages.compactMap { message in
                 guard let channelId = message.cid else { return nil }
-                guard let channel = messageSearchController.client.channelController(for: channelId).channel else {
+                guard let channel = self?.chatClient.channelController(for: channelId).channel else {
                     return nil
                 }
                 return ChannelSelectionInfo(
@@ -432,7 +432,7 @@ open class ChatChannelListViewModel: ObservableObject, ChatChannelListController
                 )
             }
             DispatchQueue.main.async {
-                self.searchResults = results
+                self?.searchResults = results
             }
         }
     }

--- a/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelNavigatableListItem.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelNavigatableListItem.swift
@@ -108,19 +108,3 @@ extension ChatChannel {
         ChannelSelectionInfo(channel: self, message: nil)
     }
 }
-
-extension ChatMessage {
-
-    func makeChannelSelectionInfo(with chatClient: ChatClient) -> ChannelSelectionInfo? {
-        if let channelId = cid,
-           let channel = chatClient.channelController(for: channelId).channel {
-            let searchResult = ChannelSelectionInfo(
-                channel: channel,
-                message: self
-            )
-            return searchResult
-        } else {
-            return nil
-        }
-    }
-}


### PR DESCRIPTION
### 🔗 Issue Links
Fixes IOS-574

### 🎯 Goal

Fixes the poor performance of Message Search.

### 🛠 Implementation

### Problem
The root cause of the issue was in the `updateMessageSearchResults()` function. We were accessing the `channelController.channel` for every search result. The problem with this is that we call `startObservers()` for every `channel` property access, which performs a Core Data fetch and, in this case, on the main thread.

We can see this from the time profiler:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/6caf74a8-2312-4bdb-9f13-46d9821f8494">

Besides this, we were calling `updateMessageSearchResults()` twice, for every completion block performed in the `loadNextMessages()` and also in the `didUpdateMessages()` delegate calls.

### First Solution

My first idea was to follow the UIKit approach. There, we use the `dataStore` to fetch the channel directly. However, this also does not work for SwiftUI. The reason is that for UIKit, the `dataStore` is accessed when the cell is reused, whereas in SwiftUI, we map all the results at once, and so we access the `dataStore.channel` for every result again, which means we convert the DTO to model on the main thread multiple times. 

Profile result:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/ea3f068d-3f08-4567-aac5-aa24a1485531">

So, to avoid converting the channel models every time, I implemented a cache that would reuse the existing channels instead of always doing the DTO -> Model conversion.

This worked and the performance was great, but it does require an additional cache, which can increase the memory and is dependent on the amount of different channels we have in the result. So the final solution (check next section) is probably the better one.

### Final Solution

Eventually, I realised that I could simply use the original implementation but offload the search results mapping to a background thread. This worked flawlessly, and it has the less amount of changes and does not require any additional caching. 

Result (No hangs, and Main thread not busy):
<img width="400" alt="image" src="https://github.com/user-attachments/assets/6b06cc3a-c78d-4a0b-8a7a-6dacc12f8453">

### 🧪 Testing

Perform a message search in the Channel List. For example, search for "Hey".

**Known Issue:** The channel name is not rendered for some search results. This is an existing issue and out of the scope of this PR.

### 🎨 Changes

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/ccdf5360-d3d2-4bd1-8185-14928164d0d2" /> | <video src="https://github.com/user-attachments/assets/d4c49534-95ac-46aa-98df-ed65e3458c45" /> |

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
