### PR TITLE
Fix MessageDisplayInfo properties being overwritten

### DIFF
--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageListView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageListView.swift
@@ -369,6 +369,8 @@ public struct MessageListView<Factory: ViewFactory>: View, KeyboardReadable {
                 frame: updatedFrame,
                 contentWidth: messageDisplayInfo.contentWidth,
                 isFirst: messageDisplayInfo.isFirst,
+                showsMessageActions: messageDisplayInfo.showsMessageActions,
+                showsBottomContainer: messageDisplayInfo.showsBottomContainer,
                 keyboardWasShown: true
             )
 


### PR DESCRIPTION
### 🔗 Issue Link

No open GitHub issue.

### 🎯 Goal

Fix an issue where `showsMessageActions` and `showsBottomContainer` are unintentionally reset to their default values when the `handleLongPress` is called. This causes incorrect UI behavior when displaying the reactions overlay.

### 🛠 Implementation

Updated `handleLongPress(messageDisplayInfo:)` to make sure that `showsMessageActions` and `showsBottomContainer` values are preserved when creating a new MessageDisplayInfo instance.

### 🧪 Testing

1. Configure MessageDisplayInfo with `showsMessageActions` and `showsBottomContainer` set to false
2. Open the chat screen and pull up the keyboard
3. Long-press on a message
4. Observe that `showsMessageActions` and `showsBottomContainer` revert to their default values (true)

### 🎨 Changes

No visual changes but this fixes a bug affecting the overlay behavior when reacting to messages.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
