### PR TITLE
[Feature] Allow customization of minOriginY in the initializer of ReactionsOverlayView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+### ✅ Added
+- Add `minOriginY` to the initializer of `ReactionsOverlayView` for better UI customization [#793](https://github.com/GetStream/stream-chat-swiftui/pull/793)
 ### 🔄 Changed
 
 # [4.75.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.75.0)

--- a/Sources/StreamChatSwiftUI/ChatChannel/Reactions/ReactionsOverlayView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Reactions/ReactionsOverlayView.swift
@@ -30,6 +30,7 @@ public struct ReactionsOverlayView<Factory: ViewFactory>: View {
     private var messageActionsCount: Int
     private let paddingValue: CGFloat = 16
     private let messageItemSize: CGFloat = 40
+    private let minOriginY: CGFloat
     private var maxMessageActionsSize: CGFloat {
         screenHeight / 3
     }
@@ -39,6 +40,7 @@ public struct ReactionsOverlayView<Factory: ViewFactory>: View {
         channel: ChatChannel,
         currentSnapshot: UIImage,
         messageDisplayInfo: MessageDisplayInfo,
+        minOriginY: CGFloat = 100,
         bottomOffset: CGFloat = 0,
         onBackgroundTap: @escaping () -> Void,
         onActionExecuted: @escaping (MessageActionInfo) -> Void
@@ -51,6 +53,7 @@ public struct ReactionsOverlayView<Factory: ViewFactory>: View {
         self.channel = channel
         self.factory = factory
         self.currentSnapshot = currentSnapshot
+        self.minOriginY = minOriginY
         self.bottomOffset = bottomOffset
         self.messageDisplayInfo = messageDisplayInfo
         self.onBackgroundTap = onBackgroundTap
@@ -280,10 +283,9 @@ public struct ReactionsOverlayView<Factory: ViewFactory>: View {
         let bottomPopupOffset =
             messageDisplayInfo.showsMessageActions ? messageActionsSize : userReactionsPopupHeight
         var originY = messageDisplayInfo.frame.origin.y
-        let minOrigin: CGFloat = 100
-        let maxOrigin: CGFloat = screenHeight - messageContainerHeight - bottomPopupOffset - minOrigin - bottomOffset
-        if originY < minOrigin {
-            originY = minOrigin
+        let maxOrigin: CGFloat = screenHeight - messageContainerHeight - bottomPopupOffset - minOriginY - bottomOffset
+        if originY < minOriginY {
+            originY = minOriginY
         } else if originY > maxOrigin {
             originY = maxOrigin
         }


### PR DESCRIPTION
### 🔗 Issue Links

N/A

### 🎯 Goal

Be able to update min origin Y position of ReactionsOverlayView content for better UI flexibility instead of using a fixed default value.


### 📝 Summary

Allow `minOriginY` to be set through the initializer for better UI customization.

### 🛠 Implementation 

Add `minOriginY` to the initializer of `ReactionsOverlayView`.

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [x] Documentation has been updated in the `docs-content` repo
