### PR TITLE
Resolve Swift 6 Concurrency Warning for localizationProvider in Appearance

### DIFF
--- a/Sources/StreamChatSwiftUI/Appearance.swift
+++ b/Sources/StreamChatSwiftUI/Appearance.swift
@@ -21,7 +21,7 @@ public class Appearance {
     }
 
     /// Provider for custom localization which is dependent on App Bundle.
-    public static var localizationProvider: (_ key: String, _ table: String) -> String = { key, table in
+    public nonisolated(unsafe) static var localizationProvider: (_ key: String, _ table: String) -> String = { key, table in
         Bundle.streamChatUI.localizedString(forKey: key, value: nil, table: table)
     }
 }


### PR DESCRIPTION
### 🔗 Issue Link
_Jira or Github issue link, if applicable._

### 🎯 Goal

Resolve Swift concurrency warnings related to assigning values to `localizationProvider` in `Appearance`, as part of our effort to enable strict concurrency checks and fully migrate to Swift 6.

### 🛠 Implementation

This PR addresses the following Swift concurrency warning:

`Reference to class property ‘localizationProvider’ is not concurrency-safe because it involves shared mutable state; this is an error in the Swift 6 language mode.`

Following the official migration guide [Unsafe Global and Static Variables](https://www.swift.org/migration/documentation/swift-6-concurrency-migration-guide/commonproblems#Unsafe-Global-and-Static-Variables), I've annotated `localizationProvider` with `nonisolated(unsafe)` since this property is only set during application initialization and is not mutated thereafter.

If this solution is incorrect or already addressed, please feel free to close this PR.

### 🧪 Testing

This change doesn't alter functionality and is specifically aimed at silencing Swift 6 concurrency warnings. No additional testing is necessary beyond verifying that the warnings are resolved.

### 🎨 Changes

_Add relevant screenshots or videos showcasing the changes._

### ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
