### PR TITLE
Fix video assets not showing in composer

### DIFF
--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/PhotoAttachmentPickerView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/PhotoAttachmentPickerView.swift
@@ -102,7 +102,7 @@ public struct PhotoAttachmentCell: View {
                             .allowsHitTesting(true)
                             .onTapGesture {
                                 withAnimation {
-                                    if let assetURL = assetJpgURL() {
+                                    if let assetURL = asset.mediaType == .image ? assetJpgURL() : assetURL {
                                         onImageTap(
                                             AddedAsset(
                                                 image: image,


### PR DESCRIPTION
### 🔗 Issue Link
Regression introduced here: https://github.com/GetStream/stream-chat-swiftui/pull/767

### 🎯 Goal

I did not realise that `onImageTap` was also for video assets. So it was also trying to convert videos into jpg. So it broke the composer.

### 🧪 Testing

It should be possible to add video assets to the composer.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
