### PR TITLE
Improve voice over labels and actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🐞 Fixed
 - Fix thread reply action shown when inside a Thread [#717](https://github.com/GetStream/stream-chat-swiftui/pull/717)
+- Improve voice over by adding missing labels, removing decorative images, and setting accessibility actions [#726](https://github.com/GetStream/stream-chat-swiftui/pull/726)
 ### 🔄 Changed
 - Deprecate unused `ChatMessage.userDisplayInfo(from:)` which only accessed cached data [#718](https://github.com/GetStream/stream-chat-swiftui/pull/718)
+### 🎭 New Localizations
+Add localizable keys for supporting accessibility labels:
+- `channel.list.scroll-to-bottom.title`
+- `channel.header.info.title`
+- `message.attachment.accessibility-label`
+- `message.read-status.seen-by*`
+- `message.cell.sent-at`
+- `composer.picker.show-all`
+- `composer.audio-recording.*`
 
 # [4.70.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.70.0)
 _January 15, 2025_

--- a/DemoAppSwiftUI/ChannelHeader/CustomChannelHeader.swift
+++ b/DemoAppSwiftUI/ChannelHeader/CustomChannelHeader.swift
@@ -36,12 +36,15 @@ public struct CustomChannelHeader: ToolbarContent {
                     .background(colors.tintColor)
                     .clipShape(Circle())
             }
+            .accessibilityLabel(Text("New Channel"))
         }
         ToolbarItem(placement: .navigationBarLeading) {
             Button {
                 actionsPopupShown = true
             } label: {
                 StreamLazyImage(url: currentUserController.currentUser?.imageURL)
+                    .accessibilityLabel("Account Actions")
+                    .accessibilityAddTraits(.isButton)
             }
         }
     }

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChannelHeader/ChatChannelHeaderViewModifier.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChannelHeader/ChatChannelHeaderViewModifier.swift
@@ -71,13 +71,15 @@ public struct DefaultChatChannelHeader: ToolbarContent {
                         .clipShape(Circle())
                         .offset(x: 8)
                 }
+                .accessibilityLabel(Text(L10n.Channel.Header.Info.title))
 
                 NavigationLink(isActive: $isActive) {
                     LazyView(ChatChannelInfoView(channel: channel, shownFromMessageList: true))
                 } label: {
                     EmptyView()
                 }
-
+                .accessibilityHidden(true)
+                
                 ChannelAvatarView(
                     avatar: headerImage,
                     showOnlineIndicator: onlineIndicatorShown,
@@ -85,6 +87,7 @@ public struct DefaultChatChannelHeader: ToolbarContent {
                 )
                 .offset(x: 8)
                 .allowsHitTesting(false)
+                .accessibilityHidden(true)
             }
             .accessibilityIdentifier("ChannelAvatarView")
         }

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/ChatChannelInfoView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/ChatChannelInfoView.swift
@@ -112,6 +112,9 @@ public struct ChatChannelInfoView: View, KeyboardReadable {
                         .onTapGesture {
                             viewModel.addUsersShown = false
                         }
+                        .accessibilityAction {
+                            viewModel.addUsersShown = false
+                        }
                     AddUsersView(
                         loadedUserIds: viewModel.participants.map(\.id),
                         onUserTap: viewModel.addUserTapped(_:)

--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/AttachmentPickerTypeView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/AttachmentPickerTypeView.swift
@@ -56,6 +56,7 @@ public struct AttachmentPickerTypeView: View {
                         pickerType: .media,
                         selected: attachmentPickerType
                     )
+                    .accessibilityLabel(Text(L10n.Composer.Picker.showAll))
                     .accessibilityIdentifier("PickerTypeButtonMedia")
                 }
 
@@ -65,6 +66,7 @@ public struct AttachmentPickerTypeView: View {
                         pickerType: .instantCommands,
                         selected: attachmentPickerType
                     )
+                    .accessibilityLabel(Text(L10n.Composer.Suggestions.Commands.header))
                     .accessibilityIdentifier("PickerTypeButtonCommands")
                 }
             case .collapsed:

--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/AttachmentPickerView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/AttachmentPickerView.swift
@@ -159,6 +159,7 @@ public struct AttachmentSourcePickerView: View {
                 isSelected: selected == .files,
                 onTap: onTap
             )
+            .accessibilityLabel(L10n.Composer.Picker.file)
             .accessibilityIdentifier("attachmentPickerFiles")
 
             AttachmentPickerButton(
@@ -176,6 +177,7 @@ public struct AttachmentSourcePickerView: View {
                     isSelected: selected == .polls,
                     onTap: onTap
                 )
+                .accessibilityLabel(L10n.Composer.Polls.createPoll)
                 .accessibilityIdentifier("attachmentPickerPolls")
             }
 

--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/SendMessageButton.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/SendMessageButton.swift
@@ -31,7 +31,7 @@ public struct SendMessageButton: View {
                 )
         }
         .disabled(!enabled)
-        .accessibilityAddTraits(.isButton)
+        .accessibilityLabel(Text(L10n.Composer.Placeholder.message))
         .accessibilityIdentifier("SendMessageButton")
     }
 

--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/TrailingComposerView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/TrailingComposerView.swift
@@ -85,5 +85,12 @@ public struct VoiceRecordingButton: View {
                         }
                     }
             )
+            .accessibilityRemoveTraits(.isImage)
+            .accessibilityAddTraits(.isButton)
+            .accessibilityLabel(Text(L10n.Composer.AudioRecording.start))
+            .accessibilityAction {
+                viewModel.recordingState = .recording(.zero)
+                viewModel.startRecording()
+            }
     }
 }

--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/VoiceRecording/RecordingView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/VoiceRecording/RecordingView.swift
@@ -20,6 +20,7 @@ struct RecordingView: View {
         HStack {
             Image(systemName: "mic")
                 .foregroundColor(.red)
+                .accessibilityHidden(true)
             RecordingDurationView(duration: audioRecordingInfo.duration)
             
             Spacer()
@@ -30,6 +31,7 @@ struct RecordingView: View {
             }
             .foregroundColor(Color(colors.textLowEmphasis))
             .opacity(opacityForSlideToCancel)
+            .accessibilityHidden(true)
             
             Spacer()
             
@@ -38,6 +40,7 @@ struct RecordingView: View {
             } label: {
                 Image(systemName: "mic")
             }
+            .accessibilityLabel(Text(L10n.Composer.AudioRecording.stop))
         }
         .padding(.all, 12)
         .overlay(

--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/AsyncVoiceMessages/VoiceRecordingContainerView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/AsyncVoiceMessages/VoiceRecordingContainerView.swift
@@ -215,6 +215,7 @@ struct VoiceRecordingView: View {
                     .resizable()
                     .aspectRatio(contentMode: .fit)
                     .frame(height: 40)
+                    .accessibilityHidden(true)
             }
         }
         .onReceive(handler.$context, perform: { value in

--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/BottomReactionsView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/BottomReactionsView.swift
@@ -95,6 +95,9 @@ struct BottomReactionsView: View {
                     .onLongPressGesture {
                         onLongPress()
                     }
+                    .accessibilityAction {
+                        viewModel.reactionTapped(reaction)
+                    }
                 }
             }
             

--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/FileAttachmentView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/FileAttachmentView.swift
@@ -97,6 +97,9 @@ public struct FileAttachmentView: View {
             .onTapGesture {
                 fullScreenShown = true
             }
+            .accessibilityAction {
+                fullScreenShown = true
+            }
 
             Spacer()
         }
@@ -134,6 +137,7 @@ public struct FileAttachmentDisplayView: View {
                 .resizable()
                 .aspectRatio(contentMode: .fit)
                 .frame(width: 34, height: 40)
+                .accessibilityHidden(true)
             VStack(alignment: .leading, spacing: 8) {
                 Text(title)
                     .font(fonts.bodyBold)

--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/FileAttachmentView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/FileAttachmentView.swift
@@ -137,7 +137,6 @@ public struct FileAttachmentDisplayView: View {
                 .resizable()
                 .aspectRatio(contentMode: .fit)
                 .frame(width: 34, height: 40)
-                .accessibilityHidden(true)
             VStack(alignment: .leading, spacing: 8) {
                 Text(title)
                     .font(fonts.bodyBold)

--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/FileAttachmentView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/FileAttachmentView.swift
@@ -137,6 +137,7 @@ public struct FileAttachmentDisplayView: View {
                 .resizable()
                 .aspectRatio(contentMode: .fit)
                 .frame(width: 34, height: 40)
+                .accessibilityHidden(true)
             VStack(alignment: .leading, spacing: 8) {
                 Text(title)
                     .font(fonts.bodyBold)
@@ -149,6 +150,7 @@ public struct FileAttachmentDisplayView: View {
             }
             Spacer()
         }
+        .accessibilityElement(children: .combine)
     }
 
     private var previewImage: UIImage {

--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/GiphyBadgeView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/GiphyBadgeView.swift
@@ -14,6 +14,7 @@ public struct GiphyBadgeView: View {
         BottomLeftView {
             HStack(spacing: 4) {
                 Image(uiImage: images.commandGiphy)
+                    .accessibilityHidden(true)
                 Text(L10n.Message.GiphyAttachment.title)
                     .font(fonts.bodyBold)
                     .foregroundColor(Color(colors.staticColorText))

--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/ImageAttachmentView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/ImageAttachmentView.swift
@@ -371,6 +371,11 @@ struct LazyLoadingImage: View {
                                     imageTapped(index ?? 0)
                                 }
                         )
+                        .accessibilityLabel(L10n.Message.Attachment.accessibilityLabel((index ?? 0) + 1))
+                        .accessibilityAddTraits(source.type == .video ? .startsMediaSession : .isImage)
+                        .accessibilityAction {
+                            imageTapped(index ?? 0)
+                        }
                 }
             } else if error != nil {
                 Color(.secondarySystemBackground)
@@ -383,6 +388,7 @@ struct LazyLoadingImage: View {
             
             if source.type == .video && width > 64 && source.uploadingState == nil {
                 VideoPlayIcon()
+                    .accessibilityHidden(true)
             }
         }
         .onAppear {
@@ -414,6 +420,7 @@ struct LazyLoadingImage: View {
             .allowsHitTesting(false)
             .scaleEffect(1.0001) // Needed because of SwiftUI sometimes incorrectly displaying landscape images.
             .clipped()
+            .accessibilityHidden(true)
     }
 }
 

--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageListHelperViews.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageListHelperViews.swift
@@ -124,10 +124,14 @@ public struct MessageReadIndicatorView: View {
             .customizable()
             .foregroundColor(!readUsers.isEmpty ? colors.tintColor : Color(colors.textLowEmphasis))
             .frame(height: 16)
+            .accessibilityLabel(
+                Text(
+                    readUsers.isEmpty ? L10n.Message.ReadStatus.seenByNoOne : L10n.Message.ReadStatus.seenByOthers
+                )
+            )
             .accessibilityIdentifier("readIndicatorCheckmark")
         }
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel(Text(L10n.Message.Cell.Read.count(readUsers.count)))
+        .accessibilityElement(children: .contain)
         .accessibilityIdentifier("MessageReadIndicatorView")
     }
     

--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageListHelperViews.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageListHelperViews.swift
@@ -26,7 +26,7 @@ public struct MessageAuthorAndDateView: View {
             }
             Spacer()
         }
-        .accessibilityElement(children: .contain)
+        .accessibilityElement(children: .combine)
         .accessibilityIdentifier("MessageAuthorAndDateView")
     }
 }
@@ -80,11 +80,16 @@ struct MessageDateView: View {
         return text
     }
     
+    var accessibilityLabel: String {
+        L10n.Message.Cell.sentAt(text)
+    }
+    
     var body: some View {
         Text(text)
             .font(fonts.footnote)
             .foregroundColor(Color(colors.textLowEmphasis))
             .animation(nil)
+            .accessibilityLabel(Text(accessibilityLabel))
             .accessibilityIdentifier("MessageDateView")
     }
 }
@@ -121,7 +126,8 @@ public struct MessageReadIndicatorView: View {
             .frame(height: 16)
             .accessibilityIdentifier("readIndicatorCheckmark")
         }
-        .accessibilityElement(children: .contain)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(Text(L10n.Message.Cell.Read.count(readUsers.count)))
         .accessibilityIdentifier("MessageReadIndicatorView")
     }
     
@@ -161,6 +167,7 @@ public struct MessagePinDetailsView: View {
             Image(uiImage: images.pin)
                 .customizable()
                 .frame(maxHeight: 12)
+                .accessibilityHidden(true)
             Text("\(L10n.Message.Cell.pinnedBy) \(message.pinDetails?.pinnedBy.name ?? L10n.Message.Cell.unknownPin)")
                 .font(fonts.footnote)
         }

--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageListView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageListView.swift
@@ -527,6 +527,7 @@ public struct DateIndicatorView: View {
                 .padding(.all, 8)
             Spacer()
         }
+        .accessibilityAddTraits(.isHeader)
     }
 }
 

--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageListView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageListView.swift
@@ -467,6 +467,7 @@ public struct ScrollToBottomButton: View {
                     .frame(width: buttonSize, height: buttonSize)
                     .modifier(ShadowViewModifier(cornerRadius: buttonSize / 2))
             }
+            .accessibilityLabel(Text(L10n.Channel.List.ScrollToBottom.title))
             .padding()
             .overlay(
                 unreadCount > 0 ?

--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/QuotedMessageView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/QuotedMessageView.swift
@@ -47,6 +47,9 @@ struct QuotedMessageViewContainer<Factory: ViewFactory>: View {
         .onTapGesture(perform: {
             scrolledId = quotedMessage.messageId
         })
+        .accessibilityAction {
+            scrolledId = quotedMessage.messageId
+        }
         .accessibilityIdentifier("QuotedMessageViewContainer")
     }
 }

--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/VideoAttachmentView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/VideoAttachmentView.swift
@@ -155,6 +155,7 @@ struct VideoAttachmentContentView: View {
                     .scaledToFill()
                     .clipped()
                     .allowsHitTesting(false)
+                    .accessibilityHidden(true)
 
                 if width > 64 && attachment.uploadingState == nil {
                     VStack {
@@ -164,6 +165,9 @@ struct VideoAttachmentContentView: View {
                     .contentShape(Rectangle())
                     .clipped()
                     .onTapGesture {
+                        fullScreenShown = true
+                    }
+                    .accessibilityAction {
                         fullScreenShown = true
                     }
                 }

--- a/Sources/StreamChatSwiftUI/ChatChannel/Reactions/ReactionsView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Reactions/ReactionsView.swift
@@ -28,6 +28,9 @@ struct ReactionsContainer: View {
                 .onLongPressGesture {
                     onLongPressGesture()
                 }
+                .accessibilityAction {
+                    onTapGesture()
+                }
             }
 
             Spacer()

--- a/Sources/StreamChatSwiftUI/ChatChannelList/MoreChannelActionsView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannelList/MoreChannelActionsView.swift
@@ -164,12 +164,14 @@ public struct ChannelMemberView: View {
                 showOnlineIndicator: onlineIndicatorShown,
                 size: memberSize
             )
+            .accessibilityHidden(true)
 
             Text(name)
                 .font(fonts.footnoteBold)
                 .multilineTextAlignment(.center)
                 .lineLimit(2)
                 .frame(maxWidth: memberSize.width, maxHeight: 34, alignment: .top)
+                .accessibilityLabel(Text(name) + Text(onlineIndicatorShown ? ", \(L10n.Message.Title.online)" : ""))
         }
     }
 }

--- a/Sources/StreamChatSwiftUI/Generated/L10n.swift
+++ b/Sources/StreamChatSwiftUI/Generated/L10n.swift
@@ -76,6 +76,12 @@ internal enum L10n {
   }
 
   internal enum Channel {
+    internal enum Header {
+      internal enum Info {
+        /// Channel info
+        internal static var title: String { L10n.tr("Localizable", "channel.header.info.title") }
+      }
+    }
     internal enum Item {
       /// Audio
       internal static var audio: String { L10n.tr("Localizable", "channel.item.audio") }
@@ -111,6 +117,12 @@ internal enum L10n {
       internal static var video: String { L10n.tr("Localizable", "channel.item.video") }
       /// Voice Message
       internal static var voiceMessage: String { L10n.tr("Localizable", "channel.item.voice-message") }
+    }
+    internal enum List {
+      internal enum ScrollToBottom {
+        /// Scroll to bottom
+        internal static var title: String { L10n.tr("Localizable", "channel.list.scroll-to-bottom.title") }
+      }
     }
     internal enum Name {
       /// and
@@ -391,8 +403,18 @@ internal enum L10n {
       internal static var edited: String { L10n.tr("Localizable", "message.cell.edited") }
       /// Pinned by
       internal static var pinnedBy: String { L10n.tr("Localizable", "message.cell.pinnedBy") }
+      /// Sent at %@
+      internal static func sentAt(_ p1: Any) -> String {
+        return L10n.tr("Localizable", "message.cell.sent-at", String(describing: p1))
+      }
       /// unknown
       internal static var unknownPin: String { L10n.tr("Localizable", "message.cell.unknownPin") }
+      internal enum Read {
+        /// Plural format key: "%#@seen@"
+        internal static func count(_ p1: Int) -> String {
+          return L10n.tr("Localizable", "message.cell.read.count", p1)
+        }
+      }
     }
     internal enum FileAttachment {
       /// Error occured while previewing the file.

--- a/Sources/StreamChatSwiftUI/Generated/L10n.swift
+++ b/Sources/StreamChatSwiftUI/Generated/L10n.swift
@@ -194,6 +194,12 @@ internal enum L10n {
   }
 
   internal enum Composer {
+    internal enum AudioRecording {
+      /// Start recording audio message
+      internal static var start: String { L10n.tr("Localizable", "composer.audio-recording.start") }
+      /// Stop recording audio message
+      internal static var stop: String { L10n.tr("Localizable", "composer.audio-recording.stop") }
+    }
     internal enum Checkmark {
       /// Also send in channel
       internal static var channelReply: String { L10n.tr("Localizable", "composer.checkmark.channel-reply") }
@@ -231,6 +237,8 @@ internal enum L10n {
       internal static var file: String { L10n.tr("Localizable", "composer.picker.file") }
       /// Photo or Video
       internal static var media: String { L10n.tr("Localizable", "composer.picker.media") }
+      /// Attachment pickers
+      internal static var showAll: String { L10n.tr("Localizable", "composer.picker.show-all") }
       /// Choose attachment type: 
       internal static var title: String { L10n.tr("Localizable", "composer.picker.title") }
     }
@@ -394,6 +402,12 @@ internal enum L10n {
         internal static var confirmationMessage: String { L10n.tr("Localizable", "message.actions.user-unblock.confirmation-message") }
       }
     }
+    internal enum Attachment {
+      /// Attachment %d
+      internal static func accessibilityLabel(_ p1: Int) -> String {
+        return L10n.tr("Localizable", "message.attachment.accessibility-label", p1)
+      }
+    }
     internal enum Bounce {
       /// Message was bounced
       internal static var title: String { L10n.tr("Localizable", "message.bounce.title") }
@@ -409,12 +423,6 @@ internal enum L10n {
       }
       /// unknown
       internal static var unknownPin: String { L10n.tr("Localizable", "message.cell.unknownPin") }
-      internal enum Read {
-        /// Plural format key: "%#@seen@"
-        internal static func count(_ p1: Int) -> String {
-          return L10n.tr("Localizable", "message.cell.read.count", p1)
-        }
-      }
     }
     internal enum FileAttachment {
       /// Error occured while previewing the file.
@@ -481,6 +489,12 @@ internal enum L10n {
     internal enum Reactions {
       /// You
       internal static var currentUser: String { L10n.tr("Localizable", "message.reactions.currentUser") }
+    }
+    internal enum ReadStatus {
+      /// Seen by no one
+      internal static var seenByNoOne: String { L10n.tr("Localizable", "message.read-status.seen-by-no-one") }
+      /// Seen by others
+      internal static var seenByOthers: String { L10n.tr("Localizable", "message.read-status.seen-by-others") }
     }
     internal enum Search {
       /// Cancel

--- a/Sources/StreamChatSwiftUI/Resources/en.lproj/Localizable.strings
+++ b/Sources/StreamChatSwiftUI/Resources/en.lproj/Localizable.strings
@@ -18,9 +18,13 @@
 "channel.name.direct-message" = "user";
 "channel.name.group" = "group";
 
+"channel.list.scroll-to-bottom.title" = "Scroll to bottom";
+
 "channel.no-content.title" = "Let's start chatting";
 "channel.no-content.message" = "How about sending your first message to a friend?";
 "channel.no-content.start" = "Start a chat";
+
+"channel.header.info.title" = "Channel info";
 
 "message.actions.inline-reply" = "Reply";
 "message.actions.thread-reply" = "Thread Reply";
@@ -54,6 +58,7 @@
 "message.cell.pinnedBy" = "Pinned by";
 "message.cell.unknownPin" = "unknown";
 "message.cell.edited" = "Edited";
+"message.cell.sent-at" = "Sent at %@";
 "message.reactions.currentUser" = "You";
 
 "message.polls.button.addComment" = "Add a Comment";

--- a/Sources/StreamChatSwiftUI/Resources/en.lproj/Localizable.strings
+++ b/Sources/StreamChatSwiftUI/Resources/en.lproj/Localizable.strings
@@ -26,6 +26,10 @@
 
 "channel.header.info.title" = "Channel info";
 
+"message.attachment.accessibility-label" = "Attachment %d";
+"message.read-status.seen-by-others" = "Seen by others";
+"message.read-status.seen-by-no-one" = "Seen by no one";
+
 "message.actions.inline-reply" = "Reply";
 "message.actions.thread-reply" = "Thread Reply";
 "message.actions.edit" = "Edit Message";
@@ -114,6 +118,7 @@
 "composer.picker.file" = "File";
 "composer.picker.media" = "Photo or Video";
 "composer.picker.cancel" = "Cancel";
+"composer.picker.show-all" = "Attachment pickers";
 "composer.files.add-more" = "Add more files";
 "composer.images.no-access-library" = "You have not granted access to the photo library.";
 "composer.images.access-settings" = "Change in Settings";
@@ -133,6 +138,8 @@
 "composer.polls.multiple-answers" = "Multiple answers";
 "composer.polls.suggest-option" = "Suggest an option";
 "composer.polls.type-number-from-1-and-10" = "Type a number from 1 and 10";
+"composer.audio-recording.start" = "Start recording audio message";
+"composer.audio-recording.stop" = "Stop recording audio message";
 
 "composer.commands.giphy" = "Giphy";
 "composer.commands.mute" = "Mute";

--- a/Sources/StreamChatSwiftUI/Resources/en.lproj/Localizable.stringsdict
+++ b/Sources/StreamChatSwiftUI/Resources/en.lproj/Localizable.stringsdict
@@ -144,5 +144,23 @@
 			<string>%d Thread Replies</string>
 		</dict>
 	</dict>
+	<key>message.cell.read.count</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@seen@</string>
+		<key>seen</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>Seen by no-one</string>
+			<key>one</key>
+			<string>Seen by %d</string>
+			<key>other</key>
+			<string>Seen by %d</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/Sources/StreamChatSwiftUI/Resources/en.lproj/Localizable.stringsdict
+++ b/Sources/StreamChatSwiftUI/Resources/en.lproj/Localizable.stringsdict
@@ -144,23 +144,5 @@
 			<string>%d Thread Replies</string>
 		</dict>
 	</dict>
-	<key>message.cell.read.count</key>
-	<dict>
-		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@seen@</string>
-		<key>seen</key>
-		<dict>
-			<key>NSStringFormatSpecTypeKey</key>
-			<string>NSStringPluralRuleType</string>
-			<key>NSStringFormatValueTypeKey</key>
-			<string>d</string>
-			<key>zero</key>
-			<string>Seen by no-one</string>
-			<key>one</key>
-			<string>Seen by %d</string>
-			<key>other</key>
-			<string>Seen by %d</string>
-		</dict>
-	</dict>
 </dict>
 </plist>

--- a/StreamChatSwiftUITests/Infrastructure/TestTools/ChatClient_Mock.swift
+++ b/StreamChatSwiftUITests/Infrastructure/TestTools/ChatClient_Mock.swift
@@ -34,8 +34,12 @@ public extension ChatClient {
                 databaseContainerBuilder: {
                     DatabaseContainer_Spy(
                         kind: $0,
+                        shouldFlushOnStart: $1,
+                        shouldResetEphemeralValuesOnStart: $2,
                         bundle: Bundle(for: StreamChatTestCase.self),
-                        chatClientConfig: $1
+                        localCachingSettings: $3,
+                        deletedMessagesVisibility: $4,
+                        shouldShowShadowedMessages: $5
                     )
                 },
                 authenticationRepositoryBuilder: AuthenticationRepository_Mock.init

--- a/StreamChatSwiftUITests/Infrastructure/TestTools/ChatClient_Mock.swift
+++ b/StreamChatSwiftUITests/Infrastructure/TestTools/ChatClient_Mock.swift
@@ -34,12 +34,8 @@ public extension ChatClient {
                 databaseContainerBuilder: {
                     DatabaseContainer_Spy(
                         kind: $0,
-                        shouldFlushOnStart: $1,
-                        shouldResetEphemeralValuesOnStart: $2,
                         bundle: Bundle(for: StreamChatTestCase.self),
-                        localCachingSettings: $3,
-                        deletedMessagesVisibility: $4,
-                        shouldShowShadowedMessages: $5
+                        chatClientConfig: $1
                     )
                 },
                 authenticationRepositoryBuilder: AuthenticationRepository_Mock.init

--- a/StreamChatSwiftUITestsAppTests/Pages/MessageListPage.swift
+++ b/StreamChatSwiftUITestsAppTests/Pages/MessageListPage.swift
@@ -227,7 +227,7 @@ class MessageListPage {
         }
 
         static func files(in messageCell: XCUIElement) -> XCUIElementQuery {
-            messageCell.images.matching(NSPredicate(format: "identifier LIKE 'FileAttachmentsContainer'"))
+            messageCell.buttons.matching(NSPredicate(format: "identifier LIKE 'FileAttachmentsContainer'"))
         }
 
         static func videoPlayer() -> XCUIElement {


### PR DESCRIPTION
### 🔗 Issue Link

Resolves [IOS-641](https://linear.app/stream/issue/IOS-641)

### 🎯 Goal

Improve voice over by hiding decorative images, adding missing labels, and accessibility actions

### 🛠 Implementation

Reviewed common views with a focus on decorative images, confusing or missing labels, and adding accessibility actions for cases we have used tap gestures only. This PR just focused on before mentioned areas for making the basic usage better.

### 🧪 Testing

-

### 🎨 Changes

_Add relevant screenshots or videos showcasing the changes._

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
