### PR TITLE
Fix channel view tab bar not hidden on iOS 16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🐞 Fixed
 - Fix tapping on invisible areas on iOS 26 [#868](https://github.com/GetStream/stream-chat-swiftui/pull/868)
+- Fix channel view tab bar not hidden on iOS 16.0 [#870](https://github.com/GetStream/stream-chat-swiftui/pull/870)
 
 # [4.80.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.80.0)
 _June 17, 2025_

--- a/DemoAppSwiftUI/ChannelHeader/NewChatView.swift
+++ b/DemoAppSwiftUI/ChannelHeader/NewChatView.swift
@@ -109,7 +109,7 @@ struct TabBarVisibilityModifier: ViewModifier {
     
     func body(content: Content) -> some View {
         if #available(iOS 16.0, *) {
-            content.toolbar(.hidden, for: .bottomBar)
+            content.toolbar(.hidden, for: .tabBar)
         } else {
             content
         }

--- a/DemoAppSwiftUI/PinChannelHelpers.swift
+++ b/DemoAppSwiftUI/PinChannelHelpers.swift
@@ -165,7 +165,10 @@ struct DemoAppChatChannelNavigatableListItem<ChannelDestination: View>: View {
                 tag: channel.channelSelectionInfo,
                 selection: $selectedChannel
             ) {
-                LazyView(channelDestination(channel.channelSelectionInfo))
+                LazyView(
+                    channelDestination(channel.channelSelectionInfo)
+                        .modifier(TabBarVisibilityModifier())
+                )
             } label: {
                 EmptyView()
             }

--- a/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelNavigatableListItem.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelNavigatableListItem.swift
@@ -14,6 +14,7 @@ public struct ChatChannelNavigatableListItem<Factory: ViewFactory, ChannelDestin
     private var avatar: UIImage
     private var disabled: Bool
     private var onlineIndicatorShown: Bool
+    private var handleTabBarVisibility: Bool
     @Binding private var selectedChannel: ChannelSelectionInfo?
     private var channelDestination: (ChannelSelectionInfo) -> ChannelDestination
     private var onItemTap: (ChatChannel) -> Void
@@ -25,6 +26,7 @@ public struct ChatChannelNavigatableListItem<Factory: ViewFactory, ChannelDestin
         avatar: UIImage,
         onlineIndicatorShown: Bool,
         disabled: Bool = false,
+        handleTabBarVisibility: Bool = true,
         selectedChannel: Binding<ChannelSelectionInfo?>,
         channelDestination: @escaping (ChannelSelectionInfo) -> ChannelDestination,
         onItemTap: @escaping (ChatChannel) -> Void
@@ -38,6 +40,7 @@ public struct ChatChannelNavigatableListItem<Factory: ViewFactory, ChannelDestin
         self.onlineIndicatorShown = onlineIndicatorShown
         self.disabled = disabled
         _selectedChannel = selectedChannel
+        self.handleTabBarVisibility = true
     }
 
     public var body: some View {
@@ -57,7 +60,10 @@ public struct ChatChannelNavigatableListItem<Factory: ViewFactory, ChannelDestin
                 tag: channel.channelSelectionInfo,
                 selection: $selectedChannel
             ) {
-                LazyView(channelDestination(channel.channelSelectionInfo))
+                LazyView(
+                    channelDestination(channel.channelSelectionInfo)
+                        .modifier(HideTabBarModifier(handleTabBarVisibility: handleTabBarVisibility))
+                )
             } label: {
                 EmptyView()
             }

--- a/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelNavigatableListItem.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelNavigatableListItem.swift
@@ -62,7 +62,11 @@ public struct ChatChannelNavigatableListItem<Factory: ViewFactory, ChannelDestin
             ) {
                 LazyView(
                     channelDestination(channel.channelSelectionInfo)
-                        .modifier(HideTabBarModifier(handleTabBarVisibility: handleTabBarVisibility))
+                        .modifier(
+                            HideTabBarModifierForiOS16(
+                                handleTabBarVisibility: handleTabBarVisibility
+                            )
+                        )
                 )
             } label: {
                 EmptyView()
@@ -117,5 +121,25 @@ extension ChatChannel {
 
     public var channelSelectionInfo: ChannelSelectionInfo {
         ChannelSelectionInfo(channel: self, message: nil)
+    }
+}
+
+/// Modifier to fix tab bar visibility issue on iOS 16.0, 16.1, 16.2.
+struct HideTabBarModifierForiOS16: ViewModifier {
+    var handleTabBarVisibility: Bool
+
+    func body(content: Content) -> some View {
+        if #available(iOS 16.0, *) {
+            if #unavailable(iOS 16.3) {
+                content
+                    .modifier(HideTabBarModifier(
+                        handleTabBarVisibility: handleTabBarVisibility
+                    ))
+            } else {
+                content
+            }
+        } else {
+            content
+        }
     }
 }

--- a/Sources/StreamChatSwiftUI/DefaultViewFactory.swift
+++ b/Sources/StreamChatSwiftUI/DefaultViewFactory.swift
@@ -73,6 +73,7 @@ extension ViewFactory {
         trailingSwipeLeftButtonTapped: @escaping (ChatChannel) -> Void,
         leadingSwipeButtonTapped: @escaping (ChatChannel) -> Void
     ) -> some View {
+        let utils = InjectedValues[\.utils]
         let listItem = ChatChannelNavigatableListItem(
             factory: self,
             channel: channel,
@@ -80,7 +81,7 @@ extension ViewFactory {
             avatar: avatar,
             onlineIndicatorShown: onlineIndicatorShown,
             disabled: disabled,
-            handleTabBarVisibility: true,
+            handleTabBarVisibility: utils.messageListConfig.handleTabBarVisibility,
             selectedChannel: selectedChannel,
             channelDestination: channelDestination,
             onItemTap: onItemTap
@@ -1072,14 +1073,15 @@ extension ViewFactory {
         threadDestination: @escaping (ChatThread) -> ThreadDestination,
         selectedThread: Binding<ThreadSelectionInfo?>
     ) -> some View {
-        ChatThreadListNavigatableItem(
+        let utils = InjectedValues[\.utils]
+        return ChatThreadListNavigatableItem(
             thread: thread,
             threadListItem: ChatThreadListItem(
                 viewModel: .init(thread: thread)
             ),
             threadDestination: threadDestination,
             selectedThread: selectedThread,
-            handleTabBarVisibility: true
+            handleTabBarVisibility: utils.messageListConfig.handleTabBarVisibility
         )
     }
 

--- a/Sources/StreamChatSwiftUI/DefaultViewFactory.swift
+++ b/Sources/StreamChatSwiftUI/DefaultViewFactory.swift
@@ -80,6 +80,7 @@ extension ViewFactory {
             avatar: avatar,
             onlineIndicatorShown: onlineIndicatorShown,
             disabled: disabled,
+            handleTabBarVisibility: true,
             selectedChannel: selectedChannel,
             channelDestination: channelDestination,
             onItemTap: onItemTap


### PR DESCRIPTION
### 🔗 Issue Links
https://linear.app/stream/issue/IOS-966/fix-channel-view-tab-bar-not-hidden-in-ios-160

### 🎯 Goal

Fix channel view tab bar not hidden on iOS 16.0.

### 📝 Summary

- Fix channel view tab bar not hidden on iOS 16.0
- Make sure the Thread View also uses the `messageListConfig.handleTabBarVisibility`

### 🛠 Implementation

Add the Thread List tab bar visibility logic to the Channel List as well.

Since the Demo App uses a custom navigation item view, I used an existing, simpler modifier.

### 🧪 Manual Testing Notes

1. Install iOS 16.0 Simulator on Xcode
2. Run the app on iOS 16.0
3. Open a channel
4. The tab bar should be visible.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
