### PR TITLE
Avoid URLSession crash on startup when on iOS 26 beta

### DIFF
--- a/DemoAppSwiftUI/AppDelegate.swift
+++ b/DemoAppSwiftUI/AppDelegate.swift
@@ -2,6 +2,7 @@
 // Copyright © 2025 Stream.io Inc. All rights reserved.
 //
 
+import Network
 import Sentry
 import StreamChat
 import StreamChatSwiftUI
@@ -25,6 +26,11 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
+        // Xcode 26 beta workaround
+        if #available(iOS 26.0, *) {
+            nw_tls_create_options()
+        }
+        
         /*
          //Customizations, uncomment to customize.
          var colors = ColorPalette()


### PR DESCRIPTION
### 🔗 Issue Links

Resolves: https://linear.app/stream/issue/IOS-926/bug-sdk-is-not-compatible-with-ios-26

### 🎯 Goal

Workaround Xcode 26 beta issue which triggers crash

### 📝 Summary

_Provide bullet points with the most important changes in the codebase._

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
