### PR TITLE
Make message spacing in message list configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### ✅ Added
 - Add extra data to user display info [#819](https://github.com/GetStream/stream-chat-swiftui/pull/819)
+- Make message spacing in message list configurable [#830](https://github.com/GetStream/stream-chat-swiftui/pull/830)
 ### 🐞 Fixed
 - Fix swipe to reply enabled when quoting a message is disabled [#824](https://github.com/GetStream/stream-chat-swiftui/pull/824)
 - Fix mark unread action not removed when read events are disabled [#823](https://github.com/GetStream/stream-chat-swiftui/pull/823)

--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageContainerView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageContainerView.swift
@@ -34,10 +34,10 @@ public struct MessageContainerView<Factory: ViewFactory>: View {
 
     private let replyThreshold: CGFloat = 60
     private var paddingValue: CGFloat {
-        utils.messageListConfig.messageListItemSpacing
+        utils.messageListConfig.messagePaddings.singleBottom
     }
     private var groupMessageInterItemSpacing: CGFloat {
-        utils.messageListConfig.messageGroupItemSpacing
+        utils.messageListConfig.messagePaddings.groupBottom
     }
 
     var isSwipeToReplyPossible: Bool {

--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageContainerView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageContainerView.swift
@@ -33,7 +33,12 @@ public struct MessageContainerView<Factory: ViewFactory>: View {
     @GestureState private var offset: CGSize = .zero
 
     private let replyThreshold: CGFloat = 60
-    private let paddingValue: CGFloat = 8
+    private var paddingValue: CGFloat {
+        utils.messageListConfig.messageListItemSpacing
+    }
+    private var groupMessageInterItemSpacing: CGFloat {
+        utils.messageListConfig.messageGroupItemSpacing
+    }
 
     var isSwipeToReplyPossible: Bool {
         message.isInteractionEnabled && channel.canQuoteMessage
@@ -275,7 +280,7 @@ public struct MessageContainerView<Factory: ViewFactory>: View {
             topReactionsShown && !isMessagePinned ? messageListConfig.messageDisplayOptions.reactionsTopPadding(message) : 0
         )
         .padding(.horizontal, messageListConfig.messagePaddings.horizontal)
-        .padding(.bottom, showsAllInfo || isMessagePinned ? paddingValue : 2)
+        .padding(.bottom, showsAllInfo || isMessagePinned ? paddingValue : groupMessageInterItemSpacing)
         .padding(.top, isLast ? paddingValue : 0)
         .background(isMessagePinned ? Color(colors.pinnedBackground) : nil)
         .padding(.bottom, isMessagePinned ? paddingValue / 2 : 0)

--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageListConfig.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageListConfig.swift
@@ -35,7 +35,9 @@ public struct MessageListConfig {
         userBlockingEnabled: Bool = false,
         bouncedMessagesAlertActionsEnabled: Bool = true,
         skipEditedMessageLabel: @escaping (ChatMessage) -> Bool = { _ in false },
-        draftMessagesEnabled: Bool = false
+        draftMessagesEnabled: Bool = false,
+        messageListItemSpacing: CGFloat = 8,
+        messageGroupItemSpacing: CGFloat = 2
     ) {
         self.messageListType = messageListType
         self.typingIndicatorPlacement = typingIndicatorPlacement
@@ -64,6 +66,8 @@ public struct MessageListConfig {
         self.bouncedMessagesAlertActionsEnabled = bouncedMessagesAlertActionsEnabled
         self.skipEditedMessageLabel = skipEditedMessageLabel
         self.draftMessagesEnabled = draftMessagesEnabled
+        self.messageListItemSpacing = messageListItemSpacing
+        self.messageGroupItemSpacing = messageGroupItemSpacing
     }
 
     public let messageListType: MessageListType
@@ -102,6 +106,9 @@ public struct MessageListConfig {
     ///
     /// If enabled, the SDK will save the message content as a draft when the user navigates away from the composer.
     public let draftMessagesEnabled: Bool
+    
+    public let messageListItemSpacing: CGFloat
+    public let messageGroupItemSpacing: CGFloat
 }
 
 /// Contains information about the message paddings.

--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageListConfig.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageListConfig.swift
@@ -35,9 +35,7 @@ public struct MessageListConfig {
         userBlockingEnabled: Bool = false,
         bouncedMessagesAlertActionsEnabled: Bool = true,
         skipEditedMessageLabel: @escaping (ChatMessage) -> Bool = { _ in false },
-        draftMessagesEnabled: Bool = false,
-        messageListItemSpacing: CGFloat = 8,
-        messageGroupItemSpacing: CGFloat = 2
+        draftMessagesEnabled: Bool = false
     ) {
         self.messageListType = messageListType
         self.typingIndicatorPlacement = typingIndicatorPlacement
@@ -66,8 +64,6 @@ public struct MessageListConfig {
         self.bouncedMessagesAlertActionsEnabled = bouncedMessagesAlertActionsEnabled
         self.skipEditedMessageLabel = skipEditedMessageLabel
         self.draftMessagesEnabled = draftMessagesEnabled
-        self.messageListItemSpacing = messageListItemSpacing
-        self.messageGroupItemSpacing = messageGroupItemSpacing
     }
 
     public let messageListType: MessageListType
@@ -106,9 +102,6 @@ public struct MessageListConfig {
     ///
     /// If enabled, the SDK will save the message content as a draft when the user navigates away from the composer.
     public let draftMessagesEnabled: Bool
-    
-    public let messageListItemSpacing: CGFloat
-    public let messageGroupItemSpacing: CGFloat
 }
 
 /// Contains information about the message paddings.
@@ -117,13 +110,19 @@ public struct MessagePaddings {
     /// Horizontal padding for messages.
     public let horizontal: CGFloat
     public let quotedViewPadding: CGFloat
+    public let singleBottom: CGFloat
+    public let groupBottom: CGFloat
 
     public init(
         horizontal: CGFloat = 8,
-        quotedViewPadding: CGFloat = 8
+        quotedViewPadding: CGFloat = 8,
+        singleBottom: CGFloat = 8,
+        groupBottom: CGFloat = 2
     ) {
         self.horizontal = horizontal
         self.quotedViewPadding = quotedViewPadding
+        self.singleBottom = singleBottom
+        self.groupBottom = groupBottom
     }
 }
 


### PR DESCRIPTION
### 🔗 Issue Links

N/A

### 🎯 Goal

Make following spacings configurable:
- Spacing between messages in message list
- Spacing between messages in a message group

### 🛠 Implementation

Create new params for `MessageListConfig` to configure these spacings and use them in `MessageContainerView`.

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

| Default spacings | Configured spacings |
| ------ | ----- |
| ![Simulator Screenshot - iPhone 16 - 2025-05-14 at 14 45 37](https://github.com/user-attachments/assets/0a5cbb11-a265-4f8f-9ab1-1d1ce5b51a03) | ![Simulator Screenshot - iPhone 16 - 2025-05-14 at 14 44 54](https://github.com/user-attachments/assets/8b51b6f4-f481-4f32-a092-1a055ad6c78d) |

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo