### PR TITLE
Fix swipe to reply enabled when quoting a message is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### ✅ Added
 - Add extra data to user display info [#819](https://github.com/GetStream/stream-chat-swiftui/pull/819)
+### 🐞 Fixed
+- Fix swipe to reply enabled when quoting a message is disabled [#824](https://github.com/GetStream/stream-chat-swiftui/pull/824)
 
 # [4.78.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.78.0)
 _April 24, 2025_

--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageContainerView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageContainerView.swift
@@ -36,7 +36,7 @@ public struct MessageContainerView<Factory: ViewFactory>: View {
     private let paddingValue: CGFloat = 8
 
     var isSwipeToReplyPossible: Bool {
-        message.isInteractionEnabled && channel.config.repliesEnabled
+        message.isInteractionEnabled && channel.canQuoteMessage
     }
 
     public init(

--- a/StreamChatSwiftUITests/Tests/ChatChannel/MessageContainerView_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/MessageContainerView_Tests.swift
@@ -403,7 +403,7 @@ class MessageContainerView_Tests: StreamChatTestCase {
         waitForExpectations(timeout: 1)
     }
 
-    func test_isSwipeToReplyPossible_whenRepliesEnabled_whenMessageInteractable_shouldBeTrue() {
+    func test_isSwipeToReplyPossible_whenCanQuoteReply_whenMessageInteractable_shouldBeTrue() {
         let message = ChatMessage.mock(
             id: .unique,
             cid: .unique,
@@ -414,7 +414,7 @@ class MessageContainerView_Tests: StreamChatTestCase {
 
         let view = MessageContainerView(
             factory: DefaultViewFactory.shared,
-            channel: .mockDMChannel(config: .mock(repliesEnabled: true)),
+            channel: .mockDMChannel(ownCapabilities: [.quoteMessage]),
             message: message,
             width: defaultScreenSize.width,
             showsAllInfo: true,
@@ -428,7 +428,7 @@ class MessageContainerView_Tests: StreamChatTestCase {
         XCTAssertTrue(view.isSwipeToReplyPossible)
     }
 
-    func test_isSwipeToReplyPossible_whenRepliesDisabled_whenMessageInteractable_shouldBeFalse() {
+    func test_isSwipeToReplyPossible_whenCanNotQuoteReply_whenMessageInteractable_shouldBeFalse() {
         let message = ChatMessage.mock(
             id: .unique,
             cid: .unique,
@@ -439,7 +439,7 @@ class MessageContainerView_Tests: StreamChatTestCase {
 
         let view = MessageContainerView(
             factory: DefaultViewFactory.shared,
-            channel: .mockDMChannel(config: .mock(repliesEnabled: false)),
+            channel: .mockDMChannel(ownCapabilities: []),
             message: message,
             width: defaultScreenSize.width,
             showsAllInfo: true,
@@ -453,7 +453,7 @@ class MessageContainerView_Tests: StreamChatTestCase {
         XCTAssertFalse(view.isSwipeToReplyPossible)
     }
 
-    func test_isSwipeToReplyPossible_whenRepliesEnabled_whenMessageNotInteractable_shouldBeFalse() {
+    func test_isSwipeToReplyPossible_whenCanQuoteReply_whenMessageNotInteractable_shouldBeFalse() {
         let message = ChatMessage.mock(
             id: .unique,
             cid: .unique,
@@ -465,7 +465,7 @@ class MessageContainerView_Tests: StreamChatTestCase {
 
         let view = MessageContainerView(
             factory: DefaultViewFactory.shared,
-            channel: .mockDMChannel(config: .mock(repliesEnabled: true)),
+            channel: .mockDMChannel(ownCapabilities: [.quoteMessage]),
             message: message,
             width: defaultScreenSize.width,
             showsAllInfo: true,


### PR DESCRIPTION
### 🔗 Issue Links

https://linear.app/stream/issue/IOS-809/swipe-to-reply-does-not-work-if-threads-are-disabled-in-the-dashboard

### 🎯 Goal

Fix swipe to reply enabled when quoting a message is disabled

### 🧪 Manual Testing Notes

1. Go to Stream Dashboard of SwiftUI Demo App
2. Go to Channel Types
3. Go to Messaging
4. Disable Quotes
5. Go to the Demo App
6. Swipe to reply in a message should not work

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
