### PR TITLE
[CI] Update danger usage

### DIFF
--- a/.github/workflows/smoke-checks.yml
+++ b/.github/workflows/smoke-checks.yml
@@ -54,7 +54,7 @@ jobs:
     - uses: actions/checkout@v4.1.1
     - uses: ./.github/actions/bootstrap
     - name: Run Danger
-      run: bundle exec danger
+      run: bundle exec fastlane lint_pr
     - name: Run Fastlane Linting
       run: bundle exec fastlane rubocop
     - name: Run SwiftFormat Linting

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -495,6 +495,11 @@ lane :rubocop do
   sh('bundle exec rubocop')
 end
 
+desc 'Run PR linting'
+lane :lint_pr do
+  danger(dangerfile: 'Dangerfile') if is_ci
+end
+
 lane :install_runtime do |options|
   install_ios_runtime(version: options[:ios], custom_script: 'Scripts/install_ios_runtime.sh')
 end


### PR DESCRIPTION
### 📝 Summary

For some reason, danger fails on CI during a day or so after updating ruby gems.
This PR introduces the use of danger through fastlane in the hope of solving the mysterious issue. In general, nothing changes.