### PR TITLE
Fix message list not scrolling to newest message with long text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix swipe to reply enabled when quoting a message is disabled  [#977](https://github.com/GetStream/stream-chat-swiftui/pull/957)
 - Fix composer not showing images in the composer when editing signed attachments [#956](https://github.com/GetStream/stream-chat-swiftui/pull/956)
 - Fix replacing an image while editing a message not showing the new image in the message list [#956](https://github.com/GetStream/stream-chat-swiftui/pull/956)
+- Improve precision when scrolling to the newest message with long text #958
 
 # [4.88.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.88.0)
 _September 10, 2025_

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelViewModel.swift
@@ -264,12 +264,11 @@ open class ChatChannelViewModel: ObservableObject, MessagesDataSource {
         }
     }
 
+    var isNewMessageFromCurrentUser = false
+
     /// The user tapped on the message sent button.
     public func messageSentTapped() {
-        // only scroll if the message is not being edited
-        if editedMessage == nil {
-            scrollToLastMessage()
-        }
+        isNewMessageFromCurrentUser = true
     }
 
     public func jumpToMessage(messageId: String) -> Bool {
@@ -448,6 +447,9 @@ open class ChatChannelViewModel: ObservableObject, MessagesDataSource {
         
         if !showScrollToLatestButton && scrolledId == nil && !loadingNextMessages {
             updateScrolledIdToNewestMessage()
+        } else if changes.first?.isInsertion == true && isNewMessageFromCurrentUser {
+            updateScrolledIdToNewestMessage()
+            isNewMessageFromCurrentUser = false
         }
     }
     

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelViewModel.swift
@@ -36,7 +36,8 @@ open class ChatChannelViewModel: ObservableObject, MessagesDataSource {
     private var readsString = ""
     private var canMarkRead = false
     private var hasSetInitialCanMarkRead = false
-    
+    private var currentUserSentNewMessage = false
+
     private let messageListDateOverlay: DateFormatter = DateFormatter.messageListDateOverlay
     
     private lazy var messagesDateFormatter = utils.dateFormatter
@@ -264,11 +265,9 @@ open class ChatChannelViewModel: ObservableObject, MessagesDataSource {
         }
     }
 
-    var isNewMessageFromCurrentUser = false
-
     /// The user tapped on the message sent button.
     public func messageSentTapped() {
-        isNewMessageFromCurrentUser = true
+        currentUserSentNewMessage = true
     }
 
     public func jumpToMessage(messageId: String) -> Bool {
@@ -447,9 +446,9 @@ open class ChatChannelViewModel: ObservableObject, MessagesDataSource {
         
         if !showScrollToLatestButton && scrolledId == nil && !loadingNextMessages {
             updateScrolledIdToNewestMessage()
-        } else if changes.first?.isInsertion == true && isNewMessageFromCurrentUser {
+        } else if changes.first?.isInsertion == true && currentUserSentNewMessage {
             updateScrolledIdToNewestMessage()
-            isNewMessageFromCurrentUser = false
+            currentUserSentNewMessage = false
         }
     }
     

--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageListView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/MessageListView.swift
@@ -251,13 +251,19 @@ public struct MessageListView<Factory: ViewFactory>: View, KeyboardReadable {
                 .frame(maxWidth: .infinity)
                 .clipped()
                 .onChange(of: scrolledId) { scrolledId in
-                    if let scrolledId = scrolledId {
-                        let shouldJump = onJumpToMessage?(scrolledId) ?? false
-                        if !shouldJump {
-                            return
-                        }
-                        withAnimation {
-                            scrollView.scrollTo(scrolledId, anchor: messageListConfig.scrollingAnchor)
+                    DispatchQueue.main.async {
+                        if let scrolledId = scrolledId {
+                            let shouldJump = onJumpToMessage?(scrolledId) ?? false
+                            if !shouldJump {
+                                return
+                            }
+                            withAnimation {
+                                if messages.first?.id == scrolledId {
+                                    scrollView.scrollTo(scrolledId, anchor: .top)
+                                } else {
+                                    scrollView.scrollTo(scrolledId, anchor: messageListConfig.scrollingAnchor)
+                                }
+                            }
                         }
                     }
                 }

--- a/StreamChatSwiftUITests/Tests/ChatChannel/ChatChannelViewModel_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/ChatChannelViewModel_Tests.swift
@@ -94,25 +94,6 @@ class ChatChannelViewModel_Tests: StreamChatTestCase {
         XCTAssert(viewModel.scrolledId!.contains(messageId))
     }
 
-    func test_chatChannelVM_messageSentTapped() {
-        // Given
-        let messageId: String = .unique
-        let message = ChatMessage.mock(
-            id: messageId,
-            cid: .unique,
-            text: "Test message",
-            author: ChatUser.mock(id: chatClient.currentUserId!)
-        )
-        let channelController = makeChannelController(messages: [message])
-        let viewModel = ChatChannelViewModel(channelController: channelController)
-
-        // When
-        viewModel.messageSentTapped()
-
-        // Then
-        XCTAssert(viewModel.scrolledId!.contains(messageId))
-    }
-
     func test_chatChannelVM_messageSentTapped_whenEditingMessage_shouldNotScroll() {
         // Given
         let messageId: String = .unique
@@ -207,6 +188,37 @@ class ChatChannelViewModel_Tests: StreamChatTestCase {
         // Then
         let newListId = viewModel.listId
         XCTAssert(initialListId == newListId)
+    }
+
+    func test_chatChannelVM_newMessageSentScrollsToNewestMessage() {
+        // Given
+        var messages = [ChatMessage]()
+        for i in 0..<5 {
+            let message = ChatMessage.mock(
+                id: .unique,
+                cid: .unique,
+                text: "Test Message \(i)",
+                author: ChatUser.mock(id: chatClient.currentUserId!)
+            )
+            messages.append(message)
+        }
+        let channelController = makeChannelController(messages: messages)
+        let viewModel = ChatChannelViewModel(channelController: channelController)
+
+        // When
+        viewModel.showScrollToLatestButton = true
+        viewModel.messageSentTapped()
+        viewModel.dataSource(
+            channelDataSource: ChatChannelDataSource(controller: channelController),
+            didUpdateMessages: LazyCachedMapCollection(elements: messages),
+            changes: [
+                .insert(messages[0], index: .init(item: 0, section: 0)),
+                .update(messages[1], index: .init(item: 1, section: 0))
+            ]
+        )
+
+        // Then
+        XCTAssertEqual(viewModel.scrolledId, messages[0].id)
     }
 
     func test_chatChannelVM_messageThread() {


### PR DESCRIPTION
### 🔗 Issue Links

https://linear.app/stream/issue/IOS-1097/deputyswiftui-scroll-to-last-message-does-not-scroll-correctly

### 🎯 Goal

Fix message list not scrolling to the newest message with long text

### 🛠 Implementation

Sometimes, when the list has a lot of messages and we are at the top, the scrolling is not precise. But this seems like a problem with SwiftUI. Either way, this change improves things a lot. After tapping again the button it works. And most importantly, when opening the channel, the list is correctly at the bottom.

### 🧪 Manual Testing Notes

1. Send a really long message
2. Close the channel
3. Open the channel
4. The message list should be scrolled to the bottom
5. Scroll up
6. Tap on the button to scroll to the bottom
7. The message should be fully visible at the bottom (Does not work 100% of times)

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
