### PR TITLE
Fix `ChatChannelView` keyboard background not using color from palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### 🐞 Fixed
+- Fix `ChatChannelView` keyboard background not using color from palette [#845](https://github.com/GetStream/stream-chat-swiftui/pull/845)
 
 # [4.79.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.79.0)
 _May 29, 2025_

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelView.swift
@@ -190,11 +190,9 @@ public struct ChatChannelView<Factory: ViewFactory>: View, KeyboardReadable {
             }
         })
         .background(
-            isIphone ?
-                Color(colors.background)
+            Color(colors.background)
                 .ignoresSafeArea(.keyboard)
                 .allowsHitTesting(false)
-                : nil
         ).background(
             TabBarAccessor { _ in
                 self.tabBarAvailable = utils.messageListConfig.handleTabBarVisibility

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelView.swift
@@ -191,13 +191,14 @@ public struct ChatChannelView<Factory: ViewFactory>: View, KeyboardReadable {
         })
         .background(
             isIphone ?
-                Color.clear.background(
-                    TabBarAccessor { _ in
-                        self.tabBarAvailable = utils.messageListConfig.handleTabBarVisibility
-                    }
-                )
+                Color(colors.background)
+                .ignoresSafeArea(.keyboard)
                 .allowsHitTesting(false)
                 : nil
+        ).background(
+            TabBarAccessor { _ in
+                self.tabBarAvailable = utils.messageListConfig.handleTabBarVisibility
+            }
         )
         .padding(.bottom, keyboardShown || !tabBarAvailable || generatingSnapshot ? 0 : bottomPadding)
         .ignoresSafeArea(.container, edges: tabBarAvailable ? .bottom : [])

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelView.swift
@@ -190,13 +190,13 @@ public struct ChatChannelView<Factory: ViewFactory>: View, KeyboardReadable {
             }
         })
         .background(
-            Color(colors.background)
-                .ignoresSafeArea(.keyboard)
-                .allowsHitTesting(false)
-        ).background(
-            TabBarAccessor { _ in
-                self.tabBarAvailable = utils.messageListConfig.handleTabBarVisibility
-            }
+            Color(colors.background).background(
+                TabBarAccessor { _ in
+                    self.tabBarAvailable = utils.messageListConfig.handleTabBarVisibility
+                }
+            )
+            .ignoresSafeArea(.keyboard)
+            .allowsHitTesting(false)
         )
         .padding(.bottom, keyboardShown || !tabBarAvailable || generatingSnapshot ? 0 : bottomPadding)
         .ignoresSafeArea(.container, edges: tabBarAvailable ? .bottom : [])


### PR DESCRIPTION
### 🔗 Issue Links

IOS-852

### 🎯 Goal

- Fix ChatChannelView keyboard background not using color from palette

### 🧪 Manual Testing Notes

N/A

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
