### PR TITLE
Fix mute and umute commands shown in the composer when removed from Dashboard

### DIFF
--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/Suggestions/CommandsConfig.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/Suggestions/CommandsConfig.swift
@@ -44,26 +44,26 @@ public class DefaultCommandsConfig: CommandsConfig {
         var instantCommands = [CommandHandler]()
 
         let channelConfig = channelController.channel?.config
+        let availableCommands = channelConfig?.commands.map(\.name) ?? []
 
-        let giphyEnabled = channelConfig?.commands.first(where: { command in
-            command.name == "giphy"
-        }) != nil
-
-        if giphyEnabled {
+        if availableCommands.contains("giphy") {
             let giphyCommand = GiphyCommandHandler(commandSymbol: "/giphy")
             instantCommands.append(giphyCommand)
         }
 
-        if channelConfig?.mutesEnabled == true {
+        if availableCommands.contains("mute") {
             let muteCommand = MuteCommandHandler(
                 channelController: channelController,
                 commandSymbol: "/mute"
             )
+            instantCommands.append(muteCommand)
+        }
+
+        if availableCommands.contains("unmute") {
             let unmuteCommand = UnmuteCommandHandler(
                 channelController: channelController,
                 commandSymbol: "/unmute"
             )
-            instantCommands.append(muteCommand)
             instantCommands.append(unmuteCommand)
         }
 

--- a/StreamChatSwiftUITests/Tests/ChatChannel/Suggestions/CommandsHandler_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/Suggestions/CommandsHandler_Tests.swift
@@ -4,6 +4,7 @@
 
 @testable import StreamChat
 @testable import StreamChatSwiftUI
+@testable import StreamChatTestTools
 import XCTest
 
 class CommandsHandler_Tests: StreamChatTestCase {
@@ -166,6 +167,39 @@ class CommandsHandler_Tests: StreamChatTestCase {
         // Then
         XCTAssert(id == "main")
         XCTAssert(displayInfo == nil)
+    }
+
+    func test_defaultCommandsConfig() {
+        // Given
+        let channelController = ChatChannelController_Mock.mock()
+        channelController.channel_mock = .mock(
+            cid: .unique,
+            config: .mock(commands: [.init(name: "mute"), .init(name: "unmute"), .init(name: "giphy")])
+        )
+        let defaultCommandsHandler = DefaultCommandsConfig()
+        let handler = defaultCommandsHandler.makeCommandsHandler(with: channelController)
+
+        XCTAssertNotNil(handler.canHandleCommand(in: "/mention @user", caretLocation: 10))
+        XCTAssertNotNil(handler.canHandleCommand(in: "/mute", caretLocation: 0))
+        XCTAssertNotNil(handler.canHandleCommand(in: "/unmute", caretLocation: 0))
+        XCTAssertNotNil(handler.canHandleCommand(in: "/giphy", caretLocation: 0))
+    }
+
+    func test_defaultCommandsConfig_whenWithoutMutesCommands() {
+        // Given
+        let channelController = ChatChannelController_Mock.mock()
+        channelController.channel_mock = .mock(
+            cid: .unique,
+            config: .mock(commands: [.init(name: "giphy")])
+        )
+        let defaultCommandsHandler = DefaultCommandsConfig()
+        let handler = defaultCommandsHandler.makeCommandsHandler(with: channelController)
+
+        XCTAssertNil(handler.canHandleCommand(in: "/mute", caretLocation: 0))
+        XCTAssertNil(handler.canHandleCommand(in: "/unmute", caretLocation: 0))
+
+        XCTAssertNotNil(handler.canHandleCommand(in: "/mention @user", caretLocation: 10))
+        XCTAssertNotNil(handler.canHandleCommand(in: "/giphy", caretLocation: 0))
     }
 
     // MARK: - private


### PR DESCRIPTION
### 🔗 Issue Links
https://linear.app/stream/issue/IOS-911/mute-and-unmute-commands-do-not-respect-dashboard

### 🎯 Goal

Fix mute and umute commands shown in the composer when removed from Dashboard.

### 🧪 Manual Testing Notes

1. Go to the Dashboard
2. Go to Channel Type
3. Tap on messaging
4. Remove mute and unmute commands
5. Submit
6. Open a channel in the mobile Demo App
7. Tap commands icon in the composer
8. Mute and Umute commands should not be there

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
