### PR TITLE
Handle canSendPoll capability when creating polls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### ✅ Added
 - Allow pasting images to the composer [#797](https://github.com/GetStream/stream-chat-swiftui/pull/797)
+### 🐞 Fixed
+- Fix allowing to send Polls when the current user does not have the capability [#798](https://github.com/GetStream/stream-chat-swiftui/pull/798)
 
 # [4.76.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.76.0)
 _March 31, 2025_

--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/AttachmentPickerView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/AttachmentPickerView.swift
@@ -170,7 +170,7 @@ public struct AttachmentSourcePickerView: View {
             )
             .accessibilityIdentifier("attachmentPickerCamera")
             
-            if viewModel.channelController.channel?.config.pollsEnabled == true && viewModel.messageController == nil {
+            if viewModel.canSendPoll {
                 AttachmentPickerButton(
                     icon: images.attachmentPickerPolls,
                     pickerType: .polls,

--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerViewModel.swift
@@ -183,7 +183,13 @@ open class MessageComposerViewModel: ObservableObject {
     public var quotedMessage: Binding<ChatMessage?>?
     public var waveformTargetSamples: Int = 100
     public internal(set) var pendingAudioRecording: AddedVoiceRecording?
-    
+
+    public var canSendPoll: Bool {
+        channelController.channel?.config.pollsEnabled == true
+            && channelController.channel?.canSendPoll == true
+            && messageController == nil
+    }
+
     internal lazy var audioRecorder: AudioRecording = {
         let audioRecorder = utils.audioRecorder
         audioRecorder.subscribe(self)

--- a/StreamChatSwiftUI.xcodeproj/project.pbxproj
+++ b/StreamChatSwiftUI.xcodeproj/project.pbxproj
@@ -3879,8 +3879,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/GetStream/stream-chat-swift.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 4.76.0;
+				branch = develop;
+				kind = branch;
 			};
 		};
 		E3A1C01A282BAC66002D1E26 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {

--- a/StreamChatSwiftUITests/Tests/ChatChannel/MessageComposerViewModel_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/MessageComposerViewModel_Tests.swift
@@ -573,7 +573,92 @@ class MessageComposerViewModel_Tests: StreamChatTestCase {
         // Then
         XCTAssert(viewModel.mentionedUsers.isEmpty)
     }
-    
+
+    func test_messageComposerVM_canSendPoll() {
+        // Given
+        let channelController = makeChannelController()
+        let viewModel = MessageComposerViewModel(
+            channelController: channelController,
+            messageController: nil
+        )
+
+        // When
+        let channelConfig = ChannelConfig(pollsEnabled: true)
+        channelController.channel_mock = .mock(
+            cid: .unique,
+            config: channelConfig,
+            ownCapabilities: [.sendPoll]
+        )
+
+        // Then
+        XCTAssertTrue(viewModel.canSendPoll)
+    }
+
+    func test_messageComposerVM_canSendPoll_whenDoesNotHaveCapability() {
+        // Given
+        let channelController = makeChannelController()
+        let viewModel = MessageComposerViewModel(
+            channelController: channelController,
+            messageController: nil
+        )
+
+        // When
+        let channelConfig = ChannelConfig(pollsEnabled: true)
+        channelController.channel_mock = .mock(
+            cid: .unique,
+            config: channelConfig,
+            ownCapabilities: [.banChannelMembers]
+        )
+
+        // Then
+        XCTAssertFalse(viewModel.canSendPoll)
+    }
+
+    func test_messageComposerVM_canSendPoll_whenNotEnabled() {
+        // Given
+        let channelController = makeChannelController()
+        let viewModel = MessageComposerViewModel(
+            channelController: channelController,
+            messageController: nil
+        )
+
+        // When
+        let channelConfig = ChannelConfig(pollsEnabled: false)
+        channelController.channel_mock = .mock(
+            cid: .unique,
+            config: channelConfig,
+            ownCapabilities: [.sendPoll]
+        )
+
+        // Then
+        XCTAssertFalse(viewModel.canSendPoll)
+    }
+
+    func test_messageComposerVM_canSendPoll_whenInsideThread() {
+        // Given
+        let channelController = makeChannelController()
+        let messageController = ChatMessageControllerSUI_Mock.mock(
+            chatClient: chatClient,
+            cid: .unique,
+            messageId: .unique
+        )
+        let viewModel = MessageComposerViewModel(
+            channelController: channelController,
+            messageController: messageController
+        )
+
+        // When
+        let channelConfig = ChannelConfig(pollsEnabled: true)
+        channelController.channel_mock = .mock(
+            cid: .unique,
+            config: channelConfig,
+            ownCapabilities: [.sendPoll]
+        )
+
+        // Then
+        XCTAssertFalse(viewModel.canSendPoll)
+    }
+
     func test_addedAsset_extraData() {
         // Given
         let image = UIImage(systemName: "person")!


### PR DESCRIPTION
### 🔗 Issue Links

https://linear.app/stream/issue/IOS-728/polls-capability-handling

### 🎯 Goal

Handle canSendPoll capability when creating polls.

### 🧪 Manual Testing Notes

1. Open the Stream Dashboard
2. Disable poll capability in a channel
3. When opening the attachments actions
4. Should not show poll creation

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
