### PR TITLE
Fix mark unread action not removed when read events are disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### ✅ Added
 - Add extra data to user display info [#819](https://github.com/GetStream/stream-chat-swiftui/pull/819)
 ### 🐞 Fixed
-- Fix mark unread action not removed when read events are disabled #823
+- Fix mark unread action not removed when read events are disabled [#823](https://github.com/GetStream/stream-chat-swiftui/pull/823)
 
 # [4.78.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.78.0)
 _April 24, 2025_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### ✅ Added
 - Add extra data to user display info [#819](https://github.com/GetStream/stream-chat-swiftui/pull/819)
+### 🐞 Fixed
+- Fix mark unread action not removed when read events are disabled #823
 
 # [4.78.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.78.0)
 _April 24, 2025_

--- a/Sources/StreamChatSwiftUI/ChatChannel/Reactions/MessageActions/DefaultMessageActions.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Reactions/MessageActions/DefaultMessageActions.swift
@@ -131,7 +131,7 @@ public extension MessageAction {
                 )
                 messageActions.append(markThreadUnreadAction)
             }
-        } else if !message.isSentByCurrentUser {
+        } else if !message.isSentByCurrentUser && channel.canReceiveReadEvents {
             if !message.isPartOfThread || message.showReplyInChannel {
                 let markUnreadAction = markAsUnreadAction(
                     for: message,

--- a/StreamChatSwiftUITests/Tests/ChatChannel/MessageActionsViewModel_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/MessageActionsViewModel_Tests.swift
@@ -20,7 +20,7 @@ class MessageActionsViewModel_Tests: StreamChatTestCase {
                 text: "test",
                 author: .mock(id: .unique)
             ),
-            channel: .mockDMChannel(ownCapabilities: [.sendMessage, .uploadFile, .pinMessage]),
+            channel: .mockDMChannel(ownCapabilities: [.sendMessage, .uploadFile, .pinMessage, .readEvents]),
             chatClient: chatClient,
             onFinish: { _ in },
             onError: { _ in }

--- a/StreamChatSwiftUITests/Tests/ChatChannel/MessageActions_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/MessageActions_Tests.swift
@@ -72,7 +72,38 @@ class MessageActions_Tests: StreamChatTestCase {
         XCTAssert(messageActions[4].title == "Mark Unread")
         XCTAssert(messageActions[5].title == "Mute User")
     }
-    
+
+    func test_messageActions_otherUserDefaultReadEventsDisabled() {
+        // Given
+        let channel = ChatChannel.mockDMChannel(ownCapabilities: [.sendMessage, .uploadFile, .pinMessage])
+        let message = ChatMessage.mock(
+            id: .unique,
+            cid: channel.cid,
+            text: "Test",
+            author: .mock(id: .unique),
+            isSentByCurrentUser: false
+        )
+        let factory = DefaultViewFactory.shared
+
+        // When
+        let messageActions = MessageAction.defaultActions(
+            factory: factory,
+            for: message,
+            channel: channel,
+            chatClient: chatClient,
+            onFinish: { _ in },
+            onError: { _ in }
+        )
+
+        // Then
+        XCTAssert(messageActions.count == 5)
+        XCTAssert(messageActions[0].title == "Reply")
+        XCTAssert(messageActions[1].title == "Thread Reply")
+        XCTAssert(messageActions[2].title == "Pin to conversation")
+        XCTAssert(messageActions[3].title == "Copy Message")
+        XCTAssert(messageActions[4].title == "Mute User")
+    }
+
     func test_messageActions_otherUserDefaultBlockingEnabled() {
         // Given
         streamChat = StreamChat(
@@ -297,7 +328,7 @@ class MessageActions_Tests: StreamChatTestCase {
     
     private var mockDMChannel: ChatChannel {
         ChatChannel.mockDMChannel(
-            ownCapabilities: [.sendMessage, .uploadFile, .pinMessage]
+            ownCapabilities: [.sendMessage, .uploadFile, .pinMessage, .readEvents]
         )
     }
 }

--- a/StreamChatSwiftUITests/Tests/ChatChannel/ReactionsOverlayView_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/ReactionsOverlayView_Tests.swift
@@ -136,7 +136,7 @@ class ReactionsOverlayView_Tests: StreamChatTestCase {
         let view = VerticallyCenteredView {
             ReactionsOverlayView(
                 factory: DefaultViewFactory.shared,
-                channel: .mockDMChannel(ownCapabilities: [.sendMessage, .uploadFile, .pinMessage]),
+                channel: .mockDMChannel(ownCapabilities: [.sendMessage, .uploadFile, .pinMessage, .readEvents]),
                 currentSnapshot: self.overlayImage,
                 messageDisplayInfo: messageDisplayInfo,
                 onBackgroundTap: {},


### PR DESCRIPTION
### 🔗 Issue Links

https://linear.app/stream/issue/IOS-812/swiftui-mark-as-unread-feature-should-be-disabled-if-read-events-are

### 🎯 Goal

Fix mark unread action not removed when read events are disabled

### 🧪 Manual Testing Notes

1. Go to Stream Dashboard of SwiftUI Demo App
2. Go to Channel Types
3. Go to Messaging
4. Disable read events
5. Go to the Demo App
6. Long tap a message from another user
7. Should not have mark unread action

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
