### PR TITLE
Add jumping to pinned message when tapping a message in the pinned messages view

### DIFF
--- a/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/PinnedMessagesView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/PinnedMessagesView.swift
@@ -8,10 +8,14 @@ import SwiftUI
 /// View displaying pinned messages in the chat info screen.
 public struct PinnedMessagesView<Factory: ViewFactory>: View {
     @Injected(\.images) private var images
+    @Injected(\.utils) private var utils
+    @Injected(\.chatClient) private var chatClient
 
     @StateObject private var viewModel: PinnedMessagesViewModel
     
     let factory: Factory
+    private let channel: ChatChannel
+    private var onItemTap: ((ChatMessage) -> Void)?
 
     public init(
         factory: Factory = DefaultViewFactory.shared,
@@ -24,6 +28,7 @@ public struct PinnedMessagesView<Factory: ViewFactory>: View {
                 channelController: channelController
             )
         )
+        self.channel = channel
         self.factory = factory
     }
 
@@ -33,7 +38,27 @@ public struct PinnedMessagesView<Factory: ViewFactory>: View {
                 ScrollView {
                     LazyVStack(spacing: 0) {
                         ForEach(viewModel.pinnedMessages) { message in
-                            PinnedMessageView(factory: factory, message: message, channel: viewModel.channel)
+                            ZStack {
+                                PinnedMessageView(factory: factory, message: message, channel: viewModel.channel)
+                                    .contentShape(Rectangle())
+                                    .onTapGesture {
+                                        viewModel.selectedMessage = message
+                                    }
+                                NavigationLink(
+                                    tag: message,
+                                    selection: $viewModel.selectedMessage
+                                ) {
+                                    LazyView(
+                                        makeMessageDestination(message: message)
+                                            .modifier(HideTabBarModifier(
+                                                handleTabBarVisibility: utils.messageListConfig.handleTabBarVisibility
+                                            ))
+                                    )
+                                } label: {
+                                    EmptyView()
+                                }
+                                .opacity(0) // Fixes showing accessibility button shape
+                            }
                             Divider()
                         }
                     }
@@ -48,6 +73,26 @@ public struct PinnedMessagesView<Factory: ViewFactory>: View {
             }
         }
         .navigationTitle(L10n.ChatInfo.PinnedMessages.title)
+    }
+
+    private func makeMessageDestination(message: ChatMessage) -> ChatChannelView<Factory> {
+        let channelController = utils.channelControllerFactory
+            .makeChannelController(for: channel.cid)
+
+        var messageController: ChatMessageController?
+        if let parentMessageId = message.parentMessageId {
+            messageController = chatClient.messageController(
+                cid: channel.cid,
+                messageId: parentMessageId
+            )
+        }
+
+        return ChatChannelView(
+            viewFactory: factory,
+            channelController: channelController,
+            messageController: messageController,
+            scrollToMessage: message
+        )
     }
 }
 

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/PinnedMessagesViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/PinnedMessagesViewModel.swift
@@ -11,7 +11,8 @@ public class PinnedMessagesViewModel: ObservableObject {
     let channel: ChatChannel
 
     @Published var pinnedMessages: [ChatMessage]
-    
+    @Published var selectedMessage: ChatMessage?
+
     private var channelController: ChatChannelController?
     
     public init(channel: ChatChannel, channelController: ChatChannelController? = nil) {


### PR DESCRIPTION
### 🔗 Issue Links
https://linear.app/stream/issue/IOS-791

### 🎯 Goal

Add jumping to pinned message when tapping a message in the pinned messages view.

### 🎨 Showcase

https://github.com/user-attachments/assets/9d8e8103-a2f5-410f-9fc1-ec9543441b11

### 🧪 Manual Testing Notes

1. Go to a Channel
2. Tap on the Channel Header Image
3. Tap on Pinned Messages View
4. Tap on a message
5. Should open the channel and jump to it

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
