### PR TITLE
Fix white circle button is visible beneath the ChannelAvatarView

### DIFF
--- a/Sources/StreamChatSwiftUI/ChatChannel/ChannelHeader/ChatChannelHeaderViewModifier.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChannelHeader/ChatChannelHeaderViewModifier.swift
@@ -64,12 +64,12 @@ public struct DefaultChatChannelHeader: ToolbarContent {
                     resignFirstResponder()
                     isActive = true
                 } label: {
-                    Rectangle()
-                        .fill(Color(colors.background))
-                        .contentShape(Rectangle())
-                        .frame(width: 36, height: 36)
-                        .clipShape(Circle())
-                        .offset(x: 8)
+                    ChannelAvatarView(
+                        avatar: headerImage,
+                        showOnlineIndicator: onlineIndicatorShown,
+                        size: CGSize(width: 36, height: 36)
+                    )
+                    .offset(x: 4)
                 }
                 .accessibilityLabel(Text(L10n.Channel.Header.Info.title))
 
@@ -78,15 +78,6 @@ public struct DefaultChatChannelHeader: ToolbarContent {
                 } label: {
                     EmptyView()
                 }
-                .accessibilityHidden(true)
-                
-                ChannelAvatarView(
-                    avatar: headerImage,
-                    showOnlineIndicator: onlineIndicatorShown,
-                    size: CGSize(width: 36, height: 36)
-                )
-                .offset(x: 8)
-                .allowsHitTesting(false)
                 .accessibilityHidden(true)
             }
             .accessibilityIdentifier("ChannelAvatarView")


### PR DESCRIPTION
### 🔗 Issue Link
[Github issue](https://github.com/GetStream/stream-chat-swiftui/issues/723)

### 🎯 Goal
The channel avatar view should show correctly without a visible white circle below.

### 🛠 Implementation
- Change the style of button inside ToolbarItem
- Update the initialization of ChannelAvatarView to remove deprecated init warninig.

### 🧪 Testing

### 🎨 Changes

![image](https://github.com/user-attachments/assets/5ee242d0-1f4f-48b8-9ac0-a077c6d798a5)

### ☑️ Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
