### PR TITLE
Fix not importing Foundation in GalleryHeaderViewDateFormatter

### DIFF
--- a/Sources/StreamChatSwiftUI/Utils/Common/GalleryHeaderViewDateFormatter.swift
+++ b/Sources/StreamChatSwiftUI/Utils/Common/GalleryHeaderViewDateFormatter.swift
@@ -2,6 +2,8 @@
 // Copyright © 2025 Stream.io Inc. All rights reserved.
 //
 
+import Foundation
+
 /// A formatter used to display the message timestamp in the gallery header view.
 public final class GalleryHeaderViewDateFormatter: DateFormatter, @unchecked Sendable {
     override public init() {


### PR DESCRIPTION
Hotfix for Release 4.89.0
