### PR TITLE
Fix user mentions not working when commands are disabled

### DIFF
--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerView.swift
@@ -192,20 +192,19 @@ public struct MessageComposerView<Factory: ViewFactory>: View, KeyboardReadable 
             }
         }
         .overlay(
-            viewModel.showCommandsOverlay ?
-                factory.makeCommandsContainerView(
-                    suggestions: viewModel.suggestions,
-                    handleCommand: { commandInfo in
-                        viewModel.handleCommand(
-                            for: $viewModel.text,
-                            selectedRangeLocation: $viewModel.selectedRangeLocation,
-                            command: $viewModel.composerCommand,
-                            extraData: commandInfo
-                        )
-                    }
-                )
-                .offset(y: -composerHeight)
-                .animation(nil) : nil,
+            factory.makeCommandsContainerView(
+                suggestions: suggestions,
+                handleCommand: { commandInfo in
+                    viewModel.handleCommand(
+                        for: $viewModel.text,
+                        selectedRangeLocation: $viewModel.selectedRangeLocation,
+                        command: $viewModel.composerCommand,
+                        extraData: commandInfo
+                    )
+                }
+            )
+            .offset(y: -composerHeight)
+            .animation(nil),
             alignment: .bottom
         )
         .modifier(factory.makeComposerViewModifier())
@@ -223,6 +222,14 @@ public struct MessageComposerView<Factory: ViewFactory>: View, KeyboardReadable 
             viewModel.updateDraftMessage(quotedMessage: quotedMessage)
         })
         .accessibilityElement(children: .contain)
+    }
+
+    var suggestions: [String: Any] {
+        var suggestions = viewModel.suggestions
+        if !viewModel.showCommandsOverlay {
+            suggestions.removeValue(forKey: "instantCommands")
+        }
+        return suggestions
     }
 }
 


### PR DESCRIPTION
### 🔗 Issue Links

https://linear.app/stream/issue/IOS-336/mentions-not-working-if-commands-disabled

### 🎯 Goal

Fix user mentions not working when commands are disabled

### 📝 Summary

I've tried multiple things, but this solution was the simplest one without breaking changes. But please let me know if there is a better one. The solution was tricky because in the SwiftUI SDK we are considering user mentions as a command, which is actually not correct. So, for now, if commands are disabled, we simply remove the "instantCommands" ID, but leave the "mentions" ID as part of the suggestions. Overall, the ID's approach is a bit fragile; we should improve this in the next major version.

Another problem I've noticed is that we don't really respect the commands from the Dashboard in relation to Mute and Unmute. The expected behaviour is that the Mute and Unmute commands should only be available if they come from the Dashboard. But at the moment, we use `channel.config.mutesEnabled` to insert these commands, so they will always be present in the composer, independent of the commands dashboard configuration. I did not change this because I'm not sure if this might break some customers.

### 🧪 Manual Testing Notes

1. Go to SwiftUI's Demo App Dashboard
2. Go to Channel Types > Messaging
3. Disable commands
4. Open the Demo App
5. Open a Channel
6. Write "/" in the composer
7. It should not show commands
8. Write "@", it should show user mentions

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
