### PR TITLE
Fix crash in ChannelAvatarsMerger when accessing shared properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ _June 03, 2025_
 ### 🐞 Fixed
 - Fix `ChatChannelView` keyboard background not using color from palette [#845](https://github.com/GetStream/stream-chat-swiftui/pull/845)
 - Fix removing new messages separator when scrolling in the channel view [#846](https://github.com/GetStream/stream-chat-swiftui/pull/846)
+- Fix rare crashes in `ChannelAvatarsMerger` [#858](https://github.com/GetStream/stream-chat-swiftui/pull/858)
 
 # [4.79.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.79.0)
 _May 29, 2025_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### 🐞 Fixed
+- Fix rare crashes in `ChannelAvatarsMerger` [#858](https://github.com/GetStream/stream-chat-swiftui/pull/858)
 
 # [4.79.1](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.79.1)
 _June 03, 2025_
@@ -11,7 +12,6 @@ _June 03, 2025_
 ### 🐞 Fixed
 - Fix `ChatChannelView` keyboard background not using color from palette [#845](https://github.com/GetStream/stream-chat-swiftui/pull/845)
 - Fix removing new messages separator when scrolling in the channel view [#846](https://github.com/GetStream/stream-chat-swiftui/pull/846)
-- Fix rare crashes in `ChannelAvatarsMerger` [#858](https://github.com/GetStream/stream-chat-swiftui/pull/858)
 
 # [4.79.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.79.0)
 _May 29, 2025_

--- a/Sources/StreamChatSwiftUI/ChatChannelList/ChannelAvatarsMerger.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannelList/ChannelAvatarsMerger.swift
@@ -21,14 +21,14 @@ public class ChannelAvatarsMerger: ChannelAvatarsMerging {
     @Injected(\.images) private var images
 
     /// Context provided utils.
-    private lazy var imageProcessor = utils.imageProcessor
-    private lazy var imageMerger = utils.imageMerger
+    private var imageProcessor: ImageProcessor { utils.imageProcessor }
+    private var imageMerger: ImageMerging { utils.imageMerger }
 
     /// Placeholder images.
-    private lazy var placeholder1 = images.userAvatarPlaceholder1
-    private lazy var placeholder2 = images.userAvatarPlaceholder2
-    private lazy var placeholder3 = images.userAvatarPlaceholder3
-    private lazy var placeholder4 = images.userAvatarPlaceholder4
+    private var placeholder1: UIImage { images.userAvatarPlaceholder1 }
+    private var placeholder2: UIImage { images.userAvatarPlaceholder2 }
+    private var placeholder3: UIImage { images.userAvatarPlaceholder3 }
+    private var placeholder4: UIImage { images.userAvatarPlaceholder4 }
 
     /// Creates a merged avatar from the given images
     /// - Parameter avatars: The individual avatars

--- a/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelSwipeableListItem.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelSwipeableListItem.swift
@@ -14,6 +14,9 @@ public struct ChatChannelSwipeableListItem<Factory: ViewFactory, ChannelListItem
 
     @GestureState private var offset: CGSize = .zero
 
+    /// The channel id of the swipable item.
+    ///
+    /// - Note: Setting this to nil will reset the swiped state.
     @Binding var swipedChannelId: String?
 
     private let numberOfTrailingItems: Int

--- a/StreamChatSwiftUI.xcodeproj/project.pbxproj
+++ b/StreamChatSwiftUI.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		402C54482B6AAC0100672BFB /* StreamChatSwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8465FBB52746873A00AF091E /* StreamChatSwiftUI.framework */; };
 		402C54492B6AAC0100672BFB /* StreamChatSwiftUI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8465FBB52746873A00AF091E /* StreamChatSwiftUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		4F03F18F2E0140C6001C71A2 /* ChannelAvatarsMerger_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F03F18E2E0140C6001C71A2 /* ChannelAvatarsMerger_Tests.swift */; };
 		4F077EF82C85E05700F06D83 /* DelayedRenderingViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F077EF72C85E05700F06D83 /* DelayedRenderingViewModifier.swift */; };
 		4F198FDD2C0480EC00148F49 /* Publisher+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F198FDC2C0480EC00148F49 /* Publisher+Extensions.swift */; };
 		4F65F1862D06EEA7009F69A8 /* ChooseChannelQueryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F65F1852D06EEA5009F69A8 /* ChooseChannelQueryView.swift */; };
@@ -610,6 +611,7 @@
 
 /* Begin PBXFileReference section */
 		4A65451E274BA170003C5FA8 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		4F03F18E2E0140C6001C71A2 /* ChannelAvatarsMerger_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelAvatarsMerger_Tests.swift; sourceTree = "<group>"; };
 		4F077EF72C85E05700F06D83 /* DelayedRenderingViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DelayedRenderingViewModifier.swift; sourceTree = "<group>"; };
 		4F198FDC2C0480EC00148F49 /* Publisher+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+Extensions.swift"; sourceTree = "<group>"; };
 		4F65F1852D06EEA5009F69A8 /* ChooseChannelQueryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChooseChannelQueryView.swift; sourceTree = "<group>"; };
@@ -2020,17 +2022,18 @@
 		84C94C7D27567CC2007FE2B9 /* ChatChannelList */ = {
 			isa = PBXGroup;
 			children = (
-				84C94C7F27567D3F007FE2B9 /* ChatChannelListViewModel_Tests.swift */,
-				84C94D432757C704007FE2B9 /* MoreChannelActionsViewModel_Tests.swift */,
+				4F03F18E2E0140C6001C71A2 /* ChannelAvatarsMerger_Tests.swift */,
 				84C94D67275A6AFD007FE2B9 /* ChannelHeaderLoader_Tests.swift */,
+				849894942AD96CCC004ACB41 /* ChatChannelListItemView_Tests.swift */,
 				84C94D412757C16D007FE2B9 /* ChatChannelListTestHelpers.swift */,
 				848399EB275FB41B003075E4 /* ChatChannelListView_Tests.swift */,
-				84DEC8DA27609FA200172876 /* MoreChannelActionsView_Tests.swift */,
+				84C94C7F27567D3F007FE2B9 /* ChatChannelListViewModel_Tests.swift */,
+				84D6B55927DF6EC7009C6D07 /* LoadingView_Tests.swift */,
 				91B763A5283EB39600B458A9 /* MoreChannelActionsFullScreenWrappingView_Tests.swift */,
+				84DEC8DA27609FA200172876 /* MoreChannelActionsView_Tests.swift */,
+				84C94D432757C704007FE2B9 /* MoreChannelActionsViewModel_Tests.swift */,
 				84DEC8DC2760A10500172876 /* NoChannelsView_Tests.swift */,
 				8413D90127A9654600A89432 /* SearchResultsView_Tests.swift */,
-				84D6B55927DF6EC7009C6D07 /* LoadingView_Tests.swift */,
-				849894942AD96CCC004ACB41 /* ChatChannelListItemView_Tests.swift */,
 			);
 			path = ChatChannelList;
 			sourceTree = "<group>";
@@ -3082,6 +3085,7 @@
 				84C94D66275A660B007FE2B9 /* MessageActionsViewModel_Tests.swift in Sources */,
 				84C94D0827578BF2007FE2B9 /* MockFunc.swift in Sources */,
 				84B2B5CA281947E100479CEE /* ViewFrameUtils.swift in Sources */,
+				4F03F18F2E0140C6001C71A2 /* ChannelAvatarsMerger_Tests.swift in Sources */,
 				8423C342277CBA280092DCF1 /* TypingSuggester_Tests.swift in Sources */,
 				84507C9A281ACCD70081DDC2 /* AddUsersView_Tests.swift in Sources */,
 				4F8D64402DDDCF9300026C09 /* MessageRelativeDateFormatter_Tests.swift in Sources */,

--- a/StreamChatSwiftUITests/Tests/ChatChannelList/ChannelAvatarsMerger_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannelList/ChannelAvatarsMerger_Tests.swift
@@ -1,0 +1,35 @@
+//
+// Copyright © 2025 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChatSwiftUI
+@testable import StreamChatTestTools
+import XCTest
+
+final class ChannelAvatarsMergerTests: StreamChatTestCase {
+    private var merger: ChannelAvatarsMerger!
+    
+    override func setUp() {
+        super.setUp()
+        merger = ChannelAvatarsMerger()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+        merger = nil
+    }
+    
+    func testConcurrentCalls() {
+        let sourceImages: [UIImage] = [
+            XCTestCase.TestImages.chewbacca.image,
+            XCTestCase.TestImages.r2.image,
+            XCTestCase.TestImages.vader.image,
+            XCTestCase.TestImages.yoda.image
+        ]
+        DispatchQueue.concurrentPerform(iterations: 100) { _ in
+            let images = Array(sourceImages.prefix((1...4).randomElement()!))
+            let mergedImage = merger.createMergedAvatar(from: images)
+            XCTAssertNotNil(mergedImage)
+        }
+    }
+}


### PR DESCRIPTION
### 🔗 Issue Links

Resolves: [IOS-913](https://linear.app/stream/issue/IOS-913/)

### 🎯 Goal

Fix crash in ChannelAvatarsMerger when accessing shared properties

### 📝 Summary

* Avoid lazy var for shared state in code running from multiple threads

### 🛠 Implementation

We got a crash on line which accesses lazy var property. This can happen from multiple threads. This PR removes lazy variables (there are still possible problematic cases since we end up reading Utils from multiple threads which is safe if it is modified only in the SDK init phase).

### 🧪 Manual Testing Notes

* N/A

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
