### PR TITLE
Fixed visibility of tabbar when reactions are shown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### 🐞 Fixed
+- Fixed visibility of tabbar when reactions are shown [#750](https://github.com/GetStream/stream-chat-swiftui/pull/750)
 
 # [4.72.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.72.0)
 _February 04, 2025_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # Upcoming
 
 ### 🐞 Fixed
-- Fixed visibility of tabbar when reactions are shown [#750](https://github.com/GetStream/stream-chat-swiftui/pull/750)
+- Fix visibility of tabbar when reactions are shown [#750](https://github.com/GetStream/stream-chat-swiftui/pull/750)
 
 # [4.72.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.72.0)
 _February 04, 2025_

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelView.swift
@@ -89,10 +89,10 @@ public struct ChatChannelView<Factory: ViewFactory>: View, KeyboardReadable {
                     Divider()
                         .navigationBarBackButtonHidden(viewModel.reactionsShown)
                         .if(viewModel.reactionsShown, transform: { view in
-                            view.navigationBarHidden(true)
+                            view.changeBarsVisibility(shouldShow: false)
                         })
                         .if(!viewModel.reactionsShown, transform: { view in
-                            view.navigationBarHidden(false)
+                            view.changeBarsVisibility(shouldShow: true)
                         })
                         .if(viewModel.channelHeaderType == .regular) { view in
                             view.modifier(factory.makeChannelHeaderViewModifier(for: channel))

--- a/Sources/StreamChatSwiftUI/Utils/Modifiers.swift
+++ b/Sources/StreamChatSwiftUI/Utils/Modifiers.swift
@@ -94,7 +94,6 @@ struct ChangeBarsVisibilityModifier: ViewModifier {
             content
                 .navigationBarHidden(!shouldShow)
         }
-
     }
 }
 

--- a/Sources/StreamChatSwiftUI/Utils/Modifiers.swift
+++ b/Sources/StreamChatSwiftUI/Utils/Modifiers.swift
@@ -79,6 +79,25 @@ struct IconOverImageModifier: ViewModifier {
     }
 }
 
+struct ChangeBarsVisibilityModifier: ViewModifier {
+    
+    @Injected(\.utils) private var utils
+    
+    var shouldShow: Bool
+    
+    func body(content: Content) -> some View {
+        if #available(iOS 16, *), !utils.messageListConfig.handleTabBarVisibility {
+            content
+                .navigationBarHidden(!shouldShow)
+                .toolbar(shouldShow ? .visible : .hidden, for: .tabBar)
+        } else {
+            content
+                .navigationBarHidden(!shouldShow)
+        }
+
+    }
+}
+
 extension View {
     /// View extension that applies default padding to elements.
     public func standardPadding() -> some View {
@@ -91,6 +110,10 @@ extension View {
 
     public func applyDefaultIconOverlayStyle() -> some View {
         modifier(IconOverImageModifier())
+    }
+    
+    public func changeBarsVisibility(shouldShow: Bool) -> some View {
+        modifier(ChangeBarsVisibilityModifier(shouldShow: shouldShow))
     }
 }
 


### PR DESCRIPTION
### 🔗 Issue Link
Resolves https://github.com/GetStream/stream-chat-swiftui/issues/748.

### 🎯 Goal

When a tab bar is shown in a channel view, and the reactions popup is shown, the tab bar covers the popup.

### 🛠 Implementation

Using the toolbar API to hide the tab bar in this case.

### 🧪 Testing

_Describe the steps how this change can be tested (or why it can't be tested)._

### 🎨 Changes

_Add relevant screenshots or videos showcasing the changes._

### ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
