### PR TITLE
Update CHANGELOG with fix for GalleryHeaderViewDateFormatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### 🐞 Fixed
+- Fix not importing Foundation in GalleryHeaderViewDateFormatter [#970](https://github.com/GetStream/stream-chat-swiftui/pull/970)
 
 # [4.89.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.89.0)
 _September 22, 2025_


### PR DESCRIPTION
Added a fix entry for not importing Foundation in GalleryHeaderViewDateFormatter.
