### PR TITLE
Expose `ChannelAvatarViewOptions.init`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+### ✅ Added
+- Expose `ChannelAvatarViewOptions.init` [#908](https://github.com/GetStream/stream-chat-swiftui/pull/908)
 ### 🐞 Fixed
 - Fix WebView error handling to enable mp3 attachments loading [#904](https://github.com/GetStream/stream-chat-swiftui/pull/904)
 

--- a/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListItem.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListItem.swift
@@ -181,9 +181,15 @@ public struct ChannelAvatarViewOptions {
     /// Whether the online indicator should be shown.
     public var showOnlineIndicator: Bool
     /// Size of the avatar.
-    public var size: CGSize = .defaultAvatarSize
+    public var size: CGSize
     /// Optional avatar image. If not provided, it will be loaded by the channel header loader.
     public var avatar: UIImage?
+
+    public init(showOnlineIndicator: Bool, size: CGSize = .defaultAvatarSize, avatar: UIImage? = nil) {
+        self.showOnlineIndicator = showOnlineIndicator
+        self.size = size
+        self.avatar = avatar
+    }
 }
 
 /// View for the avatar used in channels (includes online indicator overlay).


### PR DESCRIPTION
### 🔗 Issue Links

N/A

### 🎯 Goal

Quick fix to expose `ChannelAvatarViewOptions.init`
