### PR TITLE
Make MediaItem and MediaAttachmentContentView public to allow customization.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### ✅ Added
 - Add option to scroll to and open a channel from the channel list [#932](https://github.com/GetStream/stream-chat-swiftui/pull/932)
+- Make `MediaItem` and `MediaAttachmentContentView` public to allow customization [#935](https://github.com/GetStream/stream-chat-swiftui/pull/935)
 
 ### 🐞 Fixed
 - Show attachment title instead of URL in the `FileAttachmentPreview` view [#930](https://github.com/GetStream/stream-chat-swiftui/pull/930)

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/MediaAttachmentsView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/MediaAttachmentsView.swift
@@ -102,7 +102,7 @@ public struct MediaAttachmentsView<Factory: ViewFactory>: View {
     }
 }
 
-struct MediaAttachmentContentView<Factory: ViewFactory>: View {
+public struct MediaAttachmentContentView<Factory: ViewFactory>: View {
     @State private var galleryShown = false
 
     let factory: Factory
@@ -112,7 +112,23 @@ struct MediaAttachmentContentView<Factory: ViewFactory>: View {
     let itemWidth: CGFloat
     let index: Int
 
-    var body: some View {
+    public init(
+        factory: Factory,
+        mediaItem: MediaItem,
+        mediaAttachment: MediaAttachment,
+        allMediaAttachments: [MediaAttachment],
+        itemWidth: CGFloat,
+        index: Int
+    ) {
+        self.factory = factory
+        self.mediaItem = mediaItem
+        self.mediaAttachment = mediaAttachment
+        self.allMediaAttachments = allMediaAttachments
+        self.itemWidth = itemWidth
+        self.index = index
+    }
+
+    public var body: some View {
         Button {
             galleryShown = true
         } label: {

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/MediaAttachmentsViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/MediaAttachmentsViewModel.swift
@@ -106,15 +106,29 @@ class MediaAttachmentsViewModel: ObservableObject, ChatMessageSearchControllerDe
     }
 }
 
-struct MediaItem: Identifiable {
-    let id: String
-    let isVideo: Bool
-    let message: ChatMessage
+public struct MediaItem: Identifiable {
+    public let id: String
+    public let isVideo: Bool
+    public let message: ChatMessage
 
-    var videoAttachment: ChatMessageVideoAttachment?
-    var imageAttachment: ChatMessageImageAttachment?
+    public var videoAttachment: ChatMessageVideoAttachment?
+    public var imageAttachment: ChatMessageImageAttachment?
     
-    var mediaAttachment: MediaAttachment? {
+    public init(
+        id: String,
+        isVideo: Bool,
+        message: ChatMessage,
+        videoAttachment: ChatMessageVideoAttachment?,
+        imageAttachment: ChatMessageImageAttachment?
+    ) {
+        self.id = id
+        self.isVideo = isVideo
+        self.message = message
+        self.videoAttachment = videoAttachment
+        self.imageAttachment = imageAttachment
+    }
+    
+    public var mediaAttachment: MediaAttachment? {
         if let videoAttachment {
             return MediaAttachment(url: videoAttachment.videoURL, type: .video)
         } else if let imageAttachment {


### PR DESCRIPTION
### 🔗 Issue Links
N/A
### 🎯 Goal

Expose `MediaItem` and `MediaAttachmentContentView` to allow customization.

### 📝 Summary

- Public `MediaItem` initializer and properties.
- Public `MediaAttachmentContentView` initializer.

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
