### PR TITLE
Make the commandsHandler and the mention methods public to allow customization of the mention command handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+### ✅ Added
+- Make the commandsHandler and the mention methods public to allow customization of the mention command handler [#979](https://github.com/GetStream/stream-chat-swiftui/pull/979)
+
 ### 🐞 Fixed
 - Fix openChannel not working when searching or another chat shown [#975](https://github.com/GetStream/stream-chat-swiftui/pull/975)
 - Fix crash when using a font that does not support bold or italic trait [#976](https://github.com/GetStream/stream-chat-swiftui/pull/976)

--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerViewModel.swift
@@ -219,7 +219,7 @@ open class MessageComposerViewModel: ObservableObject {
     }
     
     private var cancellables = Set<AnyCancellable>()
-    private lazy var commandsHandler = utils
+    public lazy var commandsHandler = utils
         .commandsConfig
         .makeCommandsHandler(
             with: channelController
@@ -690,7 +690,7 @@ open class MessageComposerViewModel: ObservableObject {
         }
     }
 
-    private func checkForMentionedUsers(
+    public func checkForMentionedUsers(
         commandId: String?,
         extraData: [String: Any]
     ) {
@@ -701,7 +701,7 @@ open class MessageComposerViewModel: ObservableObject {
         mentionedUsers.insert(user)
     }
     
-    private func clearRemovedMentions() {
+    public func clearRemovedMentions() {
         for user in mentionedUsers {
             if !text.contains("@\(user.mentionText)") {
                 mentionedUsers.remove(user)
@@ -742,7 +742,7 @@ open class MessageComposerViewModel: ObservableObject {
         clearInputData()
     }
     
-    private func clearInputData() {
+    public func clearInputData() {
         addedAssets = []
         addedFileURLs = []
         addedVoiceRecordings = []
@@ -806,7 +806,7 @@ open class MessageComposerViewModel: ObservableObject {
         .store(in: &cancellables)
     }
 
-    private func checkChannelCooldown() {
+    public func checkChannelCooldown() {
         let duration = channelController.channel?.cooldownDuration ?? 0
         if duration > 0 && timer == nil && !isSlowModeDisabled {
             cooldownDuration = duration


### PR DESCRIPTION
### 🔗 Issue Links

N/A

### 🎯 Goal

Allow customization of the mention command handler

### 📝 Summary

Make the commandsHandler and the mention methods public

### 🛠 Implementation

In the `MessageComposerViewModel.swift`, make the following public: 
- property `commandsHandler`
- method `checkForMentionedUsers`
- method `clearRemovedMentions`
- method `clearInputData`
- method `checkChannelCooldown`
### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
