### PR TITLE
Expose `MediaAttachment` properties and initializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add participant actions in channel info view [#982](https://github.com/GetStream/stream-chat-swiftui/pull/982)
 - Add support for overriding `onImageTap` in `LinkAttachmentView` [#986](https://github.com/GetStream/stream-chat-swiftui/pull/986)
 - Add support for customizing text colors in `LinkAttachmentView` [#992](https://github.com/GetStream/stream-chat-swiftui/pull/992)
+- Expose `MediaAttachment` properties and initializer [#1000](https://github.com/GetStream/stream-chat-swiftui/pull/1000)
 
 ### 🐞 Fixed
 - Fix openChannel not working when searching or another chat shown [#975](https://github.com/GetStream/stream-chat-swiftui/pull/975)

--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/ImageAttachmentView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/ImageAttachmentView.swift
@@ -425,9 +425,15 @@ extension ChatMessage {
 public struct MediaAttachment: Identifiable, Equatable {
     @Injected(\.utils) var utils
 
-    let url: URL
-    let type: MediaAttachmentType
-    var uploadingState: AttachmentUploadingState?
+    public let url: URL
+    public let type: MediaAttachmentType
+    public var uploadingState: AttachmentUploadingState?
+
+    public init(url: URL, type: MediaAttachmentType, uploadingState: AttachmentUploadingState? = nil) {
+        self.url = url
+        self.type = type
+        self.uploadingState = uploadingState
+    }
 
     public var id: String {
         url.absoluteString
@@ -477,9 +483,14 @@ extension MediaAttachment {
     }
 }
 
-enum MediaAttachmentType {
-    case image
-    case video
+public struct MediaAttachmentType: RawRepresentable {
+    public let rawValue: String
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public static let image = Self(rawValue: "image")
+    public static let video = Self(rawValue: "video")
 }
 
 /// Options for the gallery view.


### PR DESCRIPTION
### 🔗 Issue Links

https://linear.app/stream/issue/IOS-1184/expose-media-attachment-properties

### 🎯 Goal

Expose `MediaAttachment` properties and initializer.

Changes `MediaAttachmentType` to a struct so that it can be extendable.

### 🧪 Manual Testing Notes

N/A

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
