### PR TITLE
Add avatar customization in add users popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### ✅ Added
+- Add avatar customization in add users popup [#787](https://github.com/GetStream/stream-chat-swiftui/pull/787)
 
 # [4.74.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.74.0)
 _March 14, 2025_

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/AddUsersView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/AddUsersView.swift
@@ -6,27 +6,27 @@ import StreamChat
 import SwiftUI
 
 /// View for the add users popup.
-struct AddUsersView: View {
+struct AddUsersView<Factory: ViewFactory>: View {
 
     @Injected(\.fonts) private var fonts
     @Injected(\.colors) private var colors
 
-    private static let columnCount = 4
-    private static let itemSize: CGFloat = 64
-
     private let columns = Array(
         repeating:
         GridItem(
-            .adaptive(minimum: itemSize),
+            .adaptive(minimum: 64),
             alignment: .top
         ),
-        count: columnCount
+        count: 4
     )
+    
+    private let factory: Factory
 
     @StateObject private var viewModel: AddUsersViewModel
     var onUserTap: (ChatUser) -> Void
 
     init(
+        factory: Factory = DefaultViewFactory.shared,
         loadedUserIds: [String],
         onUserTap: @escaping (ChatUser) -> Void
     ) {
@@ -34,9 +34,11 @@ struct AddUsersView: View {
             wrappedValue: AddUsersViewModel(loadedUserIds: loadedUserIds)
         )
         self.onUserTap = onUserTap
+        self.factory = factory
     }
 
     init(
+        factory: Factory = DefaultViewFactory.shared,
         viewModel: AddUsersViewModel,
         onUserTap: @escaping (ChatUser) -> Void
     ) {
@@ -44,6 +46,7 @@ struct AddUsersView: View {
             wrappedValue: viewModel
         )
         self.onUserTap = onUserTap
+        self.factory = factory
     }
 
     var body: some View {
@@ -57,17 +60,20 @@ struct AddUsersView: View {
                             onUserTap(user)
                         } label: {
                             VStack {
-                                MessageAvatarView(
-                                    avatarURL: user.imageURL,
-                                    size: CGSize(width: Self.itemSize, height: Self.itemSize),
-                                    showOnlineIndicator: false
+                                let itemSize: CGFloat = 64
+                                let userDisplayInfo = UserDisplayInfo(
+                                    id: user.id,
+                                    name: user.name ?? "",
+                                    imageURL: user.imageURL,
+                                    size: CGSize(width: itemSize, height: itemSize)
                                 )
+                                factory.makeMessageAvatarView(for: userDisplayInfo)
 
                                 Text(user.name ?? user.id)
                                     .multilineTextAlignment(.center)
                                     .lineLimit(2)
                                     .font(fonts.footnoteBold)
-                                    .frame(width: Self.itemSize)
+                                    .frame(width: itemSize)
                                     .foregroundColor(Color(colors.text))
                             }
                             .padding(.all, 8)

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/ChatChannelInfoView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/ChatChannelInfoView.swift
@@ -126,6 +126,7 @@ public struct ChatChannelInfoView<Factory: ViewFactory>: View, KeyboardReadable 
                             viewModel.addUsersShown = false
                         }
                     AddUsersView(
+                        factory: factory,
                         loadedUserIds: viewModel.participants.map(\.id),
                         onUserTap: viewModel.addUserTapped(_:)
                     )


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-751/invite-view-doesnt-use-the-avatar-factory-method.

### 🎯 Goal

We were missing the factory method here.

### 📝 Summary

_Provide bullet points with the most important changes in the codebase._

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
