### PR TITLE
Add extra data to user display info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### ✅ Added
+- Add extra data to user display info [#819](https://github.com/GetStream/stream-chat-swiftui/pull/819)
 
 # [4.78.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.78.0)
 _April 24, 2025_

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/AddUsersView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/AddUsersView.swift
@@ -65,7 +65,8 @@ struct AddUsersView<Factory: ViewFactory>: View {
                                     id: user.id,
                                     name: user.name ?? "",
                                     imageURL: user.imageURL,
-                                    size: CGSize(width: itemSize, height: itemSize)
+                                    size: CGSize(width: itemSize, height: itemSize),
+                                    extraData: user.extraData
                                 )
                                 factory.makeMessageAvatarView(for: userDisplayInfo)
 

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/ChatChannelInfoHelperViews.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/ChatChannelInfoHelperViews.swift
@@ -264,7 +264,8 @@ struct ChatInfoDirectChannelView<Factory: ViewFactory>: View {
                 id: participant?.chatUser.id ?? "",
                 name: participant?.chatUser.name ?? "",
                 imageURL: participant?.chatUser.imageURL,
-                size: .init(width: 64, height: 64)
+                size: .init(width: 64, height: 64),
+                extraData: participant?.chatUser.extraData ?? [:]
             )
             factory.makeMessageAvatarView(for: displayInfo)
             

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/ChatInfoParticipantsView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/ChatInfoParticipantsView.swift
@@ -32,7 +32,8 @@ struct ChatInfoParticipantsView<Factory: ViewFactory>: View {
                     let displayInfo = UserDisplayInfo(
                         id: participant.chatUser.id,
                         name: participant.chatUser.name ?? "",
-                        imageURL: participant.chatUser.imageURL
+                        imageURL: participant.chatUser.imageURL,
+                        extraData: participant.chatUser.extraData
                     )
                     factory.makeMessageAvatarView(for: displayInfo)
 

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/MediaAttachmentsView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/MediaAttachmentsView.swift
@@ -83,7 +83,8 @@ public struct MediaAttachmentsView<Factory: ViewFactory>: View {
                                             id: mediaItem.message.author.id,
                                             name: mediaItem.message.author.name ?? "",
                                             imageURL: mediaItem.message.author.imageURL,
-                                            size: .init(width: 24, height: 24)
+                                            size: .init(width: 24, height: 24),
+                                            extraData: mediaItem.message.author.extraData
                                         )
                                     )
                                     .overlay(

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/PinnedMessagesView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/PinnedMessagesView.swift
@@ -71,7 +71,8 @@ struct PinnedMessageView<Factory: ViewFactory>: View {
                     id: message.author.id,
                     name: message.author.name ?? "",
                     imageURL: message.author.imageURL,
-                    size: avatarSize
+                    size: avatarSize,
+                    extraData: message.author.extraData
                 )
             )
 

--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/Polls/PollAttachmentView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/Polls/PollAttachmentView.swift
@@ -228,7 +228,8 @@ struct PollOptionView<Factory: ViewFactory>: View {
                                         id: vote.user?.id ?? "",
                                         name: vote.user?.name ?? "",
                                         imageURL: vote.user?.imageURL,
-                                        size: .init(width: 20, height: 20)
+                                        size: .init(width: 20, height: 20),
+                                        extraData: vote.user?.extraData ?? [:]
                                     )
                                 )
                             }

--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/Polls/PollCommentsView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/Polls/PollCommentsView.swift
@@ -43,7 +43,8 @@ struct PollCommentsView<Factory: ViewFactory>: View {
                                         let displayInfo = UserDisplayInfo(
                                             id: comment.user?.id ?? "",
                                             name: comment.user?.name ?? "",
-                                            imageURL: comment.user?.imageURL
+                                            imageURL: comment.user?.imageURL,
+                                            extraData: comment.user?.extraData ?? [:]
                                         )
                                         factory.makeMessageAvatarView(for: displayInfo)
                                     }

--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/Polls/PollResultsView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/Polls/PollResultsView.swift
@@ -113,7 +113,8 @@ struct PollOptionResultsView<Factory: ViewFactory>: View {
                                 id: vote.user?.id ?? "",
                                 name: vote.user?.name ?? "",
                                 imageURL: vote.user?.imageURL,
-                                size: .init(width: 20, height: 20)
+                                size: .init(width: 20, height: 20),
+                                extraData: vote.user?.extraData ?? [:]
                             )
                         )
                     }

--- a/Sources/StreamChatSwiftUI/Utils/MessageCachingUtils.swift
+++ b/Sources/StreamChatSwiftUI/Utils/MessageCachingUtils.swift
@@ -34,19 +34,22 @@ public struct UserDisplayInfo {
     public let imageURL: URL?
     public let role: UserRole?
     public let size: CGSize?
+    public let extraData: [String: RawJSON]
 
     public init(
         id: String,
         name: String,
         imageURL: URL?,
         role: UserRole? = nil,
-        size: CGSize? = nil
+        size: CGSize? = nil,
+        extraData: [String: RawJSON] = [:]
     ) {
         self.id = id
         self.name = name
         self.imageURL = imageURL
         self.role = role
         self.size = size
+        self.extraData = extraData
     }
 }
 
@@ -57,7 +60,8 @@ extension ChatMessage {
             id: author.id,
             name: author.name ?? author.id,
             imageURL: author.imageURL,
-            role: author.userRole
+            role: author.userRole,
+            extraData: author.extraData
         )
     }
 


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-830/add-extra-data-to-user-display-info.

### 🎯 Goal

Expose custom user data to the user display info.

### 📝 Summary

_Provide bullet points with the most important changes in the codebase._

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
