### PR TITLE
Add view factory methods for customising headers in GalleryView and VideoPlayerView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add `MessageViewModel` to `MessageContainerView` to make it easier to customise presentation logic [#815](https://github.com/GetStream/stream-chat-swiftui/pull/815)
 - Add `MessageListConfig.messaeDisplayOptions.showOriginalTranslatedButton` to enable showing original text in translated message [#815](https://github.com/GetStream/stream-chat-swiftui/pull/815)
 - Add `Utils.originalTranslationsStore` to keep track of messages that should show the original text [#815](https://github.com/GetStream/stream-chat-swiftui/pull/815)
+- Add `ViewFactory.makeGalleryHeaderView` for customising header view in `GalleryView` [#837](https://github.com/GetStream/stream-chat-swiftui/pull/837)
+- Add `ViewFactory.makeVideoPlayerHeaderView` for customising header view in `VideoPlayerView` [#837](https://github.com/GetStream/stream-chat-swiftui/pull/837)
 ### 🐞 Fixed
 - Fix swipe to reply enabled when quoting a message is disabled [#824](https://github.com/GetStream/stream-chat-swiftui/pull/824)
 - Fix mark unread action not removed when read events are disabled [#823](https://github.com/GetStream/stream-chat-swiftui/pull/823)

--- a/Sources/StreamChatSwiftUI/ChatChannel/Gallery/GalleryView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Gallery/GalleryView.swift
@@ -7,7 +7,7 @@ import StreamChat
 import SwiftUI
 
 /// View used for displaying image attachments in a gallery.
-public struct GalleryView: View {
+public struct GalleryView<Factory: ViewFactory>: View {
 
     @Environment(\.presentationMode) var presentationMode
 
@@ -15,6 +15,7 @@ public struct GalleryView: View {
     @Injected(\.fonts) private var fonts
     @Injected(\.images) private var images
 
+    private let viewFactory: Factory
     var mediaAttachments: [MediaAttachment]
     var author: ChatUser
     @Binding var isShown: Bool
@@ -23,6 +24,7 @@ public struct GalleryView: View {
     @State private var gridShown = false
 
     public init(
+        viewFactory: Factory = DefaultViewFactory.shared,
         imageAttachments: [ChatMessageImageAttachment],
         author: ChatUser,
         isShown: Binding<Bool>,
@@ -30,6 +32,7 @@ public struct GalleryView: View {
     ) {
         let mediaAttachments = imageAttachments.map { MediaAttachment(from: $0) }
         self.init(
+            viewFactory: viewFactory,
             mediaAttachments: mediaAttachments,
             author: author,
             isShown: isShown,
@@ -38,11 +41,13 @@ public struct GalleryView: View {
     }
     
     public init(
+        viewFactory: Factory = DefaultViewFactory.shared,
         mediaAttachments: [MediaAttachment],
         author: ChatUser,
         isShown: Binding<Bool>,
         selected: Int
     ) {
+        self.viewFactory = viewFactory
         self.mediaAttachments = mediaAttachments
         self.author = author
         _isShown = isShown
@@ -52,10 +57,10 @@ public struct GalleryView: View {
     public var body: some View {
         GeometryReader { reader in
             VStack {
-                GalleryHeaderView(
+                viewFactory.makeGalleryHeaderView(
                     title: author.name ?? "",
                     subtitle: author.onlineText,
-                    isShown: $isShown
+                    shown: $isShown
                 )
 
                 TabView(selection: $selected) {

--- a/Sources/StreamChatSwiftUI/ChatChannel/Gallery/VideoPlayerView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Gallery/VideoPlayerView.swift
@@ -7,7 +7,7 @@ import StreamChat
 import SwiftUI
 
 /// View used for displaying videos.
-public struct VideoPlayerView: View {
+public struct VideoPlayerView<Factory: ViewFactory>: View {
     @Environment(\.presentationMode) var presentationMode
 
     @Injected(\.fonts) private var fonts
@@ -18,6 +18,7 @@ public struct VideoPlayerView: View {
         utils.fileCDN
     }
 
+    private let viewFactory: Factory
     let attachment: ChatMessageVideoAttachment
     let author: ChatUser
     @Binding var isShown: Bool
@@ -26,10 +27,12 @@ public struct VideoPlayerView: View {
     @State private var error: Error?
 
     public init(
+        viewFactory: Factory = DefaultViewFactory.shared,
         attachment: ChatMessageVideoAttachment,
         author: ChatUser,
         isShown: Binding<Bool>
     ) {
+        self.viewFactory = viewFactory
         self.attachment = attachment
         self.author = author
         _isShown = isShown
@@ -37,10 +40,10 @@ public struct VideoPlayerView: View {
 
     public var body: some View {
         VStack {
-            GalleryHeaderView(
+            viewFactory.makeVideoPlayerHeaderView(
                 title: author.name ?? "",
                 subtitle: author.onlineText,
-                isShown: $isShown
+                shown: $isShown
             )
             if let avPlayer {
                 VideoPlayer(player: avPlayer)

--- a/Sources/StreamChatSwiftUI/DefaultViewFactory.swift
+++ b/Sources/StreamChatSwiftUI/DefaultViewFactory.swift
@@ -460,11 +460,20 @@ extension ViewFactory {
         options: MediaViewsOptions
     ) -> some View {
         GalleryView(
+            viewFactory: self,
             mediaAttachments: mediaAttachments,
             author: message.author,
             isShown: isShown,
             selected: options.selectedIndex
         )
+    }
+    
+    public func makeGalleryHeaderView(
+        title: String,
+        subtitle: String,
+        shown: Binding<Bool>
+    ) -> some View {
+        GalleryHeaderView(title: title, subtitle: subtitle, isShown: shown)
     }
     
     public func makeVideoPlayerView(
@@ -474,10 +483,19 @@ extension ViewFactory {
         options: MediaViewsOptions
     ) -> some View {
         VideoPlayerView(
+            viewFactory: self,
             attachment: attachment,
             author: message.author,
             isShown: isShown
         )
+    }
+    
+    public func makeVideoPlayerHeaderView(
+        title: String,
+        subtitle: String,
+        shown: Binding<Bool>
+    ) -> some View {
+        GalleryHeaderView(title: title, subtitle: subtitle, isShown: shown)
     }
     
     public func makeDeletedMessageView(

--- a/Sources/StreamChatSwiftUI/ViewFactory.swift
+++ b/Sources/StreamChatSwiftUI/ViewFactory.swift
@@ -464,6 +464,19 @@ public protocol ViewFactory: AnyObject {
         options: MediaViewsOptions
     ) -> GalleryViewType
     
+    associatedtype GalleryHeaderViewType: View
+    /// Creates the gallery header view presented with a sheet.
+    /// - Parameters:
+    ///  - title: The title displayed in the header.
+    ///  - subtitle: The subtitle displayed in the header.
+    ///  - shown: Binding controlling whether the gallery is shown.
+    /// - Returns: View displayed in the gallery header slot.
+    func makeGalleryHeaderView(
+        title: String,
+        subtitle: String,
+        shown: Binding<Bool>
+    ) -> GalleryHeaderViewType
+    
     associatedtype VideoPlayerViewType: View
     /// Creates the video player view.
     /// - Parameters:
@@ -478,6 +491,19 @@ public protocol ViewFactory: AnyObject {
         isShown: Binding<Bool>,
         options: MediaViewsOptions
     ) -> VideoPlayerViewType
+    
+    associatedtype VideoPlayerHeaderViewType: View
+    /// Creates the video player header view presented with a sheet.
+    /// - Parameters:
+    ///  - title: The title displayed in the header.
+    ///  - subtitle: The subtitle displayed in the header.
+    ///  - shown: Binding controlling whether the video player is shown.
+    /// - Returns: View displayed in the video player header slot.
+    func makeVideoPlayerHeaderView(
+        title: String,
+        subtitle: String,
+        shown: Binding<Bool>
+    ) -> VideoPlayerHeaderViewType
 
     associatedtype DeletedMessageViewType: View
     /// Creates the deleted message view.

--- a/StreamChatSwiftUITests/Tests/Utils/ViewFactory_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/Utils/ViewFactory_Tests.swift
@@ -985,6 +985,21 @@ class ViewFactory_Tests: StreamChatTestCase {
         XCTAssert(view is GalleryView<DefaultViewFactory>)
     }
     
+    func test_viewFactory_makeGalleryHeaderView() {
+        // Given
+        let viewFactory = DefaultViewFactory.shared
+        
+        // When
+        let view = viewFactory.makeGalleryHeaderView(
+            title: .unique,
+            subtitle: .unique,
+            shown: .constant(true)
+        )
+            
+        // Then
+        XCTAssert(view is GalleryHeaderView)
+    }
+    
     func test_viewFactory_makeVideoPlayerView() {
         // Given
         let viewFactory = DefaultViewFactory.shared
@@ -999,6 +1014,21 @@ class ViewFactory_Tests: StreamChatTestCase {
             
         // Then
         XCTAssert(view is VideoPlayerView<DefaultViewFactory>)
+    }
+    
+    func test_viewFactory_makeVideoPlayerHeaderView() {
+        // Given
+        let viewFactory = DefaultViewFactory.shared
+        
+        // When
+        let view = viewFactory.makeVideoPlayerHeaderView(
+            title: .unique,
+            subtitle: .unique,
+            shown: .constant(true)
+        )
+            
+        // Then
+        XCTAssert(view is GalleryHeaderView)
     }
 }
 

--- a/StreamChatSwiftUITests/Tests/Utils/ViewFactory_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/Utils/ViewFactory_Tests.swift
@@ -982,7 +982,7 @@ class ViewFactory_Tests: StreamChatTestCase {
         )
             
         // Then
-        XCTAssert(view is GalleryView)
+        XCTAssert(view is GalleryView<DefaultViewFactory>)
     }
     
     func test_viewFactory_makeVideoPlayerView() {
@@ -998,7 +998,7 @@ class ViewFactory_Tests: StreamChatTestCase {
         )
             
         // Then
-        XCTAssert(view is VideoPlayerView)
+        XCTAssert(view is VideoPlayerView<DefaultViewFactory>)
     }
 }
 


### PR DESCRIPTION
### 🔗 Issue Links

Resolves: [IOS-880](https://linear.app/stream/issue/IOS-880)

### 🎯 Goal

* Enable customising headers in `GalleryView` and `VideoPlayerView`

### 📝 Summary

* Add view factory methods for creating `GalleryHeaderView` in `GalleryView` and `VideoPlayerView`

### 🛠 Implementation

### 🧪 Manual Testing Notes

N/A

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
