### PR TITLE
Fix tapping on invisible areas on iOS 26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### 🐞 Fixed
+- Fix tapping on invisible areas on iOS 26 [#868](https://github.com/GetStream/stream-chat-swiftui/pull/868)
 
 # [4.80.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.80.0)
 _June 17, 2025_

--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/PhotoAttachmentPickerView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/PhotoAttachmentPickerView.swift
@@ -96,8 +96,9 @@ public struct PhotoAttachmentCell: View {
                         
                         // Needed because of SwiftUI bug with tap area of Image.
                         Rectangle()
-                            .opacity(0.000001)
+                            .fill(.clear)
                             .frame(width: reader.size.width, height: reader.size.height)
+                            .contentShape(.rect)
                             .clipped()
                             .allowsHitTesting(true)
                             .onTapGesture {

--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/ImageAttachmentView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/ImageAttachmentView.swift
@@ -361,8 +361,9 @@ struct LazyLoadingImage: View {
                     // NOTE: needed because of bug with SwiftUI.
                     // The click area expands outside the image view (although not visible).
                     Rectangle()
-                        .opacity(0.000001)
+                        .fill(.clear)
                         .frame(width: width, height: height)
+                        .contentShape(.rect)
                         .clipped()
                         .allowsHitTesting(true)
                         .highPriorityGesture(


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-949/cant-select-and-send-the-media-ios-26-beta.

### 🎯 Goal

Seems like this is not working any longer in iOS 26, but there's a better way anyway (also tested on iOS 18).

### 📝 Summary

_Provide bullet points with the most important changes in the codebase._

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
