### PR TITLE
Expose all the default message actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+### ✅ Added
+- Exposes all the default message actions [#711](https://github.com/GetStream/stream-chat-swiftui/pull/711)
 ### 🐞 Fixed
 - Use bright color for typing indicator animation in dark mode [#702](https://github.com/GetStream/stream-chat-swiftui/pull/702)
 - Refresh quoted message preview when the quoted message is deleted [#705](https://github.com/GetStream/stream-chat-swiftui/pull/705)

--- a/Sources/StreamChatSwiftUI/ChatChannel/Reactions/MessageActions/DefaultMessageActions.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Reactions/MessageActions/DefaultMessageActions.swift
@@ -5,7 +5,9 @@
 import StreamChat
 import SwiftUI
 
-extension MessageAction {
+// MARK: - Default Message Actions
+
+public extension MessageAction {
     /// Returns the default message actions.
     ///
     ///  - Parameters:
@@ -13,7 +15,7 @@ extension MessageAction {
     ///     - chatClient: the chat client.
     ///     - onDimiss: called when the action is executed.
     ///  - Returns: array of `MessageAction`.
-    public static func defaultActions<Factory: ViewFactory>(
+    static func defaultActions<Factory: ViewFactory>(
         factory: Factory,
         for message: ChatMessage,
         channel: ChatChannel,
@@ -229,7 +231,8 @@ extension MessageAction {
         return messageActions
     }
 
-    public static func copyMessageAction(
+    /// The action to copy the message text.
+    static func copyMessageAction(
         for message: ChatMessage,
         onFinish: @escaping (MessageActionInfo) -> Void
     ) -> MessageAction {
@@ -253,7 +256,8 @@ extension MessageAction {
         return copyAction
     }
 
-    public static func editMessageAction(
+    /// The action to edit the message.
+    static func editMessageAction(
         for message: ChatMessage,
         channel: ChatChannel,
         onFinish: @escaping (MessageActionInfo) -> Void
@@ -277,7 +281,8 @@ extension MessageAction {
         return editAction
     }
 
-    public static func pinMessageAction(
+    /// The action to pin the message.
+    static func pinMessageAction(
         for message: ChatMessage,
         channel: ChatChannel,
         chatClient: ChatClient,
@@ -316,7 +321,8 @@ extension MessageAction {
         return pinAction
     }
 
-    public static func unpinMessageAction(
+    /// The action to unpin the message.
+    static func unpinMessageAction(
         for message: ChatMessage,
         channel: ChatChannel,
         chatClient: ChatClient,
@@ -355,7 +361,8 @@ extension MessageAction {
         return pinAction
     }
 
-    public static func replyAction(
+    /// The action to reply to the message
+    static func replyAction(
         for message: ChatMessage,
         channel: ChatChannel,
         onFinish: @escaping (MessageActionInfo) -> Void
@@ -379,7 +386,8 @@ extension MessageAction {
         return replyAction
     }
 
-    public static func threadReplyAction<Factory: ViewFactory>(
+    /// The action to reply to the message in a thread
+    static func threadReplyAction<Factory: ViewFactory>(
         factory: Factory,
         for message: ChatMessage,
         channel: ChatChannel
@@ -402,7 +410,8 @@ extension MessageAction {
         return replyThread
     }
 
-    public static func deleteMessageAction(
+    /// The action to delete the message.
+    static func deleteMessageAction(
         for message: ChatMessage,
         channel: ChatChannel,
         chatClient: ChatClient,
@@ -447,7 +456,8 @@ extension MessageAction {
         return deleteMessage
     }
 
-    public static func flagMessageAction(
+    /// The action to flag the message.
+    static func flagMessageAction(
         for message: ChatMessage,
         channel: ChatChannel,
         chatClient: ChatClient,
@@ -491,8 +501,9 @@ extension MessageAction {
 
         return flagMessage
     }
-    
-    public static func markAsUnreadAction(
+
+    /// The action to mark the message as unread.
+    static func markAsUnreadAction(
         for message: ChatMessage,
         channel: ChatChannel,
         chatClient: ChatClient,
@@ -528,7 +539,8 @@ extension MessageAction {
         return unreadAction
     }
 
-    public static func markThreadAsUnreadAction(
+    /// The action to mark the thread as unread.
+    static func markThreadAsUnreadAction(
         messageController: ChatMessageController,
         message: ChatMessage,
         onFinish: @escaping (MessageActionInfo) -> Void,
@@ -560,7 +572,8 @@ extension MessageAction {
         return unreadAction
     }
 
-    public static func muteAction(
+    /// The action to mute the user.
+    static func muteAction(
         for message: ChatMessage,
         channel: ChatChannel,
         chatClient: ChatClient,
@@ -595,8 +608,9 @@ extension MessageAction {
 
         return muteUser
     }
-    
-    public static func blockUserAction(
+
+    /// The action to block the user
+    static func blockUserAction(
         for message: ChatMessage,
         channel: ChatChannel,
         chatClient: ChatClient,
@@ -636,7 +650,8 @@ extension MessageAction {
         return blockUser
     }
 
-    public static func unmuteAction(
+    /// The action to unmute the user.
+    static func unmuteAction(
         for message: ChatMessage,
         channel: ChatChannel,
         chatClient: ChatClient,
@@ -671,8 +686,9 @@ extension MessageAction {
 
         return unmuteUser
     }
-    
-    public static func unblockUserAction(
+
+    /// The action to unblock the user.
+    static func unblockUserAction(
         for message: ChatMessage,
         channel: ChatChannel,
         chatClient: ChatClient,
@@ -712,7 +728,8 @@ extension MessageAction {
         return unblockUser
     }
 
-    public static func resendMessageAction(
+    /// The action to resend the message.
+    static func resendMessageAction(
         for message: ChatMessage,
         channel: ChatChannel,
         chatClient: ChatClient,
@@ -751,7 +768,8 @@ extension MessageAction {
         return messageAction
     }
 
-    public static func messageNotSentActions(
+    /// The actions for a message that was not sent.
+    static func messageNotSentActions(
         for message: ChatMessage,
         channel: ChatChannel,
         chatClient: ChatClient,
@@ -780,6 +798,8 @@ extension MessageAction {
 
         return messageActions
     }
+
+    // MARK: - Helpers
 
     private static func editAndDeleteActions(
         for message: ChatMessage,

--- a/Sources/StreamChatSwiftUI/ChatChannel/Reactions/MessageActions/DefaultMessageActions.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Reactions/MessageActions/DefaultMessageActions.swift
@@ -229,9 +229,7 @@ extension MessageAction {
         return messageActions
     }
 
-    // MARK: - private
-
-    private static func copyMessageAction(
+    public static func copyMessageAction(
         for message: ChatMessage,
         onFinish: @escaping (MessageActionInfo) -> Void
     ) -> MessageAction {
@@ -255,7 +253,7 @@ extension MessageAction {
         return copyAction
     }
 
-    private static func editMessageAction(
+    public static func editMessageAction(
         for message: ChatMessage,
         channel: ChatChannel,
         onFinish: @escaping (MessageActionInfo) -> Void
@@ -279,7 +277,7 @@ extension MessageAction {
         return editAction
     }
 
-    private static func pinMessageAction(
+    public static func pinMessageAction(
         for message: ChatMessage,
         channel: ChatChannel,
         chatClient: ChatClient,
@@ -318,7 +316,7 @@ extension MessageAction {
         return pinAction
     }
 
-    private static func unpinMessageAction(
+    public static func unpinMessageAction(
         for message: ChatMessage,
         channel: ChatChannel,
         chatClient: ChatClient,
@@ -357,7 +355,7 @@ extension MessageAction {
         return pinAction
     }
 
-    private static func replyAction(
+    public static func replyAction(
         for message: ChatMessage,
         channel: ChatChannel,
         onFinish: @escaping (MessageActionInfo) -> Void
@@ -381,7 +379,7 @@ extension MessageAction {
         return replyAction
     }
 
-    private static func threadReplyAction<Factory: ViewFactory>(
+    public static func threadReplyAction<Factory: ViewFactory>(
         factory: Factory,
         for message: ChatMessage,
         channel: ChatChannel
@@ -404,7 +402,7 @@ extension MessageAction {
         return replyThread
     }
 
-    private static func deleteMessageAction(
+    public static func deleteMessageAction(
         for message: ChatMessage,
         channel: ChatChannel,
         chatClient: ChatClient,
@@ -449,7 +447,7 @@ extension MessageAction {
         return deleteMessage
     }
 
-    private static func flagMessageAction(
+    public static func flagMessageAction(
         for message: ChatMessage,
         channel: ChatChannel,
         chatClient: ChatClient,
@@ -494,7 +492,7 @@ extension MessageAction {
         return flagMessage
     }
     
-    private static func markAsUnreadAction(
+    public static func markAsUnreadAction(
         for message: ChatMessage,
         channel: ChatChannel,
         chatClient: ChatClient,
@@ -530,7 +528,7 @@ extension MessageAction {
         return unreadAction
     }
 
-    private static func markThreadAsUnreadAction(
+    public static func markThreadAsUnreadAction(
         messageController: ChatMessageController,
         message: ChatMessage,
         onFinish: @escaping (MessageActionInfo) -> Void,
@@ -562,7 +560,7 @@ extension MessageAction {
         return unreadAction
     }
 
-    private static func muteAction(
+    public static func muteAction(
         for message: ChatMessage,
         channel: ChatChannel,
         chatClient: ChatClient,
@@ -598,7 +596,7 @@ extension MessageAction {
         return muteUser
     }
     
-    private static func blockUserAction(
+    public static func blockUserAction(
         for message: ChatMessage,
         channel: ChatChannel,
         chatClient: ChatClient,
@@ -638,7 +636,7 @@ extension MessageAction {
         return blockUser
     }
 
-    private static func unmuteAction(
+    public static func unmuteAction(
         for message: ChatMessage,
         channel: ChatChannel,
         chatClient: ChatClient,
@@ -674,7 +672,7 @@ extension MessageAction {
         return unmuteUser
     }
     
-    private static func unblockUserAction(
+    public static func unblockUserAction(
         for message: ChatMessage,
         channel: ChatChannel,
         chatClient: ChatClient,
@@ -714,7 +712,7 @@ extension MessageAction {
         return unblockUser
     }
 
-    private static func resendMessageAction(
+    public static func resendMessageAction(
         for message: ChatMessage,
         channel: ChatChannel,
         chatClient: ChatClient,
@@ -753,7 +751,7 @@ extension MessageAction {
         return messageAction
     }
 
-    private static func messageNotSentActions(
+    public static func messageNotSentActions(
         for message: ChatMessage,
         channel: ChatChannel,
         chatClient: ChatClient,


### PR DESCRIPTION
### 🔗 Issue Link
https://github.com/GetStream/stream-chat-swiftui/issues/706

### 🎯 Goal
Exposes all the default message actions so that customers can reuse them.


### 🧪 Testing

N/A

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
