### PR TITLE
Respect channel list sort in message search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # Upcoming
 
 ### ✅ Added
-- Channel list message search now uses the channel list's sort order: `ChatChannelListViewModel.performMessageSearch()` is set from the channel list query in the default strategy, and is passed to the search API.
+- Channel list message search now uses the channel list's sort order: `ChatChannelListViewModel.performMessageSearch()` is set from the channel list query in the default strategy, and is passed to the search API [#1237](https://github.com/GetStream/stream-chat-swiftui/pull/1237)
 
 ### 🐞 Fixed
 - Fix composer text, placeholder and icons not respecting layout direction in RTL [#1206](https://github.com/GetStream/stream-chat-swiftui/pull/1206)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+### ✅ Added
+- Channel list message search now uses the channel list's sort order: `ChatChannelListViewModel.performMessageSearch()` is set from the channel list query in the default strategy, and is passed to the search API.
+
 ### 🐞 Fixed
 - Fix composer text, placeholder and icons not respecting layout direction in RTL [#1206](https://github.com/GetStream/stream-chat-swiftui/pull/1206)
 - Use `chevron.forward` instead of `chevron.right` for channel info disclosure indicator in RTL [#1206](https://github.com/GetStream/stream-chat-swiftui/pull/1206)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # Upcoming
 
 ### ✅ Added
-- Channel list message search now uses the channel list's sort order: `ChatChannelListViewModel.performMessageSearch()` is set from the channel list query in the default strategy, and is passed to the search API [#1237](https://github.com/GetStream/stream-chat-swiftui/pull/1237)
+- Add support for optional sort in channel list message search [#1237](https://github.com/GetStream/stream-chat-swiftui/pull/1237)
 
 ### 🐞 Fixed
 - Fix composer text, placeholder and icons not respecting layout direction in RTL [#1206](https://github.com/GetStream/stream-chat-swiftui/pull/1206)

--- a/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListViewModel.swift
@@ -441,10 +441,14 @@ open class ChatChannelListViewModel: ObservableObject, ChatChannelListController
     }
 
     /// Creates a new message search controller, sets its delegate, and triggers the search operation.
+    /// Message search uses the channel list's sort order when available.
     open func performMessageSearch() {
         messageSearchController = chatClient.messageSearchController()
         loadingSearchResults = true
-        messageSearchController?.search(text: searchText) { [weak self] _ in
+        let messageSearchSort = controller.map {
+            MessageSearchQuery.messageSearchSort(fromChannelListSort: $0.query.sort)
+        } ?? nil
+        messageSearchController?.search(text: searchText, sort: messageSearchSort) { [weak self] _ in
             self?.loadingSearchResults = false
             self?.messageSearchController?.delegate = self
             self?.updateMessageSearchResults()

--- a/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListViewModel.swift
@@ -113,6 +113,10 @@ open class ChatChannelListViewModel: ObservableObject, ChatChannelListController
     /// The message search controller which should be created only by ``performMessageSearch()``.
     public var messageSearchController: ChatMessageSearchController?
 
+    /// Sort order for message search results. When set (e.g. from the channel list's sort), it is passed to the search API.
+    /// When `nil`, the controller uses its default (newest first).
+    public var messageSearchSort: [Sorting<MessageSearchSortingKey>]?
+
     /// Serial queue used to process the search results.
     private let queue = DispatchQueue(label: "com.getstream.stream-chat-swiftui.ChatChannelListViewModel")
 
@@ -444,7 +448,7 @@ open class ChatChannelListViewModel: ObservableObject, ChatChannelListController
     open func performMessageSearch() {
         messageSearchController = chatClient.messageSearchController()
         loadingSearchResults = true
-        messageSearchController?.search(text: searchText) { [weak self] _ in
+        messageSearchController?.search(text: searchText, sort: messageSearchSort) { [weak self] _ in
             self?.loadingSearchResults = false
             self?.messageSearchController?.delegate = self
             self?.updateMessageSearchResults()

--- a/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListViewModel.swift
@@ -441,14 +441,10 @@ open class ChatChannelListViewModel: ObservableObject, ChatChannelListController
     }
 
     /// Creates a new message search controller, sets its delegate, and triggers the search operation.
-    /// Message search uses the channel list's sort order when available.
     open func performMessageSearch() {
         messageSearchController = chatClient.messageSearchController()
         loadingSearchResults = true
-        let messageSearchSort = controller.map {
-            MessageSearchQuery.messageSearchSort(fromChannelListSort: $0.query.sort)
-        } ?? nil
-        messageSearchController?.search(text: searchText, sort: messageSearchSort) { [weak self] _ in
+        messageSearchController?.search(text: searchText) { [weak self] _ in
             self?.loadingSearchResults = false
             self?.messageSearchController?.delegate = self
             self?.updateMessageSearchResults()

--- a/StreamChatSwiftUI.xcodeproj/project.pbxproj
+++ b/StreamChatSwiftUI.xcodeproj/project.pbxproj
@@ -1462,8 +1462,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/GetStream/stream-chat-swift.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 4.97.1;
+				branch = "feature/channel-list-sort-in-message-search";
+				kind = branch;
 			};
 		};
 		E3A1C01A282BAC66002D1E26 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {

--- a/StreamChatSwiftUI.xcodeproj/project.pbxproj
+++ b/StreamChatSwiftUI.xcodeproj/project.pbxproj
@@ -1462,7 +1462,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/GetStream/stream-chat-swift.git";
 			requirement = {
-				branch = "feature/channel-list-sort-in-message-search";
+				branch = develop;
 				kind = branch;
 			};
 		};


### PR DESCRIPTION
### 🔗 Issue Links

Resolve https://linear.app/stream/issue/IOS-1450

### 🎯 Goal

Channel list message search should be able to use the channel list's sort order

### 🧪 Manual Testing Notes

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Channel list message search now supports an optional sort order to better control how search results are organized.

* **Documentation**
  * Changelog updated to reflect the new message search sorting capability.

* **Chores**
  * Build/dependency configuration adjusted for development workflow (internal, no user-facing behavior changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->