### PR TITLE
Add option to scroll to and open a channel from the channel list

### DIFF
--- a/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelList.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelList.swift
@@ -14,6 +14,7 @@ public struct ChannelList<Factory: ViewFactory>: View {
     var channels: LazyCachedMapCollection<ChatChannel>
     @Binding var selectedChannel: ChannelSelectionInfo?
     @Binding var swipedChannelId: String?
+    @Binding var scrollChannelId: String?
     private var scrollable: Bool
     private var onlineIndicatorShown: (ChatChannel) -> Bool
     private var imageLoader: (ChatChannel) -> UIImage
@@ -30,6 +31,7 @@ public struct ChannelList<Factory: ViewFactory>: View {
         channels: LazyCachedMapCollection<ChatChannel>,
         selectedChannel: Binding<ChannelSelectionInfo?>,
         swipedChannelId: Binding<String?>,
+        scrollChannelId: Binding<String?> = .constant(nil),
         scrollable: Bool = true,
         onlineIndicatorShown: ((ChatChannel) -> Bool)? = nil,
         imageLoader: ((ChatChannel) -> UIImage)? = nil,
@@ -72,13 +74,23 @@ public struct ChannelList<Factory: ViewFactory>: View {
         self.scrollable = scrollable
         _selectedChannel = selectedChannel
         _swipedChannelId = swipedChannelId
+        _scrollChannelId = scrollChannelId
     }
 
     public var body: some View {
         Group {
             if scrollable {
-                ScrollView {
-                    channelsVStack
+                ScrollViewReader { scrollView in
+                    ScrollView {
+                        channelsVStack
+                    }
+                    .onChange(of: scrollChannelId) { newValue in
+                        if let newValue {
+                            withAnimation {
+                                scrollView.scrollTo(newValue, anchor: .bottom)
+                            }
+                        }
+                    }
                 }
             } else {
                 channelsVStack

--- a/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelList.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelList.swift
@@ -14,7 +14,7 @@ public struct ChannelList<Factory: ViewFactory>: View {
     var channels: LazyCachedMapCollection<ChatChannel>
     @Binding var selectedChannel: ChannelSelectionInfo?
     @Binding var swipedChannelId: String?
-    @Binding var scrollChannelId: String?
+    @Binding var scrolledChannelId: String?
     private var scrollable: Bool
     private var onlineIndicatorShown: (ChatChannel) -> Bool
     private var imageLoader: (ChatChannel) -> UIImage
@@ -31,7 +31,7 @@ public struct ChannelList<Factory: ViewFactory>: View {
         channels: LazyCachedMapCollection<ChatChannel>,
         selectedChannel: Binding<ChannelSelectionInfo?>,
         swipedChannelId: Binding<String?>,
-        scrollChannelId: Binding<String?> = .constant(nil),
+        scrolledChannelId: Binding<String?> = .constant(nil),
         scrollable: Bool = true,
         onlineIndicatorShown: ((ChatChannel) -> Bool)? = nil,
         imageLoader: ((ChatChannel) -> UIImage)? = nil,
@@ -74,7 +74,7 @@ public struct ChannelList<Factory: ViewFactory>: View {
         self.scrollable = scrollable
         _selectedChannel = selectedChannel
         _swipedChannelId = swipedChannelId
-        _scrollChannelId = scrollChannelId
+        _scrolledChannelId = scrolledChannelId
     }
 
     public var body: some View {
@@ -84,7 +84,7 @@ public struct ChannelList<Factory: ViewFactory>: View {
                     ScrollView {
                         channelsVStack
                     }
-                    .onChange(of: scrollChannelId) { newValue in
+                    .onChange(of: scrolledChannelId) { newValue in
                         if let newValue {
                             withAnimation {
                                 scrollView.scrollTo(newValue, anchor: .bottom)

--- a/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListView.swift
@@ -234,6 +234,7 @@ public struct ChatChannelListContentView<Factory: ViewFactory>: View {
                     channels: viewModel.channels,
                     selectedChannel: $viewModel.selectedChannel,
                     swipedChannelId: $viewModel.swipedChannelId,
+                    scrollChannelId: $viewModel.scrollToId,
                     onlineIndicatorShown: viewModel.onlineIndicatorShown(for:),
                     imageLoader: channelHeaderLoader.image(for:),
                     onItemTap: onItemTap,

--- a/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListView.swift
@@ -234,7 +234,7 @@ public struct ChatChannelListContentView<Factory: ViewFactory>: View {
                     channels: viewModel.channels,
                     selectedChannel: $viewModel.selectedChannel,
                     swipedChannelId: $viewModel.swipedChannelId,
-                    scrollChannelId: $viewModel.scrollToId,
+                    scrolledChannelId: $viewModel.scrolledChannelId,
                     onlineIndicatorShown: viewModel.onlineIndicatorShown(for:),
                     imageLoader: channelHeaderLoader.image(for:),
                     onItemTap: onItemTap,

--- a/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListViewModel.swift
@@ -39,6 +39,8 @@ open class ChatChannelListViewModel: ObservableObject, ChatChannelListController
 
     /// Index of the selected channel.
     private var selectedChannelIndex: Int?
+    
+    @Published public var scrollToId: String?
 
     /// Published variables.
     @Published public var channels = LazyCachedMapCollection<ChatChannel>() {

--- a/StreamChatSwiftUITests/Tests/ChatChannelList/ChatChannelListViewModel_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannelList/ChatChannelListViewModel_Tests.swift
@@ -372,6 +372,126 @@ class ChatChannelListViewModel_Tests: StreamChatTestCase {
         XCTAssertNotNil(viewModel.messageSearchController)
     }
 
+    // MARK: - Open Channel
+
+    func test_openChannel_whenChannelExistsInList_shouldScrollToAndOpenChannel() {
+        // Given
+        let channel = ChatChannel.mockDMChannel()
+        let channelListController = makeChannelListController(channels: [channel])
+        let viewModel = ChatChannelListViewModel(
+            channelListController: channelListController,
+            selectedChannelId: nil
+        )
+        
+        // When
+        viewModel.open(channel: channel)
+        
+        // Then
+        XCTAssertEqual(viewModel.scrolledChannelId, channel.id)
+        
+        // Wait for the async delay and verify selectedChannel is set
+        let expectation = XCTestExpectation(description: "Channel opened")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+            XCTAssertEqual(viewModel.selectedChannel?.channel.id, channel.id)
+            XCTAssertNil(viewModel.scrolledChannelId)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+    }
+    
+    func test_openChannel_whenChannelNotInList_shouldLoadNextChannelsUntilFound() {
+        // Given
+        let existingChannel = ChatChannel.mockDMChannel()
+        let targetChannel = ChatChannel.mockDMChannel()
+        let channelListController = makeChannelListController(channels: [existingChannel])
+        let viewModel = ChatChannelListViewModel(
+            channelListController: channelListController,
+            selectedChannelId: nil
+        )
+        
+        // When
+        viewModel.open(channel: targetChannel)
+        
+        // Then
+        XCTAssertEqual(channelListController.loadNextChannelsCallCount, 1)
+        
+        // Simulate the channel being found after loading
+        channelListController.simulate(
+            channels: [existingChannel, targetChannel],
+            changes: [.insert(targetChannel, index: .init(row: 1, section: 0))]
+        )
+        
+        // When
+        viewModel.open(channel: targetChannel)
+        
+        // Verify the channel is eventually opened
+        let expectation = XCTestExpectation(description: "Channel opened after loading")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            XCTAssertEqual(viewModel.selectedChannel?.channel.id, targetChannel.id)
+            XCTAssertNil(viewModel.scrolledChannelId)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+    }
+    
+    func test_openChannel_whenChannelNotFoundAndNoMoreChannels_shouldSetScrolledChannelIdToNil() {
+        // Given
+        let existingChannel = ChatChannel.mockDMChannel()
+        let targetChannel = ChatChannel.mockDMChannel()
+        let channelListController = makeChannelListController(channels: [existingChannel])
+        let viewModel = ChatChannelListViewModel(
+            channelListController: channelListController,
+            selectedChannelId: nil
+        )
+        
+        // When
+        viewModel.open(channel: targetChannel)
+        
+        // Then
+        XCTAssertNil(viewModel.scrolledChannelId)
+        XCTAssertNil(viewModel.selectedChannel)
+    }
+    
+    func test_openChannel_whenChannelFoundAfterMultipleLoads_shouldEventuallyOpenChannel() {
+        // Given
+        let existingChannel = ChatChannel.mockDMChannel()
+        let targetChannel = ChatChannel.mockDMChannel()
+        let channelListController = makeChannelListController(channels: [existingChannel])
+        let viewModel = ChatChannelListViewModel(
+            channelListController: channelListController,
+            selectedChannelId: nil
+        )
+        
+        // When
+        viewModel.open(channel: targetChannel)
+        
+        // Then
+        XCTAssertEqual(channelListController.loadNextChannelsCallCount, 1)
+        
+        // Simulate first load not finding the channel
+        channelListController.simulate(
+            channels: [existingChannel],
+            changes: []
+        )
+        
+        // Simulate second load finding the channel
+        channelListController.simulate(
+            channels: [existingChannel, targetChannel],
+            changes: [.insert(targetChannel, index: .init(row: 1, section: 0))]
+        )
+        
+        viewModel.open(channel: targetChannel)
+        
+        // Verify the channel is eventually opened
+        let expectation = XCTestExpectation(description: "Channel opened after multiple loads")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            XCTAssertEqual(viewModel.selectedChannel?.channel.id, targetChannel.id)
+            XCTAssertNil(viewModel.scrolledChannelId)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+    }
+
     // MARK: - private
 
     private func makeChannelListController(


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1102/add-a-way-to-scroll-and-open-channels-via-the-view-model.

### 🎯 Goal

_Describe why we are making this change._

### 📝 Summary

_Provide bullet points with the most important changes in the codebase._

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
