### PR TITLE
Check canUpdateAnyMessage and canUpdateOwnMessage permissions for edit message action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix swipe to reply enabled when quoting a message is disabled [#824](https://github.com/GetStream/stream-chat-swiftui/pull/824)
 - Fix mark unread action not removed when read events are disabled [#823](https://github.com/GetStream/stream-chat-swiftui/pull/823)
 - Fix user mentions not working when commands are disabled [#826](https://github.com/GetStream/stream-chat-swiftui/pull/826)
+- Fix hiding edit message action when no update message permissions [#835](https://github.com/GetStream/stream-chat-swiftui/pull/835)
 
 # [4.78.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.78.0)
 _April 24, 2025_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix swipe to reply enabled when quoting a message is disabled [#824](https://github.com/GetStream/stream-chat-swiftui/pull/824)
 - Fix mark unread action not removed when read events are disabled [#823](https://github.com/GetStream/stream-chat-swiftui/pull/823)
 - Fix user mentions not working when commands are disabled [#826](https://github.com/GetStream/stream-chat-swiftui/pull/826)
-- Fix hiding edit message action when no update message permissions [#835](https://github.com/GetStream/stream-chat-swiftui/pull/835)
+- Fix edit message action shown when user does not have permissions [#835](https://github.com/GetStream/stream-chat-swiftui/pull/835)
 
 # [4.78.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.78.0)
 _April 24, 2025_

--- a/Sources/StreamChatSwiftUI/ChatChannel/Reactions/MessageActions/DefaultMessageActions.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Reactions/MessageActions/DefaultMessageActions.swift
@@ -145,8 +145,8 @@ public extension MessageAction {
             }
         }
 
-        if message.isSentByCurrentUser {
-            if message.poll == nil && message.giphyAttachments.isEmpty {
+        if message.poll == nil, message.giphyAttachments.isEmpty {
+            if channel.canUpdateAnyMessage || channel.canUpdateOwnMessage && message.isSentByCurrentUser {
                 let editAction = editMessageAction(
                     for: message,
                     channel: channel,
@@ -154,7 +154,9 @@ public extension MessageAction {
                 )
                 messageActions.append(editAction)
             }
-
+        }
+        
+        if message.isSentByCurrentUser {
             let deleteAction = deleteMessageAction(
                 for: message,
                 channel: channel,

--- a/StreamChatSwiftUITests/Tests/ChatChannel/MessageActions_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/MessageActions_Tests.swift
@@ -323,12 +323,64 @@ class MessageActions_Tests: StreamChatTestCase {
         XCTAssertEqual(messageActions[3].title, "Copy Message")
         XCTAssertEqual(messageActions[4].title, "Delete Message")
     }
+    
+    func test_messageActions_currentUser_editingDisabledWhenNoUpdateCapabilities() {
+        // Given
+        let channel = ChatChannel.mockDMChannel(ownCapabilities: [])
+        let message = ChatMessage.mock(
+            id: .unique,
+            cid: channel.cid,
+            text: "Test",
+            author: .mock(id: chatClient.currentUserId!),
+            isSentByCurrentUser: true
+        )
+        let factory = DefaultViewFactory.shared
+        
+        // When
+        let messageActions = MessageAction.defaultActions(
+            factory: factory,
+            for: message,
+            channel: channel,
+            chatClient: chatClient,
+            onFinish: { _ in },
+            onError: { _ in }
+        )
+        
+        // Then
+        XCTAssertFalse(messageActions.contains(where: { $0.title == "Edit Message" }))
+    }
+    
+    func test_messageActions_otherUser_editingEnabledWhenUpdateAnyMessageCapability() {
+        // Given
+        let channel = ChatChannel.mockDMChannel(ownCapabilities: [.updateAnyMessage])
+        let message = ChatMessage.mock(
+            id: .unique,
+            cid: channel.cid,
+            text: "Test",
+            author: .mock(id: .unique),
+            isSentByCurrentUser: false
+        )
+        let factory = DefaultViewFactory.shared
+        
+        // When
+        let messageActions = MessageAction.defaultActions(
+            factory: factory,
+            for: message,
+            channel: channel,
+            chatClient: chatClient,
+            onFinish: { _ in },
+            onError: { _ in }
+        )
+        
+        // Then
+        XCTAssertTrue(messageActions.contains(where: { $0.title == "Edit Message" }))
+    }
 
     // MARK: - Private
     
     private var mockDMChannel: ChatChannel {
         ChatChannel.mockDMChannel(
-            ownCapabilities: [.sendMessage, .uploadFile, .pinMessage, .readEvents]
+            ownCapabilities: [.updateOwnMessage, .sendMessage, .uploadFile, .pinMessage, .readEvents]
         )
     }
 }


### PR DESCRIPTION
### 🔗 Issue Links

Resolves [IOS-850](https://linear.app/stream/issue/IOS-850)

### 🎯 Goal

* Fix an issue where edit message action was shown although there were no permissions

### 📝 Summary

Check channel permissions before adding edit message action 

### 🛠 Implementation

Check channel permissions for edit message action. Note that there is `canUpdateAnyMessage` and `canUpdateOwnMessage`.

### 🎨 Showcase

### 🧪 Manual Testing Notes

N/A

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
