### PR TITLE
Upload photos from the library as JPEG instead of HEIC

### DIFF
--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/PhotoAttachmentPickerView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/PhotoAttachmentPickerView.swift
@@ -102,7 +102,7 @@ public struct PhotoAttachmentCell: View {
                             .allowsHitTesting(true)
                             .onTapGesture {
                                 withAnimation {
-                                    if let assetURL = assetURL {
+                                    if let assetURL = assetJpgURL() {
                                         onImageTap(
                                             AddedAsset(
                                                 image: image,
@@ -192,5 +192,14 @@ public struct PhotoAttachmentCell: View {
                 loading = false
             }
         }
+    }
+
+    /// The original photo is usually in HEIC format.
+    /// This makes sure that the photo is converted to JPG.
+    /// This way it is more compatible with other platforms.
+    private func assetJpgURL() -> URL? {
+        guard let assetURL = assetURL else { return nil }
+        guard let assetData = try? Data(contentsOf: assetURL) else { return nil }
+        return try? UIImage(data: assetData)?.temporaryLocalFileUrl()
     }
 }


### PR DESCRIPTION
### 🔗 Issue Link
https://github.com/GetStream/stream-chat-swiftui/issues/759

### 🎯 Goal

Send photos from the library as JPEG instead of HEIC to make sure other platforms can show the images correctly. 

### 🛠 Implementation
We now convert the HEIC image to JPG when adding it to the composer.

This approach is what we do when sending photos from the Camera. With this change, we are also consistent with UIKit as well which follows the same approach.

### 🧪 Testing

Smoke testing around images

### ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
