### PR TITLE
Add a view factory method to customise footer in VideoPlayerView

### DIFF
--- a/Sources/StreamChatSwiftUI/ChatChannel/Gallery/VideoPlayerFooterView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Gallery/VideoPlayerFooterView.swift
@@ -1,0 +1,25 @@
+//
+// Copyright © 2025 Stream.io Inc. All rights reserved.
+//
+
+import StreamChat
+import SwiftUI
+
+/// View used as a video player's footer.
+struct VideoPlayerFooterView: View {
+
+    @Injected(\.colors) private var colors
+
+    let attachment: ChatMessageVideoAttachment
+    @Binding var shown: Bool
+
+    var body: some View {
+        HStack {
+            ShareButtonView(content: [attachment.payload.videoURL])
+                .standardPadding()
+
+            Spacer()
+        }
+        .foregroundColor(Color(colors.text))
+    }
+}

--- a/Sources/StreamChatSwiftUI/ChatChannel/Gallery/VideoPlayerView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Gallery/VideoPlayerView.swift
@@ -49,13 +49,10 @@ public struct VideoPlayerView<Factory: ViewFactory>: View {
                 VideoPlayer(player: avPlayer)
             }
             Spacer()
-            HStack {
-                ShareButtonView(content: [attachment.payload.videoURL])
-                    .standardPadding()
-
-                Spacer()
-            }
-            .foregroundColor(Color(colors.text))
+            viewFactory.makeVideoPlayerFooterView(
+                attachment: attachment,
+                shown: $isShown
+            )
         }
         .onAppear {
             fileCDN.adjustedURL(for: attachment.payload.videoURL) { result in

--- a/Sources/StreamChatSwiftUI/DefaultViewFactory.swift
+++ b/Sources/StreamChatSwiftUI/DefaultViewFactory.swift
@@ -498,6 +498,16 @@ extension ViewFactory {
         GalleryHeaderView(title: title, subtitle: subtitle, isShown: shown)
     }
     
+    public func makeVideoPlayerFooterView(
+        attachment: ChatMessageVideoAttachment,
+        shown: Binding<Bool>
+    ) -> some View {
+        VideoPlayerFooterView(
+            attachment: attachment,
+            shown: shown
+        )
+    }
+    
     public func makeDeletedMessageView(
         for message: ChatMessage,
         isFirst: Bool,

--- a/Sources/StreamChatSwiftUI/ViewFactory.swift
+++ b/Sources/StreamChatSwiftUI/ViewFactory.swift
@@ -504,6 +504,17 @@ public protocol ViewFactory: AnyObject {
         subtitle: String,
         shown: Binding<Bool>
     ) -> VideoPlayerHeaderViewType
+    
+    associatedtype VideoPlayerFooterViewType: View
+    /// Creates the video player footer view presented with a sheet.
+    /// - Parameters:
+    ///  - attachment: the video attachment that will be displayed.
+    ///  - shown: Binding controlling whether the video player is shown.
+    /// - Returns: View displayed in the video player footer slot.
+    func makeVideoPlayerFooterView(
+        attachment: ChatMessageVideoAttachment,
+        shown: Binding<Bool>
+    ) -> VideoPlayerFooterViewType
 
     associatedtype DeletedMessageViewType: View
     /// Creates the deleted message view.

--- a/StreamChatSwiftUI.xcodeproj/project.pbxproj
+++ b/StreamChatSwiftUI.xcodeproj/project.pbxproj
@@ -539,6 +539,7 @@
 		ADE442F22CBDAAC40066CDF7 /* ChatThreadListItemView_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADE442F12CBDAAC40066CDF7 /* ChatThreadListItemView_Tests.swift */; };
 		ADF544382DC93C2A0024A0B3 /* MessageTranslationFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADF544372DC93C0D0024A0B3 /* MessageTranslationFooterView.swift */; };
 		C14A465B284665B100EF498E /* SDKIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14A465A284665B100EF498E /* SDKIdentifier.swift */; };
+		C52A0B5F2E1557F900176379 /* VideoPlayerFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C52A0B5E2E1557F300176379 /* VideoPlayerFooterView.swift */; };
 		E3A1C01C282BAC66002D1E26 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = E3A1C01B282BAC66002D1E26 /* Sentry */; };
 /* End PBXBuildFile section */
 
@@ -1146,6 +1147,7 @@
 		ADE442F12CBDAAC40066CDF7 /* ChatThreadListItemView_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatThreadListItemView_Tests.swift; sourceTree = "<group>"; };
 		ADF544372DC93C0D0024A0B3 /* MessageTranslationFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageTranslationFooterView.swift; sourceTree = "<group>"; };
 		C14A465A284665B100EF498E /* SDKIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDKIdentifier.swift; sourceTree = "<group>"; };
+		C52A0B5E2E1557F300176379 /* VideoPlayerFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoPlayerFooterView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2261,6 +2263,7 @@
 				84F29089276B90610045472D /* GalleryView.swift */,
 				8434E58027707F19001E1B83 /* GridPhotosView.swift */,
 				8465FD032746A95600AF091E /* VideoPlayerView.swift */,
+				C52A0B5E2E1557F300176379 /* VideoPlayerFooterView.swift */,
 				84F2908B276B91700045472D /* ZoomableScrollView.swift */,
 				84F2908F276CC1280045472D /* ShareButtonView.swift */,
 			);
@@ -2917,6 +2920,7 @@
 				AD3AB65C2CB730090014D4D7 /* Shimmer.swift in Sources */,
 				AD3AB6522CB498380014D4D7 /* HideTabBarModifier.swift in Sources */,
 				8423C33F277C9A5F0092DCF1 /* UnmuteCommandHandler.swift in Sources */,
+				C52A0B5F2E1557F900176379 /* VideoPlayerFooterView.swift in Sources */,
 				8421BCEE27A43E14000F977D /* SearchBar.swift in Sources */,
 				84EADEBB2B28BAE40046B50C /* RecordingWaveform.swift in Sources */,
 				841B64CA2775BBC10016FF3B /* Errors.swift in Sources */,


### PR DESCRIPTION
### 🔗 Issue Links

### 🎯 Goal

Enable `VideoPlayerView` footer customisation (e.g. add `download video` feature).

### 📝 Summary

`ViewFactory.makeVideoPlayerFooterView()` was implemented.

### 🛠 Implementation

The default footer implementation has been migrated to `VideoPlayerFooterView`.

### 🎨 Showcase

### 🧪 Manual Testing Notes

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo

### 🙋‍♂️To discuss

What do you think about making `ShareButtonView` `public` to add ability to reuse it in a custom footer?
