### PR TITLE
Allow customizing channel and message search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+### ✅ Added
+- Make `CreatePollView` public [#685](https://github.com/GetStream/stream-chat-swiftui/pull/685)
+- Allow customizing channel and message search in the `ChatChannelListViewModel` [#XYZ](ADD)
+  - Allow overriding `ChatChannelListViewModel.performChannelSearch` and `ChatChannelListViewModel.performMessageSearch`
+  - Make `ChatChannelListViewModel.channelListSearchController` and `ChatChannelListViewModel.messageSearchController` public
 ### 🐞 Fixed
 - Fix message thread reply footnote view not shown if parent message not in cache [#681](https://github.com/GetStream/stream-chat-swiftui/pull/681)
 ### ⚡ Performance
 - Improve message search performance [#680](https://github.com/GetStream/stream-chat-swiftui/pull/680)
-### ✅ Added
-- Make `CreatePollView` public [#685](https://github.com/GetStream/stream-chat-swiftui/pull/685)
 ### 🔄 Changed
 - Update `VoiceRecordingContainerView` background colors and layout by moving the message text outside of the recording cell [#689](https://github.com/GetStream/stream-chat-swiftui/pull/689/)
 

--- a/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListViewModel.swift
@@ -102,8 +102,10 @@ open class ChatChannelListViewModel: ObservableObject, ChatChannelListController
     }
 
     private let searchType: ChannelListSearchType
-    internal var channelListSearchController: ChatChannelListController?
-    internal var messageSearchController: ChatMessageSearchController?
+    /// The channel search controller which should be created only by ``performChannelSearch()``.
+    public var channelListSearchController: ChatChannelListController?
+    /// The message search controller which should be created only by ``performMessageSearch()``.
+    public var messageSearchController: ChatMessageSearchController?
 
     /// Serial queue used to process the search results.
     private let queue = DispatchQueue(label: "com.getstream.stream-chat-swiftui.ChatChannelListViewModel")
@@ -388,7 +390,8 @@ open class ChatChannelListViewModel: ObservableObject, ChatChannelListController
         }
     }
 
-    private func performMessageSearch() {
+    /// Creates a new message search controller, sets its delegate, and triggers the search operation.
+    open func performMessageSearch() {
         messageSearchController = chatClient.messageSearchController()
         messageSearchController?.delegate = self
         loadingSearchResults = true
@@ -397,7 +400,8 @@ open class ChatChannelListViewModel: ObservableObject, ChatChannelListController
         }
     }
 
-    private func performChannelSearch() {
+    /// Creates a new channel search controller, sets its delegate, and triggers the search operation.
+    open func performChannelSearch() {
         guard let userId = chatClient.currentUserId else { return }
         var query = ChannelListQuery(
             filter: .and([
@@ -405,6 +409,7 @@ open class ChatChannelListViewModel: ObservableObject, ChatChannelListController
                 .containMembers(userIds: [userId])
             ])
         )
+        // Do not start watching any of the searched channels.
         query.options = []
         channelListSearchController = chatClient.channelListController(query: query)
         loadingSearchResults = true


### PR DESCRIPTION
### 🔗 Issue Link

Resolves: [IOS-608](https://linear.app/stream/issue/IOS-608)

### 🎯 Goal

- Allow customizing channel and message search in the `ChatChannelListViewModel`

### 🛠 Implementation

- Allow overriding `ChatChannelListViewModel.performChannelSearch` and `ChatChannelListViewModel.performMessageSearch`
- Make `ChatChannelListViewModel.channelListSearchController` and `ChatChannelListViewModel.messageSearchController` public

### 🧪 Testing

N/A

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
