### PR TITLE
[CI] Bump snapshot version after every release

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,7 +26,7 @@ GEM
     ast (2.4.3)
     atomos (0.1.3)
     aws-eventstream (1.4.0)
-    aws-partitions (1.1112.0)
+    aws-partitions (1.1114.0)
     aws-sdk-core (3.225.1)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
@@ -34,7 +34,7 @@ GEM
       base64
       jmespath (~> 1, >= 1.6.1)
       logger
-    aws-sdk-kms (1.103.0)
+    aws-sdk-kms (1.104.0)
       aws-sdk-core (~> 3, >= 3.225.0)
       aws-sigv4 (~> 1.5)
     aws-sdk-s3 (1.189.0)
@@ -159,7 +159,7 @@ GEM
     faraday_middleware (1.2.1)
       faraday (~> 1.0)
     fastimage (2.4.0)
-    fastlane (2.227.2)
+    fastlane (2.228.0)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.8, < 3.0.0)
       artifactory (~> 3.0)
@@ -207,7 +207,7 @@ GEM
       fastlane
       pry
     fastlane-plugin-sonarcloud_metric_kit (0.2.1)
-    fastlane-plugin-stream_actions (0.3.82)
+    fastlane-plugin-stream_actions (0.3.83)
       xctest_list (= 1.2.1)
     fastlane-plugin-versioning (0.7.1)
     fastlane-sirp (1.0.0)
@@ -284,7 +284,7 @@ GEM
     mutex_m (0.3.0)
     nanaimo (0.4.0)
     nap (1.1.0)
-    naturally (2.2.1)
+    naturally (2.2.2)
     netrc (0.11.0)
     nio4r (2.7.4)
     nkf (0.2.0)
@@ -342,7 +342,7 @@ GEM
       rubocop-ast (>= 1.23.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.45.0)
+    rubocop-ast (1.45.1)
       parser (>= 3.3.7.2)
       prism (~> 1.4)
     rubocop-performance (1.19.1)
@@ -421,7 +421,7 @@ DEPENDENCIES
   fastlane-plugin-create_xcframework
   fastlane-plugin-lizard
   fastlane-plugin-sonarcloud_metric_kit
-  fastlane-plugin-stream_actions (= 0.3.82)
+  fastlane-plugin-stream_actions (= 0.3.83)
   fastlane-plugin-versioning
   json
   plist

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -116,7 +116,7 @@ lane :merge_main do
   update_release_version_to_snapshot(file_path: swift_environment_path)
   ensure_git_branch(branch: 'develop')
   sh("git add #{swift_environment_path}")
-  sh("git commit -m 'Update release version to snapshot")
+  sh("git commit -m 'Update release version to snapshot'")
   sh('git push')
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -77,7 +77,6 @@ end
 
 desc 'Release a new version'
 lane :release do |options|
-  previous_version_number = last_git_tag
   artifacts_path = File.absolute_path('../StreamChatSwiftUIArtifacts.json')
   extra_changes = lambda do |release_version|
     # Set the framework version on the artifacts
@@ -86,7 +85,9 @@ lane :release do |options|
     File.write(artifacts_path, JSON.dump(artifacts))
 
     # Set the framework version in SystemEnvironment+Version.swift
-    new_content = File.read(swift_environment_path).gsub!(previous_version_number, release_version).gsub('-SNAPSHOT', '')
+    old_content = File.read(swift_environment_path)
+    current_version = old_content[/version: String = "([^"]+)"/, 1]
+    new_content = old_content.gsub(current_version, release_version)
     File.open(swift_environment_path, 'w') { |f| f.puts(new_content) }
 
     # Update sdk sizes
@@ -112,11 +113,10 @@ end
 
 lane :merge_main do
   merge_main_to_develop
-  current_version = get_sdk_version_from_environment
-  add_snapshot_to_current_version(file_path: swift_environment_path)
+  update_release_version_to_snapshot(file_path: swift_environment_path)
   ensure_git_branch(branch: 'develop')
   sh("git add #{swift_environment_path}")
-  sh("git commit -m 'Add snapshot postfix to v#{current_version}'")
+  sh("git commit -m 'Update release version to snapshot")
   sh('git push')
 end
 

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -5,4 +5,4 @@
 gem 'fastlane-plugin-versioning'
 gem 'fastlane-plugin-sonarcloud_metric_kit'
 gem 'fastlane-plugin-create_xcframework'
-gem 'fastlane-plugin-stream_actions', '0.3.82'
+gem 'fastlane-plugin-stream_actions', '0.3.83'


### PR DESCRIPTION
### 🔗 Issue Links

Resolve https://linear.app/stream/issue/IOS-891

### 🎯 Goal

To avoid an issue when AppStore version locks a TestFlight version

### 📝 Summary

|  Before  |  After  |
| -------- | ------- |
|  We used to add a `-SNAPSHOT` postfix to already released version and push it to `develop`.   |  This PR introduces a new approach -  to bump a minor version of an already released version, add a `-SNAPSHOT` postfix and push it to `develop`.  |

### ⚠️ Warning

One time `bundle install` from this branch (or from develop after this PR is merged) is required to be able to release locally next time.

### 🎁 Meme

![gif](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExeXRoZDYxa2hnMHFwYWppaHVienFiYzg3MDA4YTYyNmpoY2drY3k0aiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/mFoCzfWhZmMmf0HMsQ/giphy.gif)
