### PR TITLE
Fix thread reply action shown when inside a Thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### 🐞 Fixed
+- Fix thread reply action shown when inside a Thread [#717](https://github.com/GetStream/stream-chat-swiftui/pull/717)
 
 # [4.70.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.70.0)
 _January 15, 2025_

--- a/Sources/StreamChatSwiftUI/ChatChannel/Reactions/MessageActions/DefaultMessageActions.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Reactions/MessageActions/DefaultMessageActions.swift
@@ -72,7 +72,14 @@ public extension MessageAction {
             messageActions.append(replyAction)
         }
 
-        if channel.config.repliesEnabled && !message.isPartOfThread {
+        // At the moment, this is the only way to know if we are inside a thread.
+        // This should be optimised in the future and provide the view context.
+        let messageController = InjectedValues[\.utils]
+            .channelControllerFactory
+            .makeMessageController(for: message.id, channelId: channel.cid)
+        let isInsideThreadView = messageController.replies.count > 0
+
+        if channel.config.repliesEnabled && !message.isPartOfThread && !isInsideThreadView {
             let replyThread = threadReplyAction(
                 factory: factory,
                 for: message,
@@ -113,12 +120,6 @@ public extension MessageAction {
         }
 
         if message.isRootOfThread {
-            let messageController = InjectedValues[\.utils]
-                .channelControllerFactory
-                .makeMessageController(for: message.id, channelId: channel.cid)
-            // At the moment, this is the only way to know if we are inside a thread.
-            // This should be optimised in the future and provide the view context.
-            let isInsideThreadView = messageController.replies.count > 0
             if isInsideThreadView {
                 let markThreadUnreadAction = markThreadAsUnreadAction(
                     messageController: messageController,


### PR DESCRIPTION
### 🔗 Issue Links

Resolves IOS-187

### 🎯 Goal

Fix thread reply action shown when inside a Thread.

The same issue was fixed on UIKit: https://github.com/GetStream/stream-chat-swift/pull/3561

### 🛠 Implementation

The currrent solution uses an existing workaround that we had already in the `MessageAction.defaultActions`. The only edge case is that when the replies are empty, it still shows the "Thread Reply" action. But at the moment this is the best workaround we can do before v5.

### 🧪 Manual Testing Notes

1. Open a Thread
2. Long press the Parent Message
3. Should not show "Thread Reply Action"

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
