### PR TITLE
Add media metadata to composer attachments for custom CDN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+### ✅ Added
+- `AddedAsset` now has `originalWidth`, `originalHeight`, and `duration` (videos), set at selection time and passed into image/video attachment payloads for custom CDN uploads.
+
 ### 🔄 Changed
 
 # [4.98.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.98.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### ✅ Added
 - `AddedAsset` now has `originalWidth`, `originalHeight`, and `duration` (videos), set at selection time and passed into image/video attachment payloads for custom CDN uploads [#1255](https://github.com/GetStream/stream-chat-swiftui/pull/1255)
 
-### 🔄 Changed
-
 # [4.98.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.98.0)
 _February 26, 2026_
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # Upcoming
 
 ### ✅ Added
-- `AddedAsset` now has `originalWidth`, `originalHeight`, and `duration` (videos), set at selection time and passed into image/video attachment payloads for custom CDN uploads.
+- `AddedAsset` now has `originalWidth`, `originalHeight`, and `duration` (videos), set at selection time and passed into image/video attachment payloads for custom CDN uploads [#1255](https://github.com/GetStream/stream-chat-swiftui/pull/1255)
 
 ### 🔄 Changed
 

--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/ComposerModels.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/ComposerModels.swift
@@ -20,12 +20,19 @@ public final class AddedAsset: Identifiable, Equatable {
     public static func == (lhs: AddedAsset, rhs: AddedAsset) -> Bool {
         lhs.id == rhs.id
     }
-    
+
     public let image: UIImage
     public let id: String
     public let url: URL
     public let type: AssetType
     public var extraData: [String: RawJSON] = [:]
+
+    /// Original width in pixels (for images and videos). Available at selection time without extra computation.
+    public var originalWidth: Double?
+    /// Original height in pixels (for images and videos). Available at selection time without extra computation.
+    public var originalHeight: Double?
+    /// Duration in seconds (for videos only). Available at selection time without extra computation.
+    public var duration: TimeInterval?
 
     /// The payload of the attachment, in case the attachment has been uploaded to server already.
     /// This is mostly used when editing an existing message that contains attachments.
@@ -37,6 +44,9 @@ public final class AddedAsset: Identifiable, Equatable {
         url: URL,
         type: AssetType,
         extraData: [String: RawJSON] = [:],
+        originalWidth: Double? = nil,
+        originalHeight: Double? = nil,
+        duration: TimeInterval? = nil,
         payload: AttachmentPayload? = nil
     ) {
         self.image = image
@@ -44,6 +54,9 @@ public final class AddedAsset: Identifiable, Equatable {
         self.url = url
         self.type = type
         self.extraData = extraData
+        self.originalWidth = originalWidth
+        self.originalHeight = originalHeight
+        self.duration = duration
         self.payload = payload
     }
 }
@@ -53,10 +66,20 @@ extension AddedAsset {
         if let payload = self.payload {
             return AnyAttachmentPayload(payload: payload)
         }
+        var localMetadata: AnyAttachmentLocalMetadata?
+        if originalWidth != nil || originalHeight != nil || duration != nil {
+            var meta = AnyAttachmentLocalMetadata()
+            if let w = originalWidth, let h = originalHeight {
+                meta.originalResolution = (width: w, height: h)
+            }
+            meta.duration = duration
+            localMetadata = meta
+        }
         return try AnyAttachmentPayload(
             localFileURL: url,
             attachmentType: type == .video ? .video : .image,
-            extraData: extraData
+            localMetadata: localMetadata,
+            extraData: extraData.isEmpty ? nil : extraData
         )
     }
 }

--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/ImagePickerView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/ImagePickerView.swift
@@ -56,11 +56,14 @@ final class ImagePickerCoordinator: NSObject, UIImagePickerControllerDelegate, U
     ) {
         if let uiImage = info[.originalImage] as? UIImage,
            let imageURL = try? uiImage.saveAsJpgToTemporaryUrl() {
+            let scale = uiImage.scale
             let addedImage = AddedAsset(
                 image: uiImage,
                 id: UUID().uuidString,
                 url: imageURL,
-                type: .image
+                type: .image,
+                originalWidth: Double(uiImage.size.width * scale),
+                originalHeight: Double(uiImage.size.height * scale)
             )
             parent.onAssetPicked(addedImage)
         } else if let videoURL = info[UIImagePickerController.InfoKey.mediaURL] as? URL {
@@ -73,11 +76,30 @@ final class ImagePickerCoordinator: NSObject, UIImagePickerControllerDelegate, U
                     actualTime: nil
                 )
                 let thumbnail = UIImage(cgImage: cgImage)
+                let durationSeconds = CMTimeGetSeconds(asset.duration)
+                let size: (Double, Double)? = {
+                    guard let track = asset.tracks(withMediaType: .video).first else { return nil }
+                    let size = track.naturalSize
+                    let transform = track.preferredTransform
+                    let width: Double
+                    let height: Double
+                    if transform.a == 0 && abs(transform.b) == 1 && abs(transform.c) == 1 && transform.d == 0 {
+                        width = Double(size.height)
+                        height = Double(size.width)
+                    } else {
+                        width = Double(size.width)
+                        height = Double(size.height)
+                    }
+                    return (width, height)
+                }()
                 let addedVideo = AddedAsset(
                     image: thumbnail,
                     id: UUID().uuidString,
                     url: videoURL,
-                    type: .video
+                    type: .video,
+                    originalWidth: size?.0,
+                    originalHeight: size?.1,
+                    duration: durationSeconds.isFinite && !durationSeconds.isNaN ? durationSeconds : nil
                 )
                 parent.onAssetPicked(addedVideo)
             } catch {

--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerViewModel.swift
@@ -533,11 +533,14 @@ open class MessageComposerViewModel: ObservableObject {
             log.error("Failed to write image to local temporary file")
             return
         }
+        let scale = image.scale
         let addedImage = AddedAsset(
             image: image,
             id: UUID().uuidString,
             url: imageURL,
-            type: .image
+            type: .image,
+            originalWidth: Double(image.size.width * scale),
+            originalHeight: Double(image.size.height * scale)
         )
         addedAssets.append(addedImage)
     }
@@ -1086,7 +1089,11 @@ class MessageAttachmentsConverter {
                 id: videoAttachment.id.rawValue,
                 url: localUrl,
                 type: .video,
-                extraData: videoAttachment.extraData ?? [:]
+                extraData: videoAttachment.extraData ?? [:],
+                originalWidth: videoAttachment.originalWidth,
+                originalHeight: videoAttachment.originalHeight,
+                duration: videoAttachment.duration,
+                payload: nil
             )
         }
 
@@ -1096,6 +1103,9 @@ class MessageAttachmentsConverter {
             url: videoAttachment.videoURL,
             type: .video,
             extraData: videoAttachment.extraData ?? [:],
+            originalWidth: videoAttachment.originalWidth,
+            originalHeight: videoAttachment.originalHeight,
+            duration: videoAttachment.duration,
             payload: videoAttachment.payload
         )
     }
@@ -1116,7 +1126,10 @@ class MessageAttachmentsConverter {
                 id: imageAttachment.id.rawValue,
                 url: localFileUrl,
                 type: .image,
-                extraData: imageAttachment.extraData ?? [:]
+                extraData: imageAttachment.extraData ?? [:],
+                originalWidth: imageAttachment.originalWidth,
+                originalHeight: imageAttachment.originalHeight,
+                payload: nil
             )
             completion(imageAsset)
             return
@@ -1135,6 +1148,8 @@ class MessageAttachmentsConverter {
                     url: imageAttachment.imageURL,
                     type: .image,
                     extraData: imageAttachment.extraData ?? [:],
+                    originalWidth: imageAttachment.originalWidth,
+                    originalHeight: imageAttachment.originalHeight,
                     payload: imageAttachment.payload
                 )
                 completion(imageAsset)

--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/PhotoAttachmentPickerView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/PhotoAttachmentPickerView.swift
@@ -103,14 +103,19 @@ public struct PhotoAttachmentCell: View {
                             .onTapGesture {
                                 withAnimation {
                                     if let assetURL = asset.mediaType == .image ? assetJpgURL() : assetURL {
+                                        let width = Double(asset.pixelWidth)
+                                        let height = Double(asset.pixelHeight)
+                                        let durationSeconds: TimeInterval? = asset.mediaType == .video ? asset.duration : nil
                                         onImageTap(
                                             AddedAsset(
                                                 image: image,
                                                 id: asset.localIdentifier,
                                                 url: assetURL,
                                                 type: assetType,
-                                                extraData: asset
-                                                    .mediaType == .video ? ["duration": .string(asset.durationString)] : [:]
+                                                extraData: asset.mediaType == .video ? ["duration": .string(asset.durationString)] : [:],
+                                                originalWidth: width > 0 ? width : nil,
+                                                originalHeight: height > 0 ? height : nil,
+                                                duration: durationSeconds
                                             )
                                         )
                                     }

--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/VideoAttachmentView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/VideoAttachmentView.swift
@@ -12,6 +12,18 @@ public struct VideoAttachmentsContainer<Factory: ViewFactory>: View {
     let width: CGFloat
     @Binding var scrolledId: String?
 
+    public init(
+        factory: Factory,
+        message: ChatMessage,
+        width: CGFloat,
+        scrolledId: Binding<String?>
+    ) {
+        self.factory = factory
+        self.message = message
+        self.width = width
+        _scrolledId = scrolledId
+    }
+
     public var body: some View {
         VStack(spacing: 0) {
             if let quotedMessage = message.quotedMessage {

--- a/StreamChatSwiftUI.xcodeproj/project.pbxproj
+++ b/StreamChatSwiftUI.xcodeproj/project.pbxproj
@@ -1462,7 +1462,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/GetStream/stream-chat-swift.git";
 			requirement = {
-				branch = "feature/pre-populating-attachment-metadata";
+				branch = develop;
 				kind = branch;
 			};
 		};

--- a/StreamChatSwiftUI.xcodeproj/project.pbxproj
+++ b/StreamChatSwiftUI.xcodeproj/project.pbxproj
@@ -1462,8 +1462,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/GetStream/stream-chat-swift.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 4.98.0;
+				branch = "feature/pre-populating-attachment-metadata";
+				kind = branch;
 			};
 		};
 		E3A1C01A282BAC66002D1E26 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {

--- a/StreamChatSwiftUITests/Tests/ChatChannel/MessageAttachmentsConverter_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/MessageAttachmentsConverter_Tests.swift
@@ -264,6 +264,22 @@ class MessageAttachmentsConverter_Tests: StreamChatTestCase {
         XCTAssertNotNil(imageAsset?.image)
         XCTAssertNotNil(imageAsset?.payload)
     }
+
+    func test_attachmentsToAssets_imageAttachmentWithoutLocalURL_preservesPayloadMetadata() {
+        let attachments = [createImageAttachmentWithoutLocalURL(originalWidth: 1024, originalHeight: 768)]
+        let expectation = XCTestExpectation(description: "Image attachment conversion completion")
+        var result: ComposerAssets?
+
+        converter.attachmentsToAssets(attachments) { composerAssets in
+            result = composerAssets
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1.0)
+        let imageAsset = result?.mediaAssets.first
+        XCTAssertEqual(imageAsset?.originalWidth, 1024)
+        XCTAssertEqual(imageAsset?.originalHeight, 768)
+    }
     
     // MARK: - Helper Methods
     
@@ -415,7 +431,10 @@ class MessageAttachmentsConverter_Tests: StreamChatTestCase {
         ).asAnyAttachment
     }
     
-    private func createImageAttachmentWithoutLocalURL() -> AnyChatMessageAttachment {
+    private func createImageAttachmentWithoutLocalURL(
+        originalWidth: Double? = nil,
+        originalHeight: Double? = nil
+    ) -> AnyChatMessageAttachment {
         let attachmentFile = AttachmentFile(type: .png, size: 512, mimeType: "image/png")
         
         return ChatMessageImageAttachment(
@@ -424,6 +443,8 @@ class MessageAttachmentsConverter_Tests: StreamChatTestCase {
             payload: ImageAttachmentPayload(
                 title: "Test Image",
                 imageRemoteURL: URL(string: "https://example.com/image.png")!,
+                originalWidth: originalWidth,
+                originalHeight: originalHeight,
                 extraData: ["test": "value"]
             ),
             downloadingState: nil,

--- a/StreamChatSwiftUITests/Tests/ChatChannel/MessageAttachmentsConverter_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/MessageAttachmentsConverter_Tests.swift
@@ -189,8 +189,11 @@ class MessageAttachmentsConverter_Tests: StreamChatTestCase {
         XCTAssertEqual(videoAsset?.type, .video)
         XCTAssertNotNil(videoAsset?.image) // Should have thumbnail
         XCTAssertNil(videoAsset?.payload) // Should not include payload when using local URL
+        XCTAssertEqual(videoAsset?.originalWidth, 1920)
+        XCTAssertEqual(videoAsset?.originalHeight, 1080)
+        XCTAssertEqual(videoAsset?.duration, 90.5)
     }
-    
+
     func test_attachmentsToAssets_videoAttachmentWithoutLocalURL() {
         // Given
         let attachments = [createVideoAttachmentWithoutLocalURL()]
@@ -235,8 +238,10 @@ class MessageAttachmentsConverter_Tests: StreamChatTestCase {
         XCTAssertEqual(imageAsset?.type, .image)
         XCTAssertNotNil(imageAsset?.image)
         XCTAssertNil(imageAsset?.payload) // Should not include payload when using local URL
+        XCTAssertEqual(imageAsset?.originalWidth, 640)
+        XCTAssertEqual(imageAsset?.originalHeight, 480)
     }
-    
+
     func test_attachmentsToAssets_imageAttachmentWithoutLocalURL() {
         // Given
         let attachments = [createImageAttachmentWithoutLocalURL()]
@@ -318,7 +323,11 @@ class MessageAttachmentsConverter_Tests: StreamChatTestCase {
         ).asAnyAttachment
     }
     
-    private func createVideoAttachmentWithLocalURL() -> AnyChatMessageAttachment {
+    private func createVideoAttachmentWithLocalURL(
+        originalWidth: Double? = 1920,
+        originalHeight: Double? = 1080,
+        duration: TimeInterval? = 90.5
+    ) -> AnyChatMessageAttachment {
         let attachmentFile = AttachmentFile(type: .mp4, size: 2048, mimeType: "video/mp4")
         let uploadingState = AttachmentUploadingState(
             localFileURL: mockVideoURL,
@@ -333,6 +342,9 @@ class MessageAttachmentsConverter_Tests: StreamChatTestCase {
                 title: "Test Video",
                 videoRemoteURL: URL(string: "https://example.com/video.mp4")!,
                 thumbnailURL: TestImages.yoda.url,
+                originalWidth: originalWidth,
+                originalHeight: originalHeight,
+                duration: duration,
                 file: attachmentFile,
                 extraData: ["test": "value"]
             ),
@@ -359,7 +371,7 @@ class MessageAttachmentsConverter_Tests: StreamChatTestCase {
         ).asAnyAttachment
     }
     
-    private func createImageAttachmentWithLocalURL() -> AnyChatMessageAttachment {
+    private func createImageAttachmentWithLocalURL(originalWidth: Double? = 640, originalHeight: Double? = 480) -> AnyChatMessageAttachment {
         let attachmentFile = AttachmentFile(type: .png, size: 512, mimeType: "image/png")
         let uploadingState = AttachmentUploadingState(
             localFileURL: mockImageURL,
@@ -373,6 +385,8 @@ class MessageAttachmentsConverter_Tests: StreamChatTestCase {
             payload: ImageAttachmentPayload(
                 title: "Test Image",
                 imageRemoteURL: URL(string: "https://example.com/image.png")!,
+                originalWidth: originalWidth,
+                originalHeight: originalHeight,
                 extraData: ["test": "value"]
             ),
             downloadingState: nil,

--- a/StreamChatSwiftUITests/Tests/ChatChannel/MessageComposerViewModel_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/MessageComposerViewModel_Tests.swift
@@ -944,7 +944,7 @@ class MessageComposerViewModel_Tests: StreamChatTestCase {
         let url = URL.newTemporaryFileURL()
         defer { try? FileManager.default.removeItem(at: url) }
         try image.pngData()?.write(to: url)
-        viewModel.addedAssets = [
+        viewModel.updateAddedAssets([
             AddedAsset(
                 image: image,
                 id: "1",
@@ -953,7 +953,7 @@ class MessageComposerViewModel_Tests: StreamChatTestCase {
                 originalWidth: 300,
                 originalHeight: 200
             )
-        ]
+        ])
 
         let payloads = try viewModel.convertAddedAssetsToPayloads()
         let imagePayload = try XCTUnwrap(payloads.first?.payload as? ImageAttachmentPayload)

--- a/StreamChatSwiftUITests/Tests/ChatChannel/MessageComposerViewModel_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/MessageComposerViewModel_Tests.swift
@@ -824,7 +824,160 @@ class MessageComposerViewModel_Tests: StreamChatTestCase {
         XCTAssertEqual(payload.originalHeight, 1080)
         XCTAssertEqual(payload.duration, 120.5)
     }
-    
+
+    func test_addedAsset_toAttachmentPayload_whenPayloadExists_returnsExistingPayload() throws {
+        let image = UIImage(systemName: "person")!
+        let url = URL.newTemporaryFileURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        try image.pngData()?.write(to: url)
+        let existingPayload = ImageAttachmentPayload(
+            title: "existing",
+            imageRemoteURL: URL(string: "https://example.com/image.png")!,
+            file: try AttachmentFile(url: url),
+            originalWidth: 100,
+            originalHeight: 200
+        )
+
+        let addedAsset = AddedAsset(
+            image: image,
+            id: "id",
+            url: url,
+            type: .image,
+            payload: existingPayload
+        )
+
+        let attachment = try addedAsset.toAttachmentPayload()
+        XCTAssertNil(attachment.localFileURL)
+        let payload = try XCTUnwrap(attachment.payload as? ImageAttachmentPayload)
+        XCTAssertEqual(payload.originalWidth, 100)
+        XCTAssertEqual(payload.originalHeight, 200)
+    }
+
+    func test_addedAsset_toAttachmentPayload_videoWithOnlyDuration_setsDurationOnPayload() throws {
+        let thumbnail = UIImage(systemName: "video")!
+        let url = URL.newTemporaryFileURL().appendingPathExtension("mp4")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try Data(count: 100).write(to: url)
+
+        let addedAsset = AddedAsset(
+            image: thumbnail,
+            id: "videoId",
+            url: url,
+            type: .video,
+            originalWidth: nil,
+            originalHeight: nil,
+            duration: 45.0
+        )
+
+        let attachment = try addedAsset.toAttachmentPayload()
+        let payload = try XCTUnwrap(attachment.payload as? VideoAttachmentPayload)
+        XCTAssertNil(payload.originalWidth)
+        XCTAssertNil(payload.originalHeight)
+        XCTAssertEqual(payload.duration, 45.0)
+    }
+
+    func test_addedAsset_toAttachmentPayload_withNoMetadata_passesNilLocalMetadata() throws {
+        let image = UIImage(systemName: "person")!
+        let url = URL.newTemporaryFileURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        try image.pngData()?.write(to: url)
+
+        let addedAsset = AddedAsset(
+            image: image,
+            id: "id",
+            url: url,
+            type: .image,
+            originalWidth: nil,
+            originalHeight: nil,
+            duration: nil
+        )
+
+        let attachment = try addedAsset.toAttachmentPayload()
+        let payload = try XCTUnwrap(attachment.payload as? ImageAttachmentPayload)
+        XCTAssertNotNil(payload.imageURL)
+        XCTAssertNil(payload.originalWidth)
+        XCTAssertNil(payload.originalHeight)
+    }
+
+    func test_imagePasted_setsOriginalWidthAndHeightOnAddedAsset() {
+        let viewModel = makeComposerViewModel()
+        let image = UIImage(systemName: "person.fill")!
+
+        viewModel.imagePasted(image)
+
+        let added = viewModel.addedAssets.last
+        XCTAssertNotNil(added)
+        XCTAssertEqual(added?.type, .image)
+        XCTAssertNotNil(added?.originalWidth)
+        XCTAssertNotNil(added?.originalHeight)
+        XCTAssertEqual(added?.originalWidth, Double(image.size.width * image.scale))
+        XCTAssertEqual(added?.originalHeight, Double(image.size.height * image.scale))
+    }
+
+    func test_cameraImageAdded_preservesAssetMetadata() {
+        let viewModel = makeComposerViewModel()
+        let image = UIImage(systemName: "video")!
+        let url = URL.newTemporaryFileURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        try? Data(count: 10).write(to: url)
+        let assetWithMetadata = AddedAsset(
+            image: image,
+            id: "cam",
+            url: url,
+            type: .video,
+            originalWidth: 640,
+            originalHeight: 480,
+            duration: 12.5
+        )
+
+        viewModel.cameraImageAdded(assetWithMetadata)
+
+        XCTAssertEqual(viewModel.addedAssets.count, 1)
+        XCTAssertEqual(viewModel.addedAssets.first?.originalWidth, 640)
+        XCTAssertEqual(viewModel.addedAssets.first?.originalHeight, 480)
+        XCTAssertEqual(viewModel.addedAssets.first?.duration, 12.5)
+    }
+
+    func test_convertAddedAssetsToPayloads_includesMetadataInPayloads() throws {
+        let viewModel = makeComposerViewModel()
+        let image = UIImage(systemName: "person")!
+        let url = URL.newTemporaryFileURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        try image.pngData()?.write(to: url)
+        viewModel.addedAssets = [
+            AddedAsset(
+                image: image,
+                id: "1",
+                url: url,
+                type: .image,
+                originalWidth: 300,
+                originalHeight: 200
+            )
+        ]
+
+        let payloads = try viewModel.convertAddedAssetsToPayloads()
+        let imagePayload = try XCTUnwrap(payloads.first?.payload as? ImageAttachmentPayload)
+        XCTAssertEqual(imagePayload.originalWidth, 300)
+        XCTAssertEqual(imagePayload.originalHeight, 200)
+    }
+
+    func test_imagePickerCoordinator_imageSelection_setsOriginalWidthAndHeightOnAsset() throws {
+        var captured: AddedAsset?
+        let view = ImagePickerView(sourceType: .photoLibrary, onAssetPicked: { captured = $0 })
+        let coordinator = view.makeCoordinator()
+        let image = UIGraphicsImageRenderer(size: CGSize(width: 100, height: 80)).image { _ in }
+
+        coordinator.imagePickerController(
+            UIImagePickerController(),
+            didFinishPickingMediaWithInfo: [.originalImage: image]
+        )
+
+        let asset = try XCTUnwrap(captured)
+        XCTAssertEqual(asset.type, .image)
+        XCTAssertEqual(asset.originalWidth, Double(image.size.width * image.scale))
+        XCTAssertEqual(asset.originalHeight, Double(image.size.height * image.scale))
+    }
+
     // MARK: - Recording
     
     func test_messageComposer_discardRecording() {

--- a/StreamChatSwiftUITests/Tests/ChatChannel/MessageComposerViewModel_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/MessageComposerViewModel_Tests.swift
@@ -780,6 +780,50 @@ class MessageComposerViewModel_Tests: StreamChatTestCase {
         XCTAssert(extraData?["test"] == "test")
         try! FileManager.default.removeItem(at: url)
     }
+
+    func test_addedAsset_toAttachmentPayload_includesOriginalWidthHeightForImage() throws {
+        let image = UIImage(systemName: "person")!
+        let url = URL.newTemporaryFileURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        try image.pngData()?.write(to: url)
+
+        let addedAsset = AddedAsset(
+            image: image,
+            id: "imageId",
+            url: url,
+            type: .image,
+            originalWidth: 800,
+            originalHeight: 600
+        )
+
+        let attachment = try addedAsset.toAttachmentPayload()
+        let payload = try XCTUnwrap(attachment.payload as? ImageAttachmentPayload)
+        XCTAssertEqual(payload.originalWidth, 800)
+        XCTAssertEqual(payload.originalHeight, 600)
+    }
+
+    func test_addedAsset_toAttachmentPayload_includesWidthHeightDurationForVideo() throws {
+        let thumbnail = UIImage(systemName: "video")!
+        let url = URL.newTemporaryFileURL().appendingPathExtension("mp4")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try Data(count: 100).write(to: url)
+
+        let addedAsset = AddedAsset(
+            image: thumbnail,
+            id: "videoId",
+            url: url,
+            type: .video,
+            originalWidth: 1920,
+            originalHeight: 1080,
+            duration: 120.5
+        )
+
+        let attachment = try addedAsset.toAttachmentPayload()
+        let payload = try XCTUnwrap(attachment.payload as? VideoAttachmentPayload)
+        XCTAssertEqual(payload.originalWidth, 1920)
+        XCTAssertEqual(payload.originalHeight, 1080)
+        XCTAssertEqual(payload.duration, 120.5)
+    }
     
     // MARK: - Recording
     


### PR DESCRIPTION
### 🔗 Issue Links

Resolve https://linear.app/stream/issue/IOS-1457

### 🎯 Goal

Enable apps using a custom CDN (per [custom CDN docs](https://getstream.io/chat/docs/sdk/ios/client/custom-cdn/)) to receive image dimensions and video dimensions + duration in the attachment payload. This metadata is captured at selection time (no extra computation during upload).

### 📝 Summary

- **AddedAsset** now has optional `originalWidth`, `originalHeight`, and `duration` (for videos).
- **toAttachmentPayload()** passes this metadata via `AnyAttachmentLocalMetadata` into `ImageAttachmentPayload` and `VideoAttachmentPayload`.
- **Image picker, photo library picker, camera, paste**: populate width/height (and duration for video) when creating `AddedAsset`.
- **Edit/restore**: when converting existing message attachments back to `AddedAsset`, image/video payload metadata is preserved on the asset.
- Tests added for payload conversion and converter metadata preservation.

### 🛠 Implementation

- **ComposerModels**: Added optional `originalWidth`, `originalHeight`, `duration` to `AddedAsset`; in `toAttachmentPayload()` build `AnyAttachmentLocalMetadata` from these and pass to `AnyAttachmentPayload(localFileURL:attachmentType:localMetadata:extraData:)`.
- **ImagePickerView**: For image, set resolution from `UIImage.size * scale`. For video, use `AVURLAsset` for duration and video track `naturalSize`/`preferredTransform` for dimensions.
- **PhotoAttachmentPickerView**: Use `PHAsset.pixelWidth`, `pixelHeight`, and (for video) `PHAsset.duration`.
- **MessageComposerViewModel**: `imagePasted` sets size from image; `imageAttachmentToAddedAsset` and `videoAttachmentToAddedAsset` pass through payload `originalWidth`/`originalHeight`/`duration` onto the restored `AddedAsset`.

Requires a stream-chat-swift version that includes `VideoAttachmentPayload.originalWidth`/`originalHeight`/`duration` and the corresponding `AnyAttachmentPayload` wiring.

### 🎨 Showcase

No UI change. Attachment payloads now include metadata that custom CDN upload code can read (e.g. in `uploadedAttachmentPostProcessor` or when building the upload request).

### 🧪 Manual Testing Notes

1. Add an image from gallery or camera; send message. In custom CDN upload flow, confirm `ImageAttachmentPayload.originalWidth` / `originalHeight` are non-nil on the attachment.
2. Add a video from gallery or camera; send message. Confirm `VideoAttachmentPayload.originalWidth`, `originalHeight`, and `duration` are non-nil.
3. Edit a message that has an image or video attachment; confirm dimensions/duration are still present when re-sending (metadata restored from payload).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Attachments now capture original image width/height and video duration at selection/paste time; this metadata is included in attachment payloads and preserved across local and remote flows.

* **Changelog**
  * Updated Upcoming entry to list new attachment metadata fields (originalWidth, originalHeight, duration).

* **Tests**
  * Added tests validating metadata propagation and payload construction for image and video attachments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->