### PR TITLE
Add `resignsFirstResponderOnScrollDown` to `MessageListConfig`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🔄 Changed
 - Uploading a HEIC photo from the library is now converted to JPEG for better compatibility [#767](https://github.com/GetStream/stream-chat-swiftui/pull/767)
 
+### ✅ Added
+- Add `resignsFirstResponderOnScrollDown` to `MessageListConfig` [#769](https://github.com/GetStream/stream-chat-swiftui/pull/769)
+
 # [4.73.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.73.0)
 _February 28, 2025_
 

--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageListConfig.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageListConfig.swift
@@ -19,6 +19,7 @@ public struct MessageListConfig {
         messagePopoverEnabled: Bool = true,
         doubleTapOverlayEnabled: Bool = false,
         becomesFirstResponderOnOpen: Bool = false,
+        resignsFirstResponderOnScrollDown: Bool = true,
         updateChannelsFromMessageList: Bool = false,
         maxTimeIntervalBetweenMessagesInGroup: TimeInterval = 60,
         cacheSizeOnChatDismiss: Int = 1024 * 1024 * 100,
@@ -45,6 +46,7 @@ public struct MessageListConfig {
         self.messagePopoverEnabled = messagePopoverEnabled
         self.doubleTapOverlayEnabled = doubleTapOverlayEnabled
         self.becomesFirstResponderOnOpen = becomesFirstResponderOnOpen
+        self.resignsFirstResponderOnScrollDown = resignsFirstResponderOnScrollDown
         self.updateChannelsFromMessageList = updateChannelsFromMessageList
         self.maxTimeIntervalBetweenMessagesInGroup = maxTimeIntervalBetweenMessagesInGroup
         self.cacheSizeOnChatDismiss = cacheSizeOnChatDismiss
@@ -72,6 +74,7 @@ public struct MessageListConfig {
     public let messagePopoverEnabled: Bool
     public let doubleTapOverlayEnabled: Bool
     public let becomesFirstResponderOnOpen: Bool
+    public let resignsFirstResponderOnScrollDown: Bool
     public let updateChannelsFromMessageList: Bool
     public let maxTimeIntervalBetweenMessagesInGroup: TimeInterval
     public let cacheSizeOnChatDismiss: Int

--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageListView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageListView.swift
@@ -238,7 +238,7 @@ public struct MessageListView<Factory: ViewFactory>: View, KeyboardReadable {
                         if scrollButtonShown != showScrollToLatestButton {
                             showScrollToLatestButton = scrollButtonShown
                         }
-                        if keyboardShown && diff < -20 {
+                        if messageListConfig.resignsFirstResponderOnScrollDown && keyboardShown && diff < -20 {
                             keyboardShown = false
                             resignFirstResponder()
                         }


### PR DESCRIPTION
### 🔗 Issue Link

N/A

### 🎯 Goal

Add a config option to control whether scrolling down on the message list dismisses the keyboard (resigns first responder) 

### 🛠 Implementation

In `MessageListConfig` we add a new property - `resignsFirstResponderOnScrollDown: Bool` with a default value of `true` (existing behaviour). This is backwards compatible, existing code uses the default value.

### 🧪 Testing

If the MessageListConfig has `resignsFirstResponderOnScrollDown = false`, scrolling on down on a chat should not hide the keyboard.

### 🎨 Changes

In the following example, the config `resignsFirstResponderOnScrollDown` has been changed from the default `true` to `false` - and we can see the keyboard is not dismissed when the chat is scrolled.

![Screen Recording 2025-03-03 at 21 16 59](https://github.com/user-attachments/assets/f9cde696-9a38-44c4-8476-34a9a6f69fc1)

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
