### PR TITLE
Add support for bounced message alert actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Only show "Pin/Unpin message" Action if user has permission [#749](https://github.com/GetStream/stream-chat-swiftui/pull/749)
 - Filter deactivated users in channel info view [#758](https://github.com/GetStream/stream-chat-swiftui/pull/758)
 ### 🎭 New Localizations
-Add localizable keys for supporting accessibility labels:
+Add localizable keys for supporting moderation alerts:
 - `message.moderation.alert.title`
 - `message.moderation.alert.message`
 - `message.moderation.alert.resend`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🔄 Changed
 - Only show "Pin/Unpin message" Action if user has permission [#749](https://github.com/GetStream/stream-chat-swiftui/pull/749)
 - Filter deactivated users in channel info view [#758](https://github.com/GetStream/stream-chat-swiftui/pull/758)
+### 🎭 New Localizations
+Add localizable keys for supporting accessibility labels:
+- `message.moderation.alert.title`
+- `message.moderation.alert.message`
+- `message.moderation.alert.resend`
+- `message.moderation.alert.edit`
+- `message.moderation.alert.delete`
+- `message.moderation.alert.cancel`
 
 # [4.72.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.72.0)
 _February 04, 2025_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+### ✅ Added
+- Add `Utils.MessageListConfig.bouncedMessagesAlertActionsEnabled` to support bounced actions alert [#764](https://github.com/GetStream/stream-chat-swiftui/pull/764)
+- Add `ViewFactory.makeBouncedMessageActionsModifier()` to customize the new bounced actions alert [#764](https://github.com/GetStream/stream-chat-swiftui/pull/764)
 ### 🐞 Fixed
 - Fix visibility of tabbar when reactions are shown [#750](https://github.com/GetStream/stream-chat-swiftui/pull/750)
 - Show all members in direct message channel info view [#760](https://github.com/GetStream/stream-chat-swiftui/pull/760)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🔄 Changed
 - Only show "Pin/Unpin message" Action if user has permission [#749](https://github.com/GetStream/stream-chat-swiftui/pull/749)
 - Filter deactivated users in channel info view [#758](https://github.com/GetStream/stream-chat-swiftui/pull/758)
+- If the `bouncedMessagesAlertActionsEnabled` is not changed to false, the bounced actions will now be shown as an alert instead of context menu [#764](https://github.com/GetStream/stream-chat-swiftui/pull/764)
 ### 🎭 New Localizations
 Add localizable keys for supporting moderation alerts:
 - `message.moderation.alert.title`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🔄 Changed
 - Only show "Pin/Unpin message" Action if user has permission [#749](https://github.com/GetStream/stream-chat-swiftui/pull/749)
 - Filter deactivated users in channel info view [#758](https://github.com/GetStream/stream-chat-swiftui/pull/758)
-- If the `bouncedMessagesAlertActionsEnabled` is not changed to false, the bounced actions will now be shown as an alert instead of context menu [#764](https://github.com/GetStream/stream-chat-swiftui/pull/764)
+- Bounced message actions will now be shown as an alert instead of a context menu by default [#764](https://github.com/GetStream/stream-chat-swiftui/pull/764)
 ### 🎭 New Localizations
 Add localizable keys for supporting moderation alerts:
 - `message.moderation.alert.title`

--- a/DemoAppSwiftUI/AppDelegate.swift
+++ b/DemoAppSwiftUI/AppDelegate.swift
@@ -66,6 +66,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
             messageListConfig: MessageListConfig(
                 dateIndicatorPlacement: .messageList,
                 userBlockingEnabled: true,
+                bouncedMessagesAlertActionsEnabled: true,
                 skipEditedMessageLabel: { message in
                     message.extraData["ai_generated"]?.boolValue == true
                 }

--- a/Sources/StreamChatSwiftUI/ChatChannel/BouncedMessageActionsModifier.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/BouncedMessageActionsModifier.swift
@@ -1,0 +1,83 @@
+//
+// Copyright © 2025 Stream.io Inc. All rights reserved.
+//
+
+import StreamChat
+import SwiftUI
+
+/// The modifier that shows the actions for a bounced message.
+public struct BouncedMessageActionsModifier: ViewModifier {
+    @ObservedObject private var viewModel: ChatChannelViewModel
+
+    public init(
+        viewModel: ChatChannelViewModel
+    ) {
+        self.viewModel = viewModel
+    }
+
+    public func body(content: Content) -> some View {
+        if #available(iOS 15.0, *) {
+            content
+                .alert(
+                    L10n.Message.Moderation.Alert.title,
+                    isPresented: $viewModel.bouncedActionsViewShown
+                ) {
+                    Button(L10n.Message.Moderation.Alert.resend) {
+                        resendBouncedMessage()
+                    }
+                    Button(L10n.Message.Moderation.Alert.edit) {
+                        editBouncedMessage()
+                    }
+                    Button(L10n.Message.Moderation.Alert.delete, role: .destructive) {
+                        deleteBouncedMessage()
+                    }
+                    Button(L10n.Message.Moderation.Alert.cancel, role: .cancel, action: {
+                        viewModel.bouncedActionsViewShown = false
+                    })
+                } message: {
+                    Text(L10n.Message.Moderation.Alert.message)
+                }
+        } else {
+            content
+                .actionSheet(isPresented: $viewModel.bouncedActionsViewShown) {
+                    ActionSheet(
+                        title: Text(L10n.Message.Moderation.Alert.title),
+                        message: Text(L10n.Message.Moderation.Alert.message),
+                        buttons: [
+                            .default(Text(L10n.Message.Moderation.Alert.resend)) {
+                                resendBouncedMessage()
+                            },
+                            .default(Text(L10n.Message.Moderation.Alert.edit)) {
+                                editBouncedMessage()
+                            },
+                            .destructive(Text(L10n.Message.Moderation.Alert.delete)) {
+                                deleteBouncedMessage()
+                            },
+                            .cancel(Text(L10n.Message.Moderation.Alert.cancel))
+                        ]
+                    )
+                }
+        }
+    }
+
+    private func editBouncedMessage() {
+        guard let bouncedMessage = viewModel.bouncedMessage else {
+            return
+        }
+        viewModel.editMessage(bouncedMessage)
+    }
+
+    private func resendBouncedMessage() {
+        guard let bouncedMessage = viewModel.bouncedMessage else {
+            return
+        }
+        viewModel.resendMessage(bouncedMessage)
+    }
+
+    private func deleteBouncedMessage() {
+        guard let bouncedMessage = viewModel.bouncedMessage else {
+            return
+        }
+        viewModel.deleteMessage(bouncedMessage)
+    }
+}

--- a/Sources/StreamChatSwiftUI/ChatChannel/BouncedMessageActionsModifier.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/BouncedMessageActionsModifier.swift
@@ -6,6 +6,8 @@ import StreamChat
 import SwiftUI
 
 /// The modifier that shows the actions for a bounced message.
+///
+/// This modifier is only used if `Utils.messageListConfig.bouncedMessagesAlertActionsEnabled` is `true`.
 public struct BouncedMessageActionsModifier: ViewModifier {
     @ObservedObject private var viewModel: ChatChannelViewModel
 

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelView.swift
@@ -61,9 +61,14 @@ public struct ChatChannelView<Factory: ViewFactory>: View, KeyboardReadable {
                             onMessageAppear: viewModel.handleMessageAppear(index:scrollDirection:),
                             onScrollToBottom: viewModel.scrollToLastMessage,
                             onLongPress: { displayInfo in
-                                messageDisplayInfo = displayInfo
-                                withAnimation {
-                                    viewModel.showReactionOverlay(for: AnyView(self))
+                                let isBouncedAlertEnabled = utils.messageListConfig.bouncedMessagesAlertActionsEnabled
+                                if isBouncedAlertEnabled && displayInfo.message.isBounced {
+                                    viewModel.showBouncedActionsView(for: displayInfo.message)
+                                } else {
+                                    messageDisplayInfo = displayInfo
+                                    withAnimation {
+                                        viewModel.showReactionOverlay(for: AnyView(self))
+                                    }
                                 }
                             },
                             onJumpToMessage: viewModel.jumpToMessage(messageId:)
@@ -196,6 +201,9 @@ public struct ChatChannelView<Factory: ViewFactory>: View, KeyboardReadable {
         .alertBanner(isPresented: $viewModel.showAlertBanner)
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("ChatChannelView")
+        .if(utils.messageListConfig.bouncedMessagesAlertActionsEnabled) {
+            $0.modifier(factory.makeBouncedMessageActionsModifier(viewModel: viewModel))
+        }
     }
 
     private var generatingSnapshot: Bool {

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelView.swift
@@ -201,9 +201,7 @@ public struct ChatChannelView<Factory: ViewFactory>: View, KeyboardReadable {
         .alertBanner(isPresented: $viewModel.showAlertBanner)
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("ChatChannelView")
-        .if(utils.messageListConfig.bouncedMessagesAlertActionsEnabled) {
-            $0.modifier(factory.makeBouncedMessageActionsModifier(viewModel: viewModel))
-        }
+        .modifier(factory.makeBouncedMessageActionsModifier(viewModel: viewModel))
     }
 
     private var generatingSnapshot: Bool {

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelViewModel.swift
@@ -89,6 +89,15 @@ open class ChatChannelViewModel: ObservableObject, MessagesDataSource {
         }
     }
 
+    public private(set) var bouncedMessage: ChatMessage?
+    @Published public var bouncedActionsViewShown = false {
+        didSet {
+            if bouncedActionsViewShown == false {
+                bouncedMessage = nil
+            }
+        }
+    }
+
     @Published public var quotedMessage: ChatMessage? {
         didSet {
             if oldValue != nil && quotedMessage == nil {
@@ -451,7 +460,28 @@ open class ChatChannelViewModel: ObservableObject, MessagesDataSource {
     public func showReactionOverlay(for view: AnyView) {
         currentSnapshot = utils.snapshotCreator.makeSnapshot(for: view)
     }
-    
+
+    public func showBouncedActionsView(for message: ChatMessage) {
+        bouncedActionsViewShown = true
+        bouncedMessage = message
+    }
+
+    public func deleteMessage(_ message: ChatMessage) {
+        guard let cid = message.cid else { return }
+        let messageController = chatClient.messageController(cid: cid, messageId: message.id)
+        messageController.deleteMessage()
+    }
+
+    public func resendMessage(_ message: ChatMessage) {
+        guard let cid = message.cid else { return }
+        let messageController = chatClient.messageController(cid: cid, messageId: message.id)
+        messageController.resendMessage()
+    }
+
+    public func editMessage(_ message: ChatMessage) {
+        messageActionExecuted(.init(message: message, identifier: "edit"))
+    }
+
     public func messageActionExecuted(_ messageActionInfo: MessageActionInfo) {
         utils.messageActionsResolver.resolveMessageAction(
             info: messageActionInfo,

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelViewModel.swift
@@ -89,7 +89,7 @@ open class ChatChannelViewModel: ObservableObject, MessagesDataSource {
         }
     }
 
-    public private(set) var bouncedMessage: ChatMessage?
+    @Published public var bouncedMessage: ChatMessage?
     @Published public var bouncedActionsViewShown = false {
         didSet {
             if bouncedActionsViewShown == false {

--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageListConfig.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageListConfig.swift
@@ -32,6 +32,7 @@ public struct MessageListConfig {
         isMessageEditedLabelEnabled: Bool = true,
         markdownSupportEnabled: Bool = true,
         userBlockingEnabled: Bool = false,
+        bouncedMessagesAlertActionsEnabled: Bool = false,
         skipEditedMessageLabel: @escaping (ChatMessage) -> Bool = { _ in false }
     ) {
         self.messageListType = messageListType
@@ -57,6 +58,7 @@ public struct MessageListConfig {
         self.isMessageEditedLabelEnabled = isMessageEditedLabelEnabled
         self.markdownSupportEnabled = markdownSupportEnabled
         self.userBlockingEnabled = userBlockingEnabled
+        self.bouncedMessagesAlertActionsEnabled = bouncedMessagesAlertActionsEnabled
         self.skipEditedMessageLabel = skipEditedMessageLabel
     }
 
@@ -83,6 +85,12 @@ public struct MessageListConfig {
     public let isMessageEditedLabelEnabled: Bool
     public let markdownSupportEnabled: Bool
     public let userBlockingEnabled: Bool
+
+    /// A boolean to enable the alert actions for bounced messages.
+    ///
+    /// By default it is false and the bounced actions are displayed in the message context menu.
+    public let bouncedMessagesAlertActionsEnabled: Bool
+
     public let skipEditedMessageLabel: (ChatMessage) -> Bool
 }
 
@@ -111,7 +119,6 @@ public enum DateIndicatorPlacement {
 
 /// Used to show and hide different helper views around the message.
 public struct MessageDisplayOptions {
-
     public let showAvatars: Bool
     public let showAvatarsInGroups: Bool
     public let showMessageDate: Bool

--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageListConfig.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageListConfig.swift
@@ -32,7 +32,7 @@ public struct MessageListConfig {
         isMessageEditedLabelEnabled: Bool = true,
         markdownSupportEnabled: Bool = true,
         userBlockingEnabled: Bool = false,
-        bouncedMessagesAlertActionsEnabled: Bool = false,
+        bouncedMessagesAlertActionsEnabled: Bool = true,
         skipEditedMessageLabel: @escaping (ChatMessage) -> Bool = { _ in false }
     ) {
         self.messageListType = messageListType
@@ -88,7 +88,7 @@ public struct MessageListConfig {
 
     /// A boolean to enable the alert actions for bounced messages.
     ///
-    /// By default it is false and the bounced actions are displayed in the message context menu.
+    /// By default it is true and the bounced actions are displayed as an alert instead of a context menu.
     public let bouncedMessagesAlertActionsEnabled: Bool
 
     public let skipEditedMessageLabel: (ChatMessage) -> Bool

--- a/Sources/StreamChatSwiftUI/DefaultViewFactory.swift
+++ b/Sources/StreamChatSwiftUI/DefaultViewFactory.swift
@@ -270,7 +270,11 @@ extension ViewFactory {
             forceLeftToRight: messageModifierInfo.forceLeftToRight
         )
     }
-    
+
+    public func makeBouncedMessageActionsModifier(viewModel: ChatChannelViewModel) -> some ViewModifier {
+        BouncedMessageActionsModifier(viewModel: viewModel)
+    }
+
     public func makeEmptyMessagesView(
         for channel: ChatChannel,
         colors: ColorPalette

--- a/Sources/StreamChatSwiftUI/Generated/L10n.swift
+++ b/Sources/StreamChatSwiftUI/Generated/L10n.swift
@@ -437,18 +437,20 @@ internal enum L10n {
       internal static var title: String { L10n.tr("Localizable", "message.giphy-attachment.title") }
     }
     internal enum Moderation {
-      /// Cancel
-      internal static var cancel: String { L10n.tr("Localizable", "message.moderation.cancel") }
-      /// Delete Message
-      internal static var delete: String { L10n.tr("Localizable", "message.moderation.delete") }
-      /// Edit Message
-      internal static var edit: String { L10n.tr("Localizable", "message.moderation.edit") }
-      /// Consider how your comment might make others feel and be sure to follow our Community Guidelines.
-      internal static var message: String { L10n.tr("Localizable", "message.moderation.message") }
-      /// Send Anyway
-      internal static var resend: String { L10n.tr("Localizable", "message.moderation.resend") }
-      /// Are you sure?
-      internal static var title: String { L10n.tr("Localizable", "message.moderation.title") }
+      internal enum Alert {
+        /// Cancel
+        internal static var cancel: String { L10n.tr("Localizable", "message.moderation.alert.cancel") }
+        /// Delete Message
+        internal static var delete: String { L10n.tr("Localizable", "message.moderation.alert.delete") }
+        /// Edit Message
+        internal static var edit: String { L10n.tr("Localizable", "message.moderation.alert.edit") }
+        /// Consider how your comment might make others feel and be sure to follow our Community Guidelines.
+        internal static var message: String { L10n.tr("Localizable", "message.moderation.alert.message") }
+        /// Send Anyway
+        internal static var resend: String { L10n.tr("Localizable", "message.moderation.alert.resend") }
+        /// Are you sure?
+        internal static var title: String { L10n.tr("Localizable", "message.moderation.alert.title") }
+      }
     }
     internal enum Polls {
       /// Anonymous

--- a/Sources/StreamChatSwiftUI/Generated/L10n.swift
+++ b/Sources/StreamChatSwiftUI/Generated/L10n.swift
@@ -436,6 +436,20 @@ internal enum L10n {
       /// GIPHY
       internal static var title: String { L10n.tr("Localizable", "message.giphy-attachment.title") }
     }
+    internal enum Moderation {
+      /// Cancel
+      internal static var cancel: String { L10n.tr("Localizable", "message.moderation.cancel") }
+      /// Delete Message
+      internal static var delete: String { L10n.tr("Localizable", "message.moderation.delete") }
+      /// Edit Message
+      internal static var edit: String { L10n.tr("Localizable", "message.moderation.edit") }
+      /// Consider how your comment might make others feel and be sure to follow our Community Guidelines.
+      internal static var message: String { L10n.tr("Localizable", "message.moderation.message") }
+      /// Send Anyway
+      internal static var resend: String { L10n.tr("Localizable", "message.moderation.resend") }
+      /// Are you sure?
+      internal static var title: String { L10n.tr("Localizable", "message.moderation.title") }
+    }
     internal enum Polls {
       /// Anonymous
       internal static var unknownVoteAuthor: String { L10n.tr("Localizable", "message.polls.unknown-vote-author") }

--- a/Sources/StreamChatSwiftUI/Resources/en.lproj/Localizable.strings
+++ b/Sources/StreamChatSwiftUI/Resources/en.lproj/Localizable.strings
@@ -51,12 +51,12 @@
 "message.actions.user-block.confirmation-message" = "Are you sure you want to block this user?";
 "message.actions.user-unblock.confirmation-message" = "Are you sure you want to unblock this user?";
 
-"message.moderation.title" = "Are you sure?";
-"message.moderation.message" = "Consider how your comment might make others feel and be sure to follow our Community Guidelines.";
-"message.moderation.resend" = "Send Anyway";
-"message.moderation.edit" = "Edit Message";
-"message.moderation.delete" = "Delete Message";
-"message.moderation.cancel" = "Cancel";
+"message.moderation.alert.title" = "Are you sure?";
+"message.moderation.alert.message" = "Consider how your comment might make others feel and be sure to follow our Community Guidelines.";
+"message.moderation.alert.resend" = "Send Anyway";
+"message.moderation.alert.edit" = "Edit Message";
+"message.moderation.alert.delete" = "Delete Message";
+"message.moderation.alert.cancel" = "Cancel";
 
 "messageList.typingIndicator.typing-unknown" = "Someone is typing";
 

--- a/Sources/StreamChatSwiftUI/Resources/en.lproj/Localizable.strings
+++ b/Sources/StreamChatSwiftUI/Resources/en.lproj/Localizable.strings
@@ -51,6 +51,13 @@
 "message.actions.user-block.confirmation-message" = "Are you sure you want to block this user?";
 "message.actions.user-unblock.confirmation-message" = "Are you sure you want to unblock this user?";
 
+"message.moderation.title" = "Are you sure?";
+"message.moderation.message" = "Consider how your comment might make others feel and be sure to follow our Community Guidelines.";
+"message.moderation.resend" = "Send Anyway";
+"message.moderation.edit" = "Edit Message";
+"message.moderation.delete" = "Delete Message";
+"message.moderation.cancel" = "Cancel";
+
 "messageList.typingIndicator.typing-unknown" = "Someone is typing";
 
 "message.threads.reply" = "Thread Reply";

--- a/Sources/StreamChatSwiftUI/ViewFactory.swift
+++ b/Sources/StreamChatSwiftUI/ViewFactory.swift
@@ -254,6 +254,14 @@ public protocol ViewFactory: AnyObject {
     /// - Parameter messageModifierInfo: the message modifier info, that will be applied to the message.
     func makeMessageViewModifier(for messageModifierInfo: MessageModifierInfo) -> MessageViewModifier
 
+    associatedtype BouncedMessageActionsModifierType: ViewModifier
+    /// Returns a view modifier applied to the bounced message actions.
+    ///
+    /// This modifier is only used if `Utils.messageListConfig.bouncedMessagesAlertActionsEnabled` is `true`.
+    /// By default the flag is false and the bounced actions are shown as a context menu.
+    /// - Parameter viewModel: the view model of the chat channel view.
+    func makeBouncedMessageActionsModifier(viewModel: ChatChannelViewModel) -> BouncedMessageActionsModifierType
+
     associatedtype UserAvatar: View
     /// Creates the message avatar view.
     /// - Parameter userDisplayInfo: the author's display info.

--- a/Sources/StreamChatSwiftUI/ViewFactory.swift
+++ b/Sources/StreamChatSwiftUI/ViewFactory.swift
@@ -258,7 +258,7 @@ public protocol ViewFactory: AnyObject {
     /// Returns a view modifier applied to the bounced message actions.
     ///
     /// This modifier is only used if `Utils.messageListConfig.bouncedMessagesAlertActionsEnabled` is `true`.
-    /// By default the flag is false and the bounced actions are shown as a context menu.
+    /// By default the flag is true and the bounced actions are shown as an alert instead of a context menu.
     /// - Parameter viewModel: the view model of the chat channel view.
     func makeBouncedMessageActionsModifier(viewModel: ChatChannelViewModel) -> BouncedMessageActionsModifierType
 

--- a/StreamChatSwiftUI.xcodeproj/project.pbxproj
+++ b/StreamChatSwiftUI.xcodeproj/project.pbxproj
@@ -516,6 +516,7 @@
 		AD3AB65C2CB730090014D4D7 /* Shimmer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD3AB65B2CB730090014D4D7 /* Shimmer.swift */; };
 		AD3AB65E2CB731360014D4D7 /* ChatThreadListLoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD3AB65D2CB731360014D4D7 /* ChatThreadListLoadingView.swift */; };
 		AD3AB6602CB7403C0014D4D7 /* ChatThreadListHeaderViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD3AB65F2CB7403C0014D4D7 /* ChatThreadListHeaderViewModifier.swift */; };
+		AD5C0A5F2D6FDD9700E1E500 /* BouncedMessageActionsModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD5C0A5E2D6FDD8600E1E500 /* BouncedMessageActionsModifier.swift */; };
 		AD6B7E052D356E8800ADEF39 /* ReactionsUsersViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD6B7E042D356E8800ADEF39 /* ReactionsUsersViewModel.swift */; };
 		ADE0F55E2CB838420053B8B9 /* ChatThreadListErrorBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADE0F55D2CB838420053B8B9 /* ChatThreadListErrorBannerView.swift */; };
 		ADE0F5602CB846EC0053B8B9 /* FloatingBannerViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADE0F55F2CB846EC0053B8B9 /* FloatingBannerViewModifier.swift */; };
@@ -1110,6 +1111,7 @@
 		AD3AB65B2CB730090014D4D7 /* Shimmer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Shimmer.swift; sourceTree = "<group>"; };
 		AD3AB65D2CB731360014D4D7 /* ChatThreadListLoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatThreadListLoadingView.swift; sourceTree = "<group>"; };
 		AD3AB65F2CB7403C0014D4D7 /* ChatThreadListHeaderViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatThreadListHeaderViewModifier.swift; sourceTree = "<group>"; };
+		AD5C0A5E2D6FDD8600E1E500 /* BouncedMessageActionsModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BouncedMessageActionsModifier.swift; sourceTree = "<group>"; };
 		AD6B7E042D356E8800ADEF39 /* ReactionsUsersViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReactionsUsersViewModel.swift; sourceTree = "<group>"; };
 		ADE0F55D2CB838420053B8B9 /* ChatThreadListErrorBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatThreadListErrorBannerView.swift; sourceTree = "<group>"; };
 		ADE0F55F2CB846EC0053B8B9 /* FloatingBannerViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingBannerViewModifier.swift; sourceTree = "<group>"; };
@@ -1740,6 +1742,7 @@
 				8465FD302746A95600AF091E /* ChatChannelViewModel.swift */,
 				84DEC8E72760EABC00172876 /* ChatChannelDataSource.swift */,
 				844D1D6528510304000CCCB9 /* ChannelControllerFactory.swift */,
+				AD5C0A5E2D6FDD8600E1E500 /* BouncedMessageActionsModifier.swift */,
 				8465FD2E2746A95600AF091E /* ChannelHeader */,
 				8465FCFD2746A95600AF091E /* MessageList */,
 				8465FD0F2746A95600AF091E /* Composer */,
@@ -2793,6 +2796,7 @@
 				82D64BF82AD7E5B700C5C79E /* ImageProcessors+Circle.swift in Sources */,
 				8465FDD32746A95800AF091E /* ColorPalette.swift in Sources */,
 				8465FD782746A95700AF091E /* FileAttachmentView.swift in Sources */,
+				AD5C0A5F2D6FDD9700E1E500 /* BouncedMessageActionsModifier.swift in Sources */,
 				82D64C152AD7E5B700C5C79E /* ImageContainer.swift in Sources */,
 				84EADEA22B2735D80046B50C /* VoiceRecordingContainerView.swift in Sources */,
 				82D64C0F2AD7E5B700C5C79E /* ImageDecoders+Video.swift in Sources */,


### PR DESCRIPTION
### 🔗 Issue Link
https://linear.app/stream/issue/IOS-713/add-moderation-flow-bounce-to-swiftui

### 🎯 Goal

Adds support for bounced message alert actions. This new UI is aligned with UIKit and other platforms, including the Figma design files. In order to avoid introducing a breaking change, a new `MessageListConfig.bouncedMessagesAlertActionsEnabled` has been introduced. 

### 🧪 Testing

**Pre-condition:**
The following git patch should be applied to include the environment for bounced messages:
[bounce-demo.patch](https://github.com/user-attachments/files/18999717/bounce-demo.patch)

**Scenario:**
1. Send "each me on my phone +38970555333" message (Without the "r" word)
2. Should show an error indicator
3. Long tap the message
4. Should show the bounced message alert actions:
    - Tapping "Send Anyway" should block the message
    - Tapping "Edit Message" should edit the message
    - Tapping "Delete Message" should delete the message
    - Tapping "Cancel" should cancel the alert

### 🎨 Changes

<img width="280px" src="https://github.com/user-attachments/assets/4d1a2a29-b1c4-48b2-ad2c-1a57e8dd0e01" />

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
