### PR TITLE
Added a method for configuring the channel alert type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### ✅ Added
 - Allow pasting images to the composer [#797](https://github.com/GetStream/stream-chat-swiftui/pull/797)
+- Add `ChatChannelListViewModel.setChannelAlertType` for setting the alert type [#801](https://github.com/GetStream/stream-chat-swiftui/pull/801)
 ### 🐞 Fixed
 - Fix allowing to send Polls when the current user does not have the capability [#798](https://github.com/GetStream/stream-chat-swiftui/pull/798)
 - Fix showing a double error indicator when sending attachments without any text [#799](https://github.com/GetStream/stream-chat-swiftui/pull/799)

--- a/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListViewModel.swift
@@ -202,7 +202,7 @@ open class ChatChannelListViewModel: ObservableObject, ChatChannelListController
     }
 
     public func onDeleteTapped(channel: ChatChannel) {
-        channelAlertType = .deleteChannel(channel)
+        setChannelAlertType(.deleteChannel(channel))
     }
 
     public func onMoreTapped(channel: ChatChannel) {
@@ -217,13 +217,17 @@ open class ChatChannelListViewModel: ObservableObject, ChatChannelListController
         controller.deleteChannel { [weak self] error in
             if error != nil {
                 // handle error
-                self?.channelAlertType = .error
+                self?.setChannelAlertType(.error)
             }
         }
     }
 
-    open func showErrorPopup(_ error: Error?) {
-        channelAlertType = .error
+    open func showErrorPopup(_ error: Error?) {        
+        setChannelAlertType(.error)
+    }
+    
+    open func setChannelAlertType(_ channelAlertType: ChannelAlertType) {
+        self.channelAlertType = channelAlertType
     }
 
     // MARK: - ChatChannelListControllerDelegate
@@ -328,7 +332,7 @@ open class ChatChannelListViewModel: ObservableObject, ChatChannelListController
             self.loading = false
             if error != nil {
                 // handle error
-                self.channelAlertType = .error
+                self.setChannelAlertType(.error)
             } else {
                 // access channels
                 self.updateChannels()

--- a/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListViewModel.swift
@@ -222,7 +222,7 @@ open class ChatChannelListViewModel: ObservableObject, ChatChannelListController
         }
     }
 
-    open func showErrorPopup(_ error: Error?) {        
+    open func showErrorPopup(_ error: Error?) {
         setChannelAlertType(.error)
     }
     

--- a/StreamChatSwiftUITests/Tests/ChatChannelList/ChatChannelListViewModel_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannelList/ChatChannelListViewModel_Tests.swift
@@ -110,7 +110,19 @@ class ChatChannelListViewModel_Tests: StreamChatTestCase {
         XCTAssert(viewModel.channelAlertType == .error)
         XCTAssert(viewModel.alertShown == true)
     }
-
+    
+    func test_channelListVM_setChannelAlertType() {
+        // Given
+        let viewModel = makeDefaultChannelListVM()
+        
+        // When
+        viewModel.setChannelAlertType(.error)
+        
+        // Then
+        XCTAssert(viewModel.channelAlertType == .error)
+        XCTAssert(viewModel.alertShown == true)
+    }
+    
     func test_channelListVM_nameForChannel() {
         // Given
         let expectedName = "test"


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-771/%5Bswiftui%5D%5Bcare%5D-make-channel-list-error-customizable.

### 🎯 Goal

Make it easier to configure the error popup in the channel list view.

### 📝 Summary

_Provide bullet points with the most important changes in the codebase._

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
