### PR TITLE
fix ios26 navigationBarTrailing style

### DIFF
--- a/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/ChatChannelInfoView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/ChatChannelInfoView.swift
@@ -170,6 +170,7 @@ public struct ChatChannelInfoView<Factory: ViewFactory>: View, KeyboardReadable 
                             .background(colors.tintColor)
                             .clipShape(Circle())
                     }
+                    .buttonStyle(.plain)
                 }
             }
         }


### PR DESCRIPTION
### 🎯 Goal

fix ios26 navigationBarTrailing style

### 📝 Summary

I found an issue at navigationBarTrailing a t iOS26 specially for adding members into group channel
 
### 🛠 Implementation

I added `.buttonStyle(.plain) ` modifier for this this training button and sound good now

### 🎨 Showcase

| Before | After |
| ------ | ----- |
|  <img width="1170" height="2532" alt="Simulator Screenshot - iPhone 16e - 2025-10-03 at 17 53 05" src="https://github.com/user-attachments/assets/7d6e95e6-ce2c-4563-a331-675a2fcd2c96" />  |  <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-10-03 at 17 50 41" src="https://github.com/user-attachments/assets/7291ec49-374e-4a78-a7e3-5cbc2a9d963a" />  |





### ☑️ Contributor Checklist
- [x] This change should be manually QAed

