### PR TITLE
Allow setting searchType dynamically in ChatChannelListViewModel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### ✅ Added
 - Make `CreatePollView` public [#685](https://github.com/GetStream/stream-chat-swiftui/pull/685)
+- Make `ChatChannelListViewModel.searchType` public and observable [#693](https://github.com/GetStream/stream-chat-swiftui/pull/693)
 - Allow customizing channel and message search in the `ChatChannelListViewModel` [#XYZ](ADD)
   - Allow overriding `ChatChannelListViewModel.performChannelSearch` and `ChatChannelListViewModel.performMessageSearch`
   - Make `ChatChannelListViewModel.channelListSearchController` and `ChatChannelListViewModel.messageSearchController` public

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### ✅ Added
 - Make `CreatePollView` public [#685](https://github.com/GetStream/stream-chat-swiftui/pull/685)
 - Make `ChatChannelListViewModel.searchType` public and observable [#693](https://github.com/GetStream/stream-chat-swiftui/pull/693)
-- Allow customizing channel and message search in the `ChatChannelListViewModel` [#XYZ](ADD)
+- Allow customizing channel and message search in the `ChatChannelListViewModel` [#690](https://github.com/GetStream/stream-chat-swiftui/pull/690)
   - Allow overriding `ChatChannelListViewModel.performChannelSearch` and `ChatChannelListViewModel.performMessageSearch`
   - Make `ChatChannelListViewModel.channelListSearchController` and `ChatChannelListViewModel.messageSearchController` public
 ### 🐞 Fixed


### PR DESCRIPTION
### 🔗 Issue Link

Resolves [IOS-603](https://linear.app/stream/issue/IOS-603)

### 🎯 Goal

Allow setting `searchType` dynamically in `ChatChannelListViewModel`

### 🛠 Implementation

Make `searchType` public in `ChatChannelListViewModel` and support reloading search results based on the type.

### 🧪 Testing

For testing purposes I added locally a button for toggling it (ChatChannelListView.swift)
```swift
VStack {
    Button("Toggle Results", action: {
        if viewModel.searchType == .messages {
            viewModel.searchType = .channels
        } else {
            viewModel.searchType = .messages
        }
    })
    ChatChannelListContentView(
        viewFactory: viewFactory,
        viewModel: viewModel,
        onItemTap: onItemTap
    )
}
```

### 🎨 Changes

![Example](https://github.com/user-attachments/assets/f8b96643-e438-43b1-895c-438de3e97845)


### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
