### PR TITLE
[DemoApp] Build gifs grid view

### DIFF
--- a/DemoAppSwiftUI/AppConfiguration/AppConfiguration.swift
+++ b/DemoAppSwiftUI/AppConfiguration/AppConfiguration.swift
@@ -16,4 +16,6 @@ final class AppConfiguration: ObservableObject {
     @Published var isChannelPinningFeatureEnabled = false
     /// Force RTL layout for preview (e.g. demo app).
     @Published var forceRTL = false
+    /// When enabled, tapping Giphy in Instant Commands shows a horizontally scrollable GIF grid; composer text drives the search query.
+    @Published var isGiphyGridEnabled = false
 }

--- a/DemoAppSwiftUI/AppConfiguration/AppConfigurationView.swift
+++ b/DemoAppSwiftUI/AppConfiguration/AppConfigurationView.swift
@@ -18,6 +18,12 @@ struct AppConfigurationView: View {
         AppConfiguration.default.forceRTL = newValue
     }
 
+    var giphyGridEnabled: Binding<Bool> = Binding {
+        AppConfiguration.default.isGiphyGridEnabled
+    } set: { newValue in
+        AppConfiguration.default.isGiphyGridEnabled = newValue
+    }
+
     var body: some View {
         NavigationView {
             List {
@@ -29,6 +35,9 @@ struct AppConfigurationView: View {
                 }
                 Section("Layout") {
                     Toggle("Force RTL (preview)", isOn: forceRTL)
+                }
+                Section("Composer") {
+                    Toggle("GIF grid (Giphy picker)", isOn: giphyGridEnabled)
                 }
             }
             .navigationBarTitleDisplayMode(.inline)

--- a/DemoAppSwiftUI/AppDelegate.swift
+++ b/DemoAppSwiftUI/AppDelegate.swift
@@ -70,6 +70,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         }
         
         let utils = Utils(
+            messageTypeResolver: DemoAppMessageTypeResolver(),
             channelListConfig: ChannelListConfig(
                 messageRelativeDateFormatEnabled: true,
                 channelItemMutedStyle: .afterChannelName

--- a/DemoAppSwiftUI/AppleMessageComposerView.swift
+++ b/DemoAppSwiftUI/AppleMessageComposerView.swift
@@ -158,6 +158,7 @@ struct AppleMessageComposerView<Factory: ViewFactory>: View, KeyboardReadable {
                         )
                     }
                 )
+                .environmentObject(viewModel)
                 .offset(y: -composerHeight)
                 .animation(nil) : nil,
             alignment: .bottom

--- a/DemoAppSwiftUI/Giphy/AnimatedGifView.swift
+++ b/DemoAppSwiftUI/Giphy/AnimatedGifView.swift
@@ -1,0 +1,54 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import SwiftUI
+import WebKit
+
+/// Displays an animated GIF via WKWebView (SwiftUI's AsyncImage only shows the first frame).
+/// Shared by the Giphy grid and the custom_giphy message bubble.
+struct AnimatedGifView: UIViewRepresentable {
+    let gifURL: URL
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    func makeUIView(context: Context) -> WKWebView {
+        let webView = WKWebView()
+        webView.isOpaque = false
+        webView.backgroundColor = .clear
+        webView.isUserInteractionEnabled = false
+        webView.scrollView.isScrollEnabled = false
+        webView.scrollView.backgroundColor = .clear
+        return webView
+    }
+
+    func updateUIView(_ webView: WKWebView, context: Context) {
+        guard gifURL != context.coordinator.lastLoadedURL else { return }
+        context.coordinator.lastLoadedURL = gifURL
+
+        guard gifURL.scheme == "https" || gifURL.scheme == "http" else { return }
+        // Load our HTML; img src is escaped so we request the image directly (avoids Giphy consent page that load(URLRequest) would hit).
+        let escaped = Self.escapeForHTMLAttribute(gifURL.absoluteString)
+        let html = """
+        <html><head><meta name="viewport" content="width=device-width,initial-scale=1"/></head>\
+        <body style="margin:0;background:transparent;width:100%;height:100%;">\
+        <img src="\(escaped)" style="width:100%;height:100%;object-fit:cover;display:block;" />\
+        </body></html>
+        """
+        webView.loadHTMLString(html, baseURL: nil)
+    }
+
+    private static func escapeForHTMLAttribute(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+    }
+
+    final class Coordinator {
+        var lastLoadedURL: URL?
+    }
+}

--- a/DemoAppSwiftUI/Giphy/CustomGiphyAttachmentPayload.swift
+++ b/DemoAppSwiftUI/Giphy/CustomGiphyAttachmentPayload.swift
@@ -1,0 +1,85 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+import StreamChat
+import StreamChatSwiftUI
+import SwiftUI
+import WebKit
+
+/// Custom attachment type for GIFs picked from the demo's Giphy grid (keeps built-in .giphy untouched).
+extension AttachmentType {
+    static let customGiphy = Self(rawValue: "custom_giphy")
+}
+
+struct CustomGiphyAttachmentPayload: AttachmentPayload {
+    static let type: AttachmentType = .customGiphy
+
+    let title: String
+    let previewURL: URL
+}
+
+/// Resolver so messages with custom_giphy attachments use the custom attachment view.
+struct DemoAppMessageTypeResolver: MessageTypeResolving {
+    func hasCustomAttachment(message: ChatMessage) -> Bool {
+        !message.attachments(payloadType: CustomGiphyAttachmentPayload.self).isEmpty
+    }
+}
+
+/// Renders a message that contains custom_giphy attachments (animated GIF in bubble).
+struct CustomGiphyMessageView: View {
+    let message: ChatMessage
+    let isFirst: Bool
+    let availableWidth: CGFloat
+    @Binding var scrolledId: String?
+
+    var body: some View {
+        let attachments = message.attachments(payloadType: CustomGiphyAttachmentPayload.self)
+        VStack(alignment: message.isSentByCurrentUser ? .trailing : .leading, spacing: 0) {
+            ForEach(Array(attachments.enumerated()), id: \.offset) { _, attachment in
+                CustomGiphyAttachmentMessageCell(payload: attachment.payload, width: availableWidth)
+            }
+        }
+        .messageBubble(for: message, isFirst: isFirst)
+    }
+}
+
+private struct CustomGiphyAttachmentMessageCell: View {
+    let payload: CustomGiphyAttachmentPayload
+    let width: CGFloat
+
+    /// Use a fixed aspect ratio so the cell has a defined size; avoids grey gap from WKWebView's unreliable intrinsic size.
+    private static let aspectRatio: CGFloat = 1
+
+    var body: some View {
+        AnimatedGifMessageView(gifURL: payload.previewURL)
+            .frame(width: width, height: width * Self.aspectRatio)
+            .clipped()
+    }
+}
+
+/// Displays an animated GIF in the message list (reuses same approach as grid).
+private struct AnimatedGifMessageView: UIViewRepresentable {
+    let gifURL: URL
+
+    func makeUIView(context: Context) -> WKWebView {
+        let webView = WKWebView()
+        webView.isOpaque = false
+        webView.backgroundColor = .clear
+        webView.isUserInteractionEnabled = false
+        webView.scrollView.isScrollEnabled = false
+        webView.scrollView.backgroundColor = .clear
+        return webView
+    }
+
+    func updateUIView(_ webView: WKWebView, context: Context) {
+        let html = """
+        <html><head><meta name="viewport" content="width=device-width,initial-scale=1"/></head>
+        <body style="margin:0;background:transparent;width:100%;height:100%;">
+        <img src="\(gifURL.absoluteString)" style="width:100%;height:100%;object-fit:cover;display:block;" />
+        </body></html>
+        """
+        webView.loadHTMLString(html, baseURL: gifURL)
+    }
+}

--- a/DemoAppSwiftUI/Giphy/CustomGiphyAttachmentPayload.swift
+++ b/DemoAppSwiftUI/Giphy/CustomGiphyAttachmentPayload.swift
@@ -6,7 +6,6 @@ import Foundation
 import StreamChat
 import StreamChatSwiftUI
 import SwiftUI
-import WebKit
 
 /// Custom attachment type for GIFs picked from the demo's Giphy grid (keeps built-in .giphy untouched).
 extension AttachmentType {
@@ -53,33 +52,8 @@ private struct CustomGiphyAttachmentMessageCell: View {
     private static let aspectRatio: CGFloat = 1
 
     var body: some View {
-        AnimatedGifMessageView(gifURL: payload.previewURL)
+        AnimatedGifView(gifURL: payload.previewURL)
             .frame(width: width, height: width * Self.aspectRatio)
             .clipped()
-    }
-}
-
-/// Displays an animated GIF in the message list (reuses same approach as grid).
-private struct AnimatedGifMessageView: UIViewRepresentable {
-    let gifURL: URL
-
-    func makeUIView(context: Context) -> WKWebView {
-        let webView = WKWebView()
-        webView.isOpaque = false
-        webView.backgroundColor = .clear
-        webView.isUserInteractionEnabled = false
-        webView.scrollView.isScrollEnabled = false
-        webView.scrollView.backgroundColor = .clear
-        return webView
-    }
-
-    func updateUIView(_ webView: WKWebView, context: Context) {
-        let html = """
-        <html><head><meta name="viewport" content="width=device-width,initial-scale=1"/></head>
-        <body style="margin:0;background:transparent;width:100%;height:100%;">
-        <img src="\(gifURL.absoluteString)" style="width:100%;height:100%;object-fit:cover;display:block;" />
-        </body></html>
-        """
-        webView.loadHTMLString(html, baseURL: gifURL)
     }
 }

--- a/DemoAppSwiftUI/Giphy/DemoAppCommandsContainerView.swift
+++ b/DemoAppSwiftUI/Giphy/DemoAppCommandsContainerView.swift
@@ -1,0 +1,62 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import StreamChat
+import StreamChatSwiftUI
+import SwiftUI
+
+/// Demo app commands container: when GIF grid is enabled and user selected Giphy, shows horizontally scrollable GIF grid; otherwise default commands (mentions, instant commands).
+struct DemoAppCommandsContainerView<Factory: ViewFactory>: View {
+    @EnvironmentObject private var viewModel: MessageComposerViewModel
+
+    var factory: Factory
+    var suggestions: [String: Any]
+    var handleCommand: ([String: Any]) -> Void
+
+    var body: some View {
+        ZStack {
+            if AppConfiguration.default.isGiphyGridEnabled,
+               viewModel.composerCommand?.id == "/giphy" {
+                GiphyGridView(
+                    searchQuery: $viewModel.text,
+                    onSelect: { item in
+                        addGiphyAndDismiss(item: item)
+                    },
+                    onBack: {
+                        viewModel.composerCommand = nil
+                    }
+                )
+                .accessibilityIdentifier("GiphyGridView")
+            } else {
+                CommandsContainerView(
+                    factory: factory,
+                    suggestions: suggestions,
+                    handleCommand: handleCommand
+                )
+            }
+        }
+        .accessibilityElement(children: .contain)
+    }
+
+    private func addGiphyAndDismiss(item: GiphyService.GiphyItem) {
+        guard let url = item.fullURL ?? item.previewURL else { return }
+        let payload = GiphyAttachmentPayload(
+            title: item.title ?? "GIF",
+            previewURL: url,
+            actions: []
+        )
+        let anyPayload = AnyAttachmentPayload(payload: payload)
+        let custom = CustomAttachment(id: item.id, content: anyPayload)
+        viewModel.addedCustomAttachments.append(custom)
+        viewModel.composerCommand = nil
+        viewModel.text = ""
+
+        viewModel.sendMessage(
+            quotedMessage: viewModel.quotedMessage?.wrappedValue,
+            editedMessage: nil
+        ) {
+            viewModel.quotedMessage?.wrappedValue = nil
+        }
+    }
+}

--- a/DemoAppSwiftUI/Giphy/DemoAppCommandsContainerView.swift
+++ b/DemoAppSwiftUI/Giphy/DemoAppCommandsContainerView.swift
@@ -58,8 +58,6 @@ struct DemoAppCommandsContainerView<Factory: ViewFactory>: View {
         ) {
             viewModel.quotedMessage?.wrappedValue = nil
             isSubmitting = false
-        } onError: { _ in
-            isSubmitting = false
         }
     }
 }

--- a/DemoAppSwiftUI/Giphy/DemoAppCommandsContainerView.swift
+++ b/DemoAppSwiftUI/Giphy/DemoAppCommandsContainerView.swift
@@ -41,10 +41,9 @@ struct DemoAppCommandsContainerView<Factory: ViewFactory>: View {
 
     private func addGiphyAndDismiss(item: GiphyService.GiphyItem) {
         guard let url = item.fullURL ?? item.previewURL else { return }
-        let payload = GiphyAttachmentPayload(
+        let payload = CustomGiphyAttachmentPayload(
             title: item.title ?? "GIF",
-            previewURL: url,
-            actions: []
+            previewURL: url
         )
         let anyPayload = AnyAttachmentPayload(payload: payload)
         let custom = CustomAttachment(id: item.id, content: anyPayload)

--- a/DemoAppSwiftUI/Giphy/DemoAppCommandsContainerView.swift
+++ b/DemoAppSwiftUI/Giphy/DemoAppCommandsContainerView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 /// Demo app commands container: when GIF grid is enabled and user selected Giphy, shows horizontally scrollable GIF grid; otherwise default commands (mentions, instant commands).
 struct DemoAppCommandsContainerView<Factory: ViewFactory>: View {
     @EnvironmentObject private var viewModel: MessageComposerViewModel
+    @State private var isSubmitting = false
 
     var factory: Factory
     var suggestions: [String: Any]
@@ -20,6 +21,7 @@ struct DemoAppCommandsContainerView<Factory: ViewFactory>: View {
                viewModel.composerCommand?.id == "/giphy" {
                 GiphyGridView(
                     searchQuery: $viewModel.text,
+                    isSelectionDisabled: isSubmitting,
                     onSelect: { item in
                         addGiphyAndDismiss(item: item)
                     },
@@ -40,7 +42,9 @@ struct DemoAppCommandsContainerView<Factory: ViewFactory>: View {
     }
 
     private func addGiphyAndDismiss(item: GiphyService.GiphyItem) {
+        guard !isSubmitting else { return }
         guard let url = item.fullURL ?? item.previewURL else { return }
+        isSubmitting = true
         let payload = CustomGiphyAttachmentPayload(
             title: item.title ?? "GIF",
             previewURL: url
@@ -56,6 +60,7 @@ struct DemoAppCommandsContainerView<Factory: ViewFactory>: View {
             editedMessage: nil
         ) {
             viewModel.quotedMessage?.wrappedValue = nil
+            isSubmitting = false
         }
     }
 }

--- a/DemoAppSwiftUI/Giphy/DemoAppCommandsContainerView.swift
+++ b/DemoAppSwiftUI/Giphy/DemoAppCommandsContainerView.swift
@@ -24,9 +24,6 @@ struct DemoAppCommandsContainerView<Factory: ViewFactory>: View {
                     isSelectionDisabled: isSubmitting,
                     onSelect: { item in
                         addGiphyAndDismiss(item: item)
-                    },
-                    onBack: {
-                        viewModel.composerCommand = nil
                     }
                 )
                 .accessibilityIdentifier("GiphyGridView")
@@ -60,6 +57,8 @@ struct DemoAppCommandsContainerView<Factory: ViewFactory>: View {
             editedMessage: nil
         ) {
             viewModel.quotedMessage?.wrappedValue = nil
+            isSubmitting = false
+        } onError: { _ in
             isSubmitting = false
         }
     }

--- a/DemoAppSwiftUI/Giphy/GiphyGridView.swift
+++ b/DemoAppSwiftUI/Giphy/GiphyGridView.swift
@@ -1,0 +1,160 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import StreamChat
+import StreamChatSwiftUI
+import SwiftUI
+import WebKit
+
+/// Horizontally scrollable grid of Giphy GIFs. Query is driven by composer text; selecting a GIF adds it as a giphy attachment and triggers send.
+struct GiphyGridView: View {
+    @Injected(\.colors) private var colors
+    @Injected(\.fonts) private var fonts
+
+    @Binding var searchQuery: String
+    var onSelect: (GiphyService.GiphyItem) -> Void
+    var onBack: () -> Void
+
+    @State private var items: [GiphyService.GiphyItem] = []
+    @State private var loading = false
+    @State private var task: Task<Void, Never>?
+
+    private let rowCount = 1
+    private let cellSize: CGFloat = 120
+    private let spacing: CGFloat = 8
+    private var gridHeight: CGFloat {
+        cellSize * CGFloat(rowCount) + spacing * CGFloat(rowCount + 1) + 16
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if loading && items.isEmpty {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if items.isEmpty {
+                VStack(spacing: 8) {
+                    Text("No GIFs loaded")
+                        .font(fonts.body)
+                        .foregroundColor(Color(colors.textLowEmphasis))
+                    Text("Add a Giphy API key in GiphyService.swift")
+                        .font(fonts.footnote)
+                        .foregroundColor(Color(colors.textLowEmphasis))
+                        .multilineTextAlignment(.center)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .padding(.top, 40)
+            } else {
+                ScrollView(.horizontal, showsIndicators: true) {
+                    LazyHGrid(
+                        rows: [GridItem(.fixed(cellSize), spacing: spacing)],
+                        alignment: .top,
+                        spacing: spacing
+                    ) {
+                        ForEach(items, id: \.id) { item in
+                            GiphyCell(item: item, size: cellSize)
+                                .contentShape(Rectangle())
+                                .highPriorityGesture(
+                                    TapGesture().onEnded { _ in onSelect(item) }
+                                )
+                        }
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                }
+                .frame(height: gridHeight)
+            }
+        }
+        .frame(height: gridHeight)
+        .background(Color(colors.background))
+        .cornerRadius(16)
+        .shadow(color: .black.opacity(0.1), radius: 10, x: 0, y: 4)
+        .overlay(
+            RoundedRectangle(cornerRadius: 16)
+                .stroke(Color(colors.innerBorder), lineWidth: 0.5)
+        )
+        .padding(.all, 8)
+        .onChange(of: searchQuery) { newValue in
+            debouncedSearch(query: normalizedQuery(newValue))
+        }
+        .onAppear {
+            // Load immediately on appear (no debounce) so grid isn't empty
+            Task { await performSearch(query: normalizedQuery(searchQuery)) }
+        }
+    }
+
+    /// Strip /giphy prefix so we search the topic, not the command; empty -> "trending".
+    private func normalizedQuery(_ raw: String) -> String {
+        let trimmed = raw
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "/giphy", with: "", options: .caseInsensitive)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "trending" : trimmed
+    }
+
+    private func debouncedSearch(query: String) {
+        task?.cancel()
+        task = Task {
+            try? await Task.sleep(nanoseconds: 300_000_000)
+            guard !Task.isCancelled else { return }
+            await performSearch(query: query)
+        }
+    }
+
+    @MainActor
+    private func performSearch(query: String) async {
+        loading = true
+        defer { loading = false }
+        do {
+            let result = try await GiphyService.search(query: query, limit: 24)
+            items = result
+        } catch {
+            items = []
+        }
+    }
+}
+
+private struct GiphyCell: View {
+    let item: GiphyService.GiphyItem
+    let size: CGFloat
+
+    var body: some View {
+        Group {
+            if let url = item.previewURL {
+                AnimatedGifView(gifURL: url)
+            } else {
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(Color.gray.opacity(0.2))
+                    .overlay(Image(systemName: "photo").foregroundColor(.gray))
+            }
+        }
+        .frame(width: size, height: size)
+        .clipped()
+        .cornerRadius(8)
+    }
+}
+
+/// Displays a GIF URL with animation via WKWebView (SwiftUI AsyncImage only shows the first frame).
+private struct AnimatedGifView: UIViewRepresentable {
+    let gifURL: URL
+
+    func makeUIView(context: Context) -> WKWebView {
+        let webView = WKWebView()
+        webView.isOpaque = false
+        webView.backgroundColor = .clear
+        webView.scrollView.isScrollEnabled = false
+        webView.scrollView.backgroundColor = .clear
+        webView.isUserInteractionEnabled = false // let taps pass through to the cell's onTapGesture
+        return webView
+    }
+
+    func updateUIView(_ webView: WKWebView, context: Context) {
+        let html = """
+        <html><head><meta name="viewport" content="width=device-width,initial-scale=1"/></head>
+        <body style="margin:0;background:transparent;">
+        <img src="\(gifURL.absoluteString)" style="width:100%;height:100%;object-fit:cover;display:block;" />
+        </body></html>
+        """
+        webView.loadHTMLString(html, baseURL: gifURL)
+    }
+}

--- a/DemoAppSwiftUI/Giphy/GiphyGridView.swift
+++ b/DemoAppSwiftUI/Giphy/GiphyGridView.swift
@@ -5,7 +5,6 @@
 import StreamChat
 import StreamChatSwiftUI
 import SwiftUI
-import WebKit
 
 /// Horizontally scrollable grid of Giphy GIFs. Query is driven by composer text; selecting a GIF adds it as a giphy attachment and triggers send.
 struct GiphyGridView: View {
@@ -13,6 +12,7 @@ struct GiphyGridView: View {
     @Injected(\.fonts) private var fonts
 
     @Binding var searchQuery: String
+    var isSelectionDisabled: Bool = false
     var onSelect: (GiphyService.GiphyItem) -> Void
     var onBack: () -> Void
 
@@ -54,8 +54,12 @@ struct GiphyGridView: View {
                         ForEach(items, id: \.id) { item in
                             GiphyCell(item: item, size: cellSize)
                                 .contentShape(Rectangle())
+                                .opacity(isSelectionDisabled ? 0.6 : 1)
+                                .allowsHitTesting(!isSelectionDisabled)
                                 .highPriorityGesture(
-                                    TapGesture().onEnded { _ in onSelect(item) }
+                                    TapGesture().onEnded { _ in
+                                        if !isSelectionDisabled { onSelect(item) }
+                                    }
                                 )
                         }
                     }
@@ -79,7 +83,10 @@ struct GiphyGridView: View {
         }
         .onAppear {
             // Load immediately on appear (no debounce) so grid isn't empty
-            Task { await performSearch(query: normalizedQuery(searchQuery)) }
+            task = Task { await performSearch(query: normalizedQuery(searchQuery)) }
+        }
+        .onDisappear {
+            task?.cancel()
         }
     }
 
@@ -131,30 +138,5 @@ private struct GiphyCell: View {
         .frame(width: size, height: size)
         .clipped()
         .cornerRadius(8)
-    }
-}
-
-/// Displays a GIF URL with animation via WKWebView (SwiftUI AsyncImage only shows the first frame).
-private struct AnimatedGifView: UIViewRepresentable {
-    let gifURL: URL
-
-    func makeUIView(context: Context) -> WKWebView {
-        let webView = WKWebView()
-        webView.isOpaque = false
-        webView.backgroundColor = .clear
-        webView.scrollView.isScrollEnabled = false
-        webView.scrollView.backgroundColor = .clear
-        webView.isUserInteractionEnabled = false // let taps pass through to the cell's onTapGesture
-        return webView
-    }
-
-    func updateUIView(_ webView: WKWebView, context: Context) {
-        let html = """
-        <html><head><meta name="viewport" content="width=device-width,initial-scale=1"/></head>
-        <body style="margin:0;background:transparent;">
-        <img src="\(gifURL.absoluteString)" style="width:100%;height:100%;object-fit:cover;display:block;" />
-        </body></html>
-        """
-        webView.loadHTMLString(html, baseURL: gifURL)
     }
 }

--- a/DemoAppSwiftUI/Giphy/GiphyGridView.swift
+++ b/DemoAppSwiftUI/Giphy/GiphyGridView.swift
@@ -14,7 +14,6 @@ struct GiphyGridView: View {
     @Binding var searchQuery: String
     var isSelectionDisabled: Bool = false
     var onSelect: (GiphyService.GiphyItem) -> Void
-    var onBack: () -> Void
 
     @State private var items: [GiphyService.GiphyItem] = []
     @State private var loading = false

--- a/DemoAppSwiftUI/Giphy/GiphyService.swift
+++ b/DemoAppSwiftUI/Giphy/GiphyService.swift
@@ -1,0 +1,66 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+
+/// Minimal Giphy API client for the demo GIF grid.
+/// Get a free API key at https://developers.giphy.com/dashboard/ and set it below (or use the deprecated beta key for basic testing).
+enum GiphyService {
+    /// Replace with your own key from https://developers.giphy.com/dashboard/ — the old public beta key may return 403.
+    static let apiKey = ""
+
+    struct SearchResponse: Decodable {
+        let data: [GiphyItem]?
+    }
+
+    struct GiphyItem: Decodable {
+        let id: String
+        let title: String?
+        let images: Images?
+
+        struct Images: Decodable {
+            let fixedHeight: ImageInfo?
+            let fixedHeightSmall: ImageInfo?
+            let downsized: ImageInfo?
+            enum CodingKeys: String, CodingKey {
+                case fixedHeight = "fixed_height"
+                case fixedHeightSmall = "fixed_height_small"
+                case downsized
+            }
+        }
+
+        struct ImageInfo: Decodable {
+            let url: URL?
+            let width: String?
+            let height: String?
+        }
+
+        var previewURL: URL? {
+            images?.fixedHeightSmall?.url ?? images?.fixedHeight?.url ?? images?.downsized?.url
+        }
+
+        var fullURL: URL? {
+            images?.fixedHeight?.url ?? images?.downsized?.url
+        }
+    }
+
+    static func search(query: String, limit: Int = 24) async throws -> [GiphyItem] {
+        let q = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        let useTrending = q.isEmpty || q.lowercased() == "trending"
+        let endpoint: String
+        if useTrending {
+            endpoint = "https://api.giphy.com/v1/gifs/trending?api_key=\(apiKey)&limit=\(limit)"
+        } else {
+            let encoded = q.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? q
+            endpoint = "https://api.giphy.com/v1/gifs/search?api_key=\(apiKey)&q=\(encoded)&limit=\(limit)"
+        }
+        guard let url = URL(string: endpoint) else { return [] }
+        let (data, response) = try await URLSession.shared.data(from: url)
+        if let http = response as? HTTPURLResponse, http.statusCode != 200 {
+            throw NSError(domain: "GiphyService", code: http.statusCode, userInfo: [NSLocalizedDescriptionKey: "HTTP \(http.statusCode)"])
+        }
+        let decoded = try JSONDecoder().decode(SearchResponse.self, from: data)
+        return decoded.data ?? []
+    }
+}

--- a/DemoAppSwiftUI/Giphy/GiphyService.swift
+++ b/DemoAppSwiftUI/Giphy/GiphyService.swift
@@ -48,14 +48,17 @@ enum GiphyService {
     static func search(query: String, limit: Int = 24) async throws -> [GiphyItem] {
         let q = query.trimmingCharacters(in: .whitespacesAndNewlines)
         let useTrending = q.isEmpty || q.lowercased() == "trending"
-        let endpoint: String
-        if useTrending {
-            endpoint = "https://api.giphy.com/v1/gifs/trending?api_key=\(apiKey)&limit=\(limit)"
-        } else {
-            let encoded = q.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? q
-            endpoint = "https://api.giphy.com/v1/gifs/search?api_key=\(apiKey)&q=\(encoded)&limit=\(limit)"
+        let path = useTrending ? "/v1/gifs/trending" : "/v1/gifs/search"
+        var components = URLComponents(string: "https://api.giphy.com")!
+        components.path = path
+        components.queryItems = [
+            URLQueryItem(name: "api_key", value: apiKey),
+            URLQueryItem(name: "limit", value: String(limit))
+        ]
+        if !useTrending {
+            components.queryItems?.append(URLQueryItem(name: "q", value: q))
         }
-        guard let url = URL(string: endpoint) else { return [] }
+        guard let url = components.url else { return [] }
         let (data, response) = try await URLSession.shared.data(from: url)
         if let http = response as? HTTPURLResponse, http.statusCode != 200 {
             throw NSError(domain: "GiphyService", code: http.statusCode, userInfo: [NSLocalizedDescriptionKey: "HTTP \(http.statusCode)"])

--- a/DemoAppSwiftUI/ViewFactoryExamples.swift
+++ b/DemoAppSwiftUI/ViewFactoryExamples.swift
@@ -80,7 +80,18 @@ class DemoAppFactory: ViewFactory {
     public func makeMessageViewModifier(for messageModifierInfo: MessageModifierInfo) -> some ViewModifier {
         ShowProfileModifier(messageModifierInfo: messageModifierInfo, mentionsHandler: mentionsHandler)
     }
-    
+
+    func makeCommandsContainerView(
+        suggestions: [String: Any],
+        handleCommand: @escaping ([String: Any]) -> Void
+    ) -> some View {
+        DemoAppCommandsContainerView(
+            factory: self,
+            suggestions: suggestions,
+            handleCommand: handleCommand
+        )
+    }
+
     private func archiveChannelAction(
         for channel: ChatChannel,
         onDismiss: @escaping () -> Void,

--- a/DemoAppSwiftUI/ViewFactoryExamples.swift
+++ b/DemoAppSwiftUI/ViewFactoryExamples.swift
@@ -92,6 +92,20 @@ class DemoAppFactory: ViewFactory {
         )
     }
 
+    func makeCustomAttachmentViewType(
+        for message: ChatMessage,
+        isFirst: Bool,
+        availableWidth: CGFloat,
+        scrolledId: Binding<String?>
+    ) -> some View {
+        CustomGiphyMessageView(
+            message: message,
+            isFirst: isFirst,
+            availableWidth: availableWidth,
+            scrolledId: scrolledId
+        )
+    }
+
     private func archiveChannelAction(
         for channel: ChatChannel,
         onDismiss: @escaping () -> Void,

--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerView.swift
@@ -209,6 +209,7 @@ public struct MessageComposerView<Factory: ViewFactory>: View, KeyboardReadable 
                         )
                     }
                 )
+                .environmentObject(viewModel)
                 .offset(y: -composerHeight)
                 .animation(nil) : nil,
             alignment: .bottom

--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/Suggestions/CommandsContainerView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/Suggestions/CommandsContainerView.swift
@@ -6,12 +6,12 @@ import StreamChat
 import SwiftUI
 
 /// Default implementation of the commands container.
-struct CommandsContainerView<Factory: ViewFactory>: View {
-    var factory: Factory
-    var suggestions: [String: Any]
-    var handleCommand: ([String: Any]) -> Void
+public struct CommandsContainerView<Factory: ViewFactory>: View {
+    public var factory: Factory
+    public var suggestions: [String: Any]
+    public var handleCommand: ([String: Any]) -> Void
 
-    init(
+    public init(
         factory: Factory = DefaultViewFactory.shared,
         suggestions: [String: Any],
         handleCommand: @escaping ([String: Any]) -> Void
@@ -21,7 +21,7 @@ struct CommandsContainerView<Factory: ViewFactory>: View {
         self.handleCommand = handleCommand
     }
 
-    var body: some View {
+    public var body: some View {
         ZStack {
             if let suggestedUsers = suggestions["mentions"] as? [ChatUser] {
                 MentionUsersView(


### PR DESCRIPTION
### 🔗 Issue Links

Resolve https://linear.app/stream/issue/IOS-143

### 📝 Notes

- [First commit](https://github.com/GetStream/stream-chat-swiftui/pull/1214/changes/5a5011f57d37341927acf44a57bfac1691b6d4b7) uses existing giphy attachment
- [Second commit](https://github.com/GetStream/stream-chat-swiftui/pull/1214/changes/8ddb997ffec4fa69f10b53babfc568bfe2bc82a4) introduces custom giphy attachment 

### 🧪 Test

1. Fill in the api key in the demo app source code
2. Build the app
3. Open config settings
4. Enable Gifs Grid
5. Login
6. Open channel
7. Tap on the giphy button
8. Type text
9. Tap on gif

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a horizontally scrollable GIF grid for Giphy in Instant Commands, enabling users to search, browse, and select GIFs directly in the composer.
  * Integrated Giphy API with real-time search results.
  * Added animated GIF rendering in messages.

* **Configuration**
  * Added a toggle in App Configuration to enable/disable the GIF grid feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->