### PR TITLE
Fix WebView error handling to enable mp3 attachments loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### 🐞 Fixed
+- Fix WebView error handling to enable mp3 attachments loading [#904](https://github.com/GetStream/stream-chat-swiftui/pull/904)
 
 # [4.83.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.83.0)
 _July 29, 2025_

--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/WebView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/WebView.swift
@@ -39,11 +39,6 @@ struct WebView: UIViewRepresentable {
         var isLoading: Binding<Bool>
         var title: Binding<String?>
         var error: Binding<Error?>
-        
-        private let WebKitErrorDomain = "WebKitErrorDomain"
-        private enum WebKitErrorCode: Int {
-            case pluginHandledLoad = 204
-        }
 
         init(
             webView: WebView,
@@ -76,8 +71,7 @@ struct WebView: UIViewRepresentable {
             didFailProvisionalNavigation navigation: WKNavigation!,
             withError error: Error
         ) {
-            let nsError = error as NSError
-            if nsError.domain == WebKitErrorDomain && nsError.code == WebKitErrorCode.pluginHandledLoad.rawValue {
+            if isPluginHandledLoadResult(error) {
                 return
             }
 
@@ -90,13 +84,17 @@ struct WebView: UIViewRepresentable {
             didFail navigation: WKNavigation!,
             withError error: Error
         ) {
-            let nsError = error as NSError
-            if nsError.domain == WebKitErrorDomain && nsError.code == WebKitErrorCode.pluginHandledLoad.rawValue {
+            if isPluginHandledLoadResult(error) {
                 return
             }
 
             isLoading.wrappedValue = false
             self.error.wrappedValue = error
+        }
+        
+        private func isPluginHandledLoadResult(_ error: Error) -> Bool {
+            let nsError = error as NSError
+            return nsError.domain == "WebKitErrorDomain" && nsError.code == 204
         }
     }
 }

--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/WebView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/WebView.swift
@@ -11,11 +11,6 @@ struct WebView: UIViewRepresentable {
     @Binding var isLoading: Bool
     @Binding var title: String?
     @Binding var error: Error?
-    
-    private let WebKitErrorDomain = "WebKitErrorDomain"
-    private enum WebKitErrorCode: Int {
-        case pluginHandledLoad = 204
-    }
 
     func makeCoordinator() -> Coordinator {
         Coordinator(
@@ -44,6 +39,11 @@ struct WebView: UIViewRepresentable {
         var isLoading: Binding<Bool>
         var title: Binding<String?>
         var error: Binding<Error?>
+        
+        private let WebKitErrorDomain = "WebKitErrorDomain"
+        private enum WebKitErrorCode: Int {
+            case pluginHandledLoad = 204
+        }
 
         init(
             webView: WebView,
@@ -76,7 +76,6 @@ struct WebView: UIViewRepresentable {
             didFailProvisionalNavigation navigation: WKNavigation!,
             withError error: Error
         ) {
-            // Ignore "Plug-in handled load" error as it's actually success for audio files
             let nsError = error as NSError
             if nsError.domain == WebKitErrorDomain && nsError.code == WebKitErrorCode.pluginHandledLoad.rawValue {
                 return
@@ -91,7 +90,6 @@ struct WebView: UIViewRepresentable {
             didFail navigation: WKNavigation!,
             withError error: Error
         ) {
-            // Ignore "Plug-in handled load" error as it's actually success for audio files
             let nsError = error as NSError
             if nsError.domain == WebKitErrorDomain && nsError.code == WebKitErrorCode.pluginHandledLoad.rawValue {
                 return

--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/WebView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/WebView.swift
@@ -71,6 +71,12 @@ struct WebView: UIViewRepresentable {
             didFailProvisionalNavigation navigation: WKNavigation!,
             withError error: Error
         ) {
+            // Ignore "Plug-in handled load" error as it's actually success for audio files
+            let nsError = error as NSError
+            if nsError.domain == "WebKitErrorDomain" && nsError.code == 204 {
+                return
+            }
+
             isLoading.wrappedValue = false
             self.error.wrappedValue = error
         }
@@ -80,6 +86,12 @@ struct WebView: UIViewRepresentable {
             didFail navigation: WKNavigation!,
             withError error: Error
         ) {
+            // Ignore "Plug-in handled load" error as it's actually success for audio files
+            let nsError = error as NSError
+            if nsError.domain == "WebKitErrorDomain" && nsError.code == 204 {
+                return
+            }
+
             isLoading.wrappedValue = false
             self.error.wrappedValue = error
         }

--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/WebView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/WebView.swift
@@ -11,6 +11,11 @@ struct WebView: UIViewRepresentable {
     @Binding var isLoading: Bool
     @Binding var title: String?
     @Binding var error: Error?
+    
+    private let WebKitErrorDomain = "WebKitErrorDomain"
+    private enum WebKitErrorCode: Int {
+        case pluginHandledLoad = 204
+    }
 
     func makeCoordinator() -> Coordinator {
         Coordinator(
@@ -73,7 +78,7 @@ struct WebView: UIViewRepresentable {
         ) {
             // Ignore "Plug-in handled load" error as it's actually success for audio files
             let nsError = error as NSError
-            if nsError.domain == "WebKitErrorDomain" && nsError.code == 204 {
+            if nsError.domain == WebKitErrorDomain && nsError.code == WebKitErrorCode.pluginHandledLoad.rawValue {
                 return
             }
 
@@ -88,7 +93,7 @@ struct WebView: UIViewRepresentable {
         ) {
             // Ignore "Plug-in handled load" error as it's actually success for audio files
             let nsError = error as NSError
-            if nsError.domain == "WebKitErrorDomain" && nsError.code == 204 {
+            if nsError.domain == WebKitErrorDomain && nsError.code == WebKitErrorCode.pluginHandledLoad.rawValue {
                 return
             }
 


### PR DESCRIPTION
### 🔗 Issue Links

Resolve https://linear.app/stream/issue/IOS-1052

### 🎯 Goal

Fix WebView error handling to enable mp3 attachments loading

### 🎨 Showcase

| Before | After |
| ------ | ----- |
|  <img width="1179" height="2556" alt="before" src="https://github.com/user-attachments/assets/a7514090-6f36-4a2f-9dfc-6ef0f573fd67" />  |  <img width="1179" height="2556" alt="after" src="https://github.com/user-attachments/assets/cba862f2-95cd-41af-8b7b-73521eb58d6e" /> |

### 🧪 Manual Testing Notes

1. Send any mp3 file (e.g.: from the internal ticket)
2. Open it in the DemoApp

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
