### PR TITLE
Make sendMessage in MessageComposerViewModel open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🔄 Changed
 - Uploading a HEIC photo from the library is now converted to JPEG for better compatibility [#767](https://github.com/GetStream/stream-chat-swiftui/pull/767)
 - Customizing the message avatar view is reflected in all views that use it [#772](https://github.com/GetStream/stream-chat-swiftui/pull/772)
-- Made the sendMessage method in MessageComposerViewModel public [#779](https://github.com/GetStream/stream-chat-swiftui/pull/779)
+- Made the sendMessage method in MessageComposerViewModel open [#779](https://github.com/GetStream/stream-chat-swiftui/pull/779)
 
 # [4.73.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.73.0)
 _February 28, 2025_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🔄 Changed
 - Uploading a HEIC photo from the library is now converted to JPEG for better compatibility [#767](https://github.com/GetStream/stream-chat-swiftui/pull/767)
 - Customizing the message avatar view is reflected in all views that use it [#772](https://github.com/GetStream/stream-chat-swiftui/pull/772)
+- Made the sendMessage method in MessageComposerViewModel public [#779](https://github.com/GetStream/stream-chat-swiftui/pull/779)
 
 # [4.73.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.73.0)
 _February 28, 2025_

--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerView.swift
@@ -22,6 +22,7 @@ public struct MessageComposerView<Factory: ViewFactory>: View, KeyboardReadable 
     @Binding var editedMessage: ChatMessage?
     
     private let recordingViewHeight: CGFloat = 80
+    private let messageSendingParameters: MessageSendingParameters
 
     public init(
         viewFactory: Factory,
@@ -30,6 +31,7 @@ public struct MessageComposerView<Factory: ViewFactory>: View, KeyboardReadable 
         messageController: ChatMessageController? = nil,
         quotedMessage: Binding<ChatMessage?>,
         editedMessage: Binding<ChatMessage?>,
+        messageSendingParameters: MessageSendingParameters = .init(),
         onMessageSent: @escaping () -> Void
     ) {
         factory = viewFactory
@@ -43,6 +45,7 @@ public struct MessageComposerView<Factory: ViewFactory>: View, KeyboardReadable 
         _quotedMessage = quotedMessage
         _editedMessage = editedMessage
         self.onMessageSent = onMessageSent
+        self.messageSendingParameters = messageSendingParameters
     }
 
     @StateObject var viewModel: MessageComposerViewModel
@@ -99,7 +102,11 @@ public struct MessageComposerView<Factory: ViewFactory>: View, KeyboardReadable 
                 ) {
                     viewModel.sendMessage(
                         quotedMessage: quotedMessage,
-                        editedMessage: editedMessage
+                        editedMessage: editedMessage,
+                        isSilent: messageSendingParameters.isSilent,
+                        skipPush: messageSendingParameters.skipPush,
+                        skipEnrichUrl: messageSendingParameters.skipEnrichUrl,
+                        extraData: messageSendingParameters.extraData
                     ) {
                         quotedMessage = nil
                         editedMessage = nil
@@ -419,5 +426,24 @@ public struct ComposerInputView<Factory: ViewFactory>: View, KeyboardReadable {
 
     private var isInCooldown: Bool {
         cooldownDuration > 0
+    }
+}
+
+public struct MessageSendingParameters {
+    public let isSilent: Bool
+    public let skipPush: Bool
+    public let skipEnrichUrl: Bool
+    public let extraData: [String: RawJSON]
+    
+    public init(
+        isSilent: Bool = false,
+        skipPush: Bool = false,
+        skipEnrichUrl: Bool = false,
+        extraData: [String: RawJSON] = [:]
+    ) {
+        self.isSilent = isSilent
+        self.skipPush = skipPush
+        self.skipEnrichUrl = skipEnrichUrl
+        self.extraData = extraData
     }
 }

--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerView.swift
@@ -22,7 +22,6 @@ public struct MessageComposerView<Factory: ViewFactory>: View, KeyboardReadable 
     @Binding var editedMessage: ChatMessage?
     
     private let recordingViewHeight: CGFloat = 80
-    private let messageSendingParameters: MessageSendingParameters
 
     public init(
         viewFactory: Factory,
@@ -31,7 +30,6 @@ public struct MessageComposerView<Factory: ViewFactory>: View, KeyboardReadable 
         messageController: ChatMessageController? = nil,
         quotedMessage: Binding<ChatMessage?>,
         editedMessage: Binding<ChatMessage?>,
-        messageSendingParameters: MessageSendingParameters = .init(),
         onMessageSent: @escaping () -> Void
     ) {
         factory = viewFactory
@@ -45,7 +43,6 @@ public struct MessageComposerView<Factory: ViewFactory>: View, KeyboardReadable 
         _quotedMessage = quotedMessage
         _editedMessage = editedMessage
         self.onMessageSent = onMessageSent
-        self.messageSendingParameters = messageSendingParameters
     }
 
     @StateObject var viewModel: MessageComposerViewModel
@@ -102,11 +99,7 @@ public struct MessageComposerView<Factory: ViewFactory>: View, KeyboardReadable 
                 ) {
                     viewModel.sendMessage(
                         quotedMessage: quotedMessage,
-                        editedMessage: editedMessage,
-                        isSilent: messageSendingParameters.isSilent,
-                        skipPush: messageSendingParameters.skipPush,
-                        skipEnrichUrl: messageSendingParameters.skipEnrichUrl,
-                        extraData: messageSendingParameters.extraData
+                        editedMessage: editedMessage
                     ) {
                         quotedMessage = nil
                         editedMessage = nil
@@ -426,24 +419,5 @@ public struct ComposerInputView<Factory: ViewFactory>: View, KeyboardReadable {
 
     private var isInCooldown: Bool {
         cooldownDuration > 0
-    }
-}
-
-public struct MessageSendingParameters {
-    public let isSilent: Bool
-    public let skipPush: Bool
-    public let skipEnrichUrl: Bool
-    public let extraData: [String: RawJSON]
-    
-    public init(
-        isSilent: Bool = false,
-        skipPush: Bool = false,
-        skipEnrichUrl: Bool = false,
-        extraData: [String: RawJSON] = [:]
-    ) {
-        self.isSilent = isSilent
-        self.skipPush = skipPush
-        self.skipEnrichUrl = skipEnrichUrl
-        self.extraData = extraData
     }
 }

--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerViewModel.swift
@@ -219,7 +219,7 @@ open class MessageComposerViewModel: ObservableObject {
         )
     }
     
-    public func sendMessage(
+    open func sendMessage(
         quotedMessage: ChatMessage?,
         editedMessage: ChatMessage?,
         isSilent: Bool = false,


### PR DESCRIPTION
### 🔗 Issue Link
Resolves https://linear.app/stream/issue/IOS-732/provide-message-sending-params-to-messagecomposerview.

### 🎯 Goal

_Describe why we are making this change._

### 🛠 Implementation

_Provide a description of the implementation._

### 🧪 Testing

_Describe the steps how this change can be tested (or why it can't be tested)._

### 🎨 Changes

_Add relevant screenshots or videos showcasing the changes._

### ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created)
