### PR TITLE
[CI] Partly revert Xcode 26 rollout

### DIFF
--- a/.github/workflows/cron-checks.yml
+++ b/.github/workflows/cron-checks.yml
@@ -23,15 +23,15 @@ jobs:
         include:
           # - ios: "26.0" TODO: IOS-1181
           #   device: "iPhone 17 Pro"
-          #   xcode: "26.0"
+          #   xcode: "26.0.1"
           #   setup_runtime: false
           - ios: "18.5"
             device: "iPhone 16 Pro"
-            xcode: "26.0"
+            xcode: "26.0.1"
             setup_runtime: false
           - ios: "17.5"
             device: "iPhone 15 Pro"
-            xcode: "26.0"
+            xcode: "26.0.1"
             setup_runtime: true
           - ios: "16.4"
             device: "iPhone 14 Pro"

--- a/.github/workflows/smoke-checks.yml
+++ b/.github/workflows/smoke-checks.yml
@@ -20,7 +20,7 @@ concurrency:
 
 env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1 # Disable cleanup for homebrew, we don't need it on CI
-  IOS_SIMULATOR_DEVICE: "iPhone 17 Pro (26.0)"
+  IOS_SIMULATOR_DEVICE: "iPhone 16 Pro (18.5)"
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GITHUB_PR_NUM: ${{ github.event.pull_request.number }}
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -8,7 +8,7 @@ require 'xcodeproj'
 import 'Sonarfile'
 import 'Allurefile'
 
-xcode_version = ENV['XCODE_VERSION'] || '26.0'
+xcode_version = ENV['XCODE_VERSION'] || '16.4'
 xcode_project = 'StreamChatSwiftUI.xcodeproj'
 sdk_names = ['StreamChatSwiftUI']
 github_repo = ENV['GITHUB_REPOSITORY'] || 'GetStream/stream-chat-swiftui'


### PR DESCRIPTION
### 🎯 Goal

To align with UIKit, we will release SwiftUI on Xcode 16.4, until UIKit is migrated to Xcode 26.

PS: cron checks will still be done on Xcode 26 as well as Xcode 16.