### PR TITLE
Only show "Pin/Unpin message" Action if user has permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🐞 Fixed
 - Fix visibility of tabbar when reactions are shown [#750](https://github.com/GetStream/stream-chat-swiftui/pull/750)
+### 🔄 Changed
+- Only show "Pin/Unpin message" Action if user has permission [#749](https://github.com/GetStream/stream-chat-swiftui/pull/749)
 
 # [4.72.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.72.0)
 _February 04, 2025_

--- a/Sources/StreamChatSwiftUI/ChatChannel/Reactions/MessageActions/DefaultMessageActions.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Reactions/MessageActions/DefaultMessageActions.swift
@@ -88,26 +88,28 @@ public extension MessageAction {
             messageActions.append(replyThread)
         }
 
-        if message.pinDetails != nil {
-            let unpinAction = unpinMessageAction(
-                for: message,
-                channel: channel,
-                chatClient: chatClient,
-                onFinish: onFinish,
-                onError: onError
-            )
-
-            messageActions.append(unpinAction)
-        } else {
-            let pinAction = pinMessageAction(
-                for: message,
-                channel: channel,
-                chatClient: chatClient,
-                onFinish: onFinish,
-                onError: onError
-            )
-
-            messageActions.append(pinAction)
+        if channel.canPinMessage {
+            if message.pinDetails != nil {
+                let unpinAction = unpinMessageAction(
+                    for: message,
+                    channel: channel,
+                    chatClient: chatClient,
+                    onFinish: onFinish,
+                    onError: onError
+                )
+                
+                messageActions.append(unpinAction)
+            } else {
+                let pinAction = pinMessageAction(
+                    for: message,
+                    channel: channel,
+                    chatClient: chatClient,
+                    onFinish: onFinish,
+                    onError: onError
+                )
+                
+                messageActions.append(pinAction)
+            }
         }
 
         if !message.text.isEmpty {


### PR DESCRIPTION
### 🔗 Issue Link
N/A

### 🎯 Goal

When long tap on a message to show actions view, user shouldn't see Pin/Unpin message action if they don't have permission.

### 🛠 Implementation

Check capability before adding Pin/Unpin Message action

### 🧪 Testing

Change user permissions and verify that the action can or cannot be seen

### 🎨 Changes

<img width="334" alt="Screenshot 2025-02-11 at 08 43 18" src="https://github.com/user-attachments/assets/cc6c1f71-ddf5-44fb-a4ba-d5d63bb2954e" />

### ☑️ Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [X] Affected documentation updated (docusaurus, tutorial, CMS (task created)
