### PR TITLE
Move `ChangeBarsVisibilityModifier ` into `ViewFactory` for better customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🔄 Changed
 - Uploading a HEIC photo from the library is now converted to JPEG for better compatibility [#767](https://github.com/GetStream/stream-chat-swiftui/pull/767)
 - Customizing the message avatar view is reflected in all views that use it [#772](https://github.com/GetStream/stream-chat-swiftui/pull/772)
+- Move `ChangeBarsVisibilityModifier` into `ViewFactory` for better customization [#774](https://github.com/GetStream/stream-chat-swiftui/pull/774)
 
 # [4.73.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.73.0)
 _February 28, 2025_

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelView.swift
@@ -94,10 +94,10 @@ public struct ChatChannelView<Factory: ViewFactory>: View, KeyboardReadable {
                     Divider()
                         .navigationBarBackButtonHidden(viewModel.reactionsShown)
                         .if(viewModel.reactionsShown, transform: { view in
-                            view.modifier(factory.changeBarsVisibility(shouldShow: false))
+                            view.modifier(factory.makeChannelBarsVisibilityViewModifier(shouldShow: false))
                         })
                         .if(!viewModel.reactionsShown, transform: { view in
-                            view.modifier(factory.changeBarsVisibility(shouldShow: true))
+                            view.modifier(factory.makeChannelBarsVisibilityViewModifier(shouldShow: true))
                         })
                         .if(viewModel.channelHeaderType == .regular) { view in
                             view.modifier(factory.makeChannelHeaderViewModifier(for: channel))

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelView.swift
@@ -94,10 +94,10 @@ public struct ChatChannelView<Factory: ViewFactory>: View, KeyboardReadable {
                     Divider()
                         .navigationBarBackButtonHidden(viewModel.reactionsShown)
                         .if(viewModel.reactionsShown, transform: { view in
-                            view.changeBarsVisibility(shouldShow: false)
+                            view.modifier(factory.changeBarsVisibility(shouldShow: false))
                         })
                         .if(!viewModel.reactionsShown, transform: { view in
-                            view.changeBarsVisibility(shouldShow: true)
+                            view.modifier(factory.changeBarsVisibility(shouldShow: true))
                         })
                         .if(viewModel.channelHeaderType == .regular) { view in
                             view.modifier(factory.makeChannelHeaderViewModifier(for: channel))

--- a/Sources/StreamChatSwiftUI/DefaultViewFactory.swift
+++ b/Sources/StreamChatSwiftUI/DefaultViewFactory.swift
@@ -301,7 +301,7 @@ extension ViewFactory {
         DefaultChannelHeaderModifier(factory: self, channel: channel)
     }
     
-    public func changeBarsVisibility(shouldShow: Bool) -> some ViewModifier {
+    public func makeChannelBarsVisibilityViewModifier(shouldShow: Bool) -> some ViewModifier {
         ChangeChannelBarsVisibilityModifier(shouldShow: shouldShow)
     }
     

--- a/Sources/StreamChatSwiftUI/DefaultViewFactory.swift
+++ b/Sources/StreamChatSwiftUI/DefaultViewFactory.swift
@@ -301,6 +301,10 @@ extension ViewFactory {
         DefaultChannelHeaderModifier(factory: self, channel: channel)
     }
     
+    public func changeBarsVisibility(shouldShow: Bool) -> some ViewModifier {
+        ChangeChannelBarsVisibilityModifier(shouldShow: shouldShow)
+    }
+    
     public func makeChannelLoadingView() -> some View {
         LoadingView()
     }

--- a/Sources/StreamChatSwiftUI/Utils/Modifiers.swift
+++ b/Sources/StreamChatSwiftUI/Utils/Modifiers.swift
@@ -79,7 +79,7 @@ struct IconOverImageModifier: ViewModifier {
     }
 }
 
-struct ChangeBarsVisibilityModifier: ViewModifier {
+struct ChangeChannelBarsVisibilityModifier: ViewModifier {
     
     @Injected(\.utils) private var utils
     
@@ -109,10 +109,6 @@ extension View {
 
     public func applyDefaultIconOverlayStyle() -> some View {
         modifier(IconOverImageModifier())
-    }
-    
-    public func changeBarsVisibility(shouldShow: Bool) -> some View {
-        modifier(ChangeBarsVisibilityModifier(shouldShow: shouldShow))
     }
 }
 

--- a/Sources/StreamChatSwiftUI/ViewFactory.swift
+++ b/Sources/StreamChatSwiftUI/ViewFactory.swift
@@ -282,6 +282,12 @@ public protocol ViewFactory: AnyObject {
     /// - Parameter channel: the displayed channel.
     func makeChannelHeaderViewModifier(for channel: ChatChannel) -> ChatHeaderViewModifier
     
+    associatedtype ChangeBarsVisibilityModifier: ViewModifier
+    /// Creates a view modifier that changes the visibility of bars.
+    /// - Parameter shouldShow: A Boolean value indicating whether the bars should be shown.
+    /// - Returns: A view modifier that changes the visibility of bars.
+    func changeBarsVisibility(shouldShow: Bool) -> ChangeBarsVisibilityModifier
+    
     associatedtype ChannelLoadingViewType: View
     /// Creates a loading view for the channel.
     func makeChannelLoadingView() -> ChannelLoadingViewType

--- a/Sources/StreamChatSwiftUI/ViewFactory.swift
+++ b/Sources/StreamChatSwiftUI/ViewFactory.swift
@@ -286,7 +286,7 @@ public protocol ViewFactory: AnyObject {
     /// Creates a view modifier that changes the visibility of bars.
     /// - Parameter shouldShow: A Boolean value indicating whether the bars should be shown.
     /// - Returns: A view modifier that changes the visibility of bars.
-    func changeBarsVisibility(shouldShow: Bool) -> ChangeBarsVisibilityModifier
+    func makeChannelBarsVisibilityViewModifier(shouldShow: Bool) -> ChangeBarsVisibilityModifier
     
     associatedtype ChannelLoadingViewType: View
     /// Creates a loading view for the channel.


### PR DESCRIPTION
Move `ChangeBarsVisibilityModifier ` into `ViewFactory` for better customization

### 🔗 Issue Link
N/A

### 🎯 Goal
The current code work well with SwiftUI only, but if the UITabbar is implemented using UIKit, it won't function correctly. 
Therefore, I'm requesting a feature to allow customizing the `ChangeBarsVisibilityModifier ` through `ViewFactory`

### 🛠 Implementation

Move `ChangeBarsVisibilityModifier` logic into `ViewFactory` for better customization

### 🧪 Testing

_Describe the steps how this change can be tested (or why it can't be tested)._

### 🎨 Changes

_Add relevant screenshots or videos showcasing the changes._

### ☑️ Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
