### PR TITLE
Fix accessibility button shapes shown in navigation link views

### DIFF
--- a/DemoAppSwiftUI/ChannelHeader/CustomChannelHeader.swift
+++ b/DemoAppSwiftUI/ChannelHeader/CustomChannelHeader.swift
@@ -78,6 +78,7 @@ struct CustomChannelModifier: ChannelListHeaderViewModifier {
             } label: {
                 EmptyView()
             }
+            .opacity(0) // Fixes showing accessibility button shape
 
             NavigationLink(isActive: $isNewChatShown) {
                 NewChatView(isNewChatShown: $isNewChatShown)
@@ -85,6 +86,7 @@ struct CustomChannelModifier: ChannelListHeaderViewModifier {
                 EmptyView()
             }
             .isDetailLink(UIDevice.current.userInterfaceIdiom == .pad)
+            .opacity(0) // Fixes showing accessibility button shape
             .alert(isPresented: $logoutAlertShown) {
                 Alert(
                     title: Text("Sign out"),

--- a/DemoAppSwiftUI/PinChannelHelpers.swift
+++ b/DemoAppSwiftUI/PinChannelHelpers.swift
@@ -169,6 +169,7 @@ struct DemoAppChatChannelNavigatableListItem<ChannelDestination: View>: View {
             } label: {
                 EmptyView()
             }
+            .opacity(0) // Fixes showing accessibility button shape
         }
     }
 

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelView.swift
@@ -134,6 +134,7 @@ public struct ChatChannelView<Factory: ViewFactory>: View, KeyboardReadable {
                     } label: {
                         EmptyView()
                     }
+                    .opacity(0) // Fixes showing accessibility button shape
                 }
                 .accentColor(colors.tintColor)
                 .overlay(

--- a/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelNavigatableListItem.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelNavigatableListItem.swift
@@ -61,6 +61,7 @@ public struct ChatChannelNavigatableListItem<Factory: ViewFactory, ChannelDestin
             } label: {
                 EmptyView()
             }
+            .opacity(0) // Fixes showing accessibility button shape
         }
     }
 

--- a/Sources/StreamChatSwiftUI/ChatChannelList/SearchResultsView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannelList/SearchResultsView.swift
@@ -113,6 +113,7 @@ struct SearchResultView<Factory: ViewFactory>: View {
             } label: {
                 EmptyView()
             }
+            .opacity(0) // Fixes showing accessibility button shape
         }
     }
 }

--- a/Sources/StreamChatSwiftUI/ChatThreadList/ChatThreadListNavigatableItem.swift
+++ b/Sources/StreamChatSwiftUI/ChatThreadList/ChatThreadListNavigatableItem.swift
@@ -44,6 +44,7 @@ public struct ChatThreadListNavigatableItem<ThreadListItem: View, ThreadDestinat
             } label: {
                 EmptyView()
             }
+            .opacity(0) // Fixes showing accessibility button shape
         }
         .foregroundColor(.black)
     }


### PR DESCRIPTION
### 🔗 Issue Links

https://github.com/GetStream/stream-chat-swiftui/issues/721
https://linear.app/stream/issue/IOS-658/unexpected-rounded-rectangle-under-message-composer-on-channel-screen

### 🎯 Goal

Fix accessibility button shapes shown in the composer as well as in the channel list.

### 🛠 Implementation

An opacity of 0 is set to the navigation link label (EmptyView) to make sure the button shape is not shown. 

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

| Before | After |
| ------ | ----- |
|   <img src="https://github.com/user-attachments/assets/54f48ee9-2454-4c86-b26a-a3fce93d7f60"/>  |  <img src="https://github.com/user-attachments/assets/873f257a-06f2-4ee2-96ec-634031021a11"/> |
|  ![Simulator Screenshot - iPhone 16 Pro - 2025-04-07 at 15 29 33](https://github.com/user-attachments/assets/df90635f-1065-4d70-9f40-2d546ca80173)   |  ![Simulator Screenshot - iPhone 16 Pro - 2025-04-07 at 15 28 56](https://github.com/user-attachments/assets/7fc8c6e4-0df1-428c-a877-905a90b5b886)  |


### 🧪 Manual Testing Notes

1. Open the Simulator
2. Go to Settings > Accessibility > Display & Text Size > Button Shapes
3. Enable the Button Shapes
4. Go to the Demo App
5. The Channel List should no display empty button shappes
6. Open a Channel or Thread
7. The composer should not display empty button shapes

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
