### PR TITLE
Pinned channels are not appearing at the top in the demo app

### DIFF
--- a/DemoAppSwiftUI/DemoAppSwiftUIApp.swift
+++ b/DemoAppSwiftUI/DemoAppSwiftUIApp.swift
@@ -147,19 +147,13 @@ extension AppState {
         guard let currentUserId = chatClient.currentUserId else { fatalError("Not logged in") }
         switch identifier {
         case .initial:
+            var sort: [Sorting<ChannelListSortingKey>] = [Sorting(key: .default)]
+            if AppConfiguration.default.isChannelPinningFeatureEnabled {
+                sort.insert(Sorting(key: .pinnedAt), at: 0)
+            }
             return ChannelListQuery(
                 filter: .containMembers(userIds: [currentUserId]),
-                sort: [
-                    Sorting(key: .default)
-                ]
-            )
-        case .initial where AppConfiguration.default.isChannelPinningFeatureEnabled:
-            return ChannelListQuery(
-                filter: .containMembers(userIds: [currentUserId]),
-                sort: [
-                    Sorting(key: .pinnedAt),
-                    Sorting(key: .default)
-                ]
+                sort: sort
             )
         case .archived:
             return ChannelListQuery(


### PR DESCRIPTION
### 🔗 Issue Links

### 🎯 Goal

* Demo app has a bug where pinned channels are not sorted when enabling channel pinning (faulty switch case handling)

### 📝 Summary

### 🛠 Implementation

### 🎨 Showcase

### 🧪 Manual Testing Notes

1. Enable channel pinning from the configuration
2. Log in and observe that pinned channels are at the top

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
