### PR TITLE
Use channel capabilities for validating delete message action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🐞 Fixed
 - Show attachment title instead of URL in the `FileAttachmentPreview` view [#930](https://github.com/GetStream/stream-chat-swiftui/pull/930)
 - Fix overriding title color in `ChannelTitleView` [#931](https://github.com/GetStream/stream-chat-swiftui/pull/931)
+- Use channel capabilities for validating delete message action [#933](https://github.com/GetStream/stream-chat-swiftui/pull/933)
 
 # [4.86.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.86.0)
 _August 21, 2025_

--- a/Sources/StreamChatSwiftUI/ChatChannel/Reactions/MessageActions/DefaultMessageActions.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Reactions/MessageActions/DefaultMessageActions.swift
@@ -156,7 +156,7 @@ public extension MessageAction {
             }
         }
         
-        if message.isSentByCurrentUser {
+        if channel.canDeleteAnyMessage || channel.canDeleteOwnMessage && message.isSentByCurrentUser {
             let deleteAction = deleteMessageAction(
                 for: message,
                 channel: channel,
@@ -166,7 +166,9 @@ public extension MessageAction {
             )
 
             messageActions.append(deleteAction)
-        } else {
+        }
+
+        if !message.isSentByCurrentUser {
             if channel.canFlagMessage {
                 let flagAction = flagMessageAction(
                     for: message,

--- a/StreamChatSwiftUITests/Tests/ChatChannel/MessageActions_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/MessageActions_Tests.swift
@@ -374,12 +374,45 @@ class MessageActions_Tests: StreamChatTestCase {
         // Then
         XCTAssertTrue(messageActions.contains(where: { $0.title == "Edit Message" }))
     }
+    
+    func test_messageActions_otherUser_deletingEnabledWhenDeleteAnyMessageCapability() {
+        // Given
+        let channel = ChatChannel.mockDMChannel(ownCapabilities: [.deleteAnyMessage])
+        let message = ChatMessage.mock(
+            id: .unique,
+            cid: channel.cid,
+            text: "Test",
+            author: .mock(id: .unique),
+            isSentByCurrentUser: false
+        )
+        let factory = DefaultViewFactory.shared
+        
+        // When
+        let messageActions = MessageAction.defaultActions(
+            factory: factory,
+            for: message,
+            channel: channel,
+            chatClient: chatClient,
+            onFinish: { _ in },
+            onError: { _ in }
+        )
+        
+        // Then
+        XCTAssertTrue(messageActions.contains(where: { $0.title == "Delete Message" }))
+    }
 
     // MARK: - Private
     
     private var mockDMChannel: ChatChannel {
         ChatChannel.mockDMChannel(
-            ownCapabilities: [.updateOwnMessage, .sendMessage, .uploadFile, .pinMessage, .readEvents]
+            ownCapabilities: [
+                .deleteOwnMessage,
+                .updateOwnMessage,
+                .sendMessage,
+                .uploadFile,
+                .pinMessage,
+                .readEvents
+            ]
         )
     }
 }


### PR DESCRIPTION
### 🔗 Issue Links

Resolves: [#IOS-1107](https://linear.app/stream/issue/IOS-1107)

### 🎯 Goal

Use channel capabilities for validating delete message action

### 📝 Summary

* Support both `deleteAnyMessage` and `deleteOwnMessage` capabilities

### 🛠 Implementation

### 🎨 Showcase

### 🧪 Manual Testing Notes

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
