### PR TITLE
Fix race condition when clearing text

### DIFF
--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerViewModel.swift
@@ -743,7 +743,6 @@ open class MessageComposerViewModel: ObservableObject {
     }
     
     private func clearInputData() {
-        text = ""
         addedAssets = []
         addedFileURLs = []
         addedVoiceRecordings = []


### PR DESCRIPTION
### 🔗 Issue Links

- ~~Fixes [#ISSUE_ID] (replace with Linear or GitHub issue link if available)~~

---

### 🎯 Goal

Ensure the chat composer `TextField` is reliably cleared after sending a message, when autocorrection is active and a SwiftUI TextField is used. 

For context, my usecase requires me to use a custom configured TextField instead of `ComposerInputView` (UIViewRepresentable implementation) provided by this SDK. There is a race condition caused by clearing the text twice and the system autocorrection.

---

### 📝 Summary

- Removed **immediate** `text = ""` call from `clearInputData()`  
- Kept deferred clear in `clearText()` to reset input after UIKit finishes applying autocorrections  
- Prevented a race condition between app state updates and UIKit’s delayed autocorrect commit  

---

### 🛠 Implementation


- Clearing `text` immediately conflicted with this delayed commit, causing the autocorrected text to reappear in the input field.  
- The fix removes the redundant immediate clear and relies solely on the deferred clear (`DispatchQueue.main.asyncAfter`).  
- This ensures the field is reset only after UIKit has finished its autocorrection cycle.  

---

### 🎨 Showcase

| Before | After |
| ------ | ----- |
| Input sometimes still shows autocorrected text after sending | Input reliably clears after sending |

---

### 🧪 Manual Testing Notes

1. Type a word that triggers autocorrection (e.g., `teh` → `the`).  
2. Without manually accepting the suggestion, tap **Send**.  
3. ✅ The message is sent and the input clears immediately.  
4. Repeat with different autocorrections and verify consistent behavior.  

---

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)  
- [x] This change should be manually QAed  
- [ ] Changelog is updated with client-facing changes  
- [ ] Changelog is updated with new localization keys  
- [ ] New code is covered by unit tests  
- [ ] Documentation has been updated in the `docs-content` repo  
