### PR TITLE
Add MessageContainerView to restructure MessageItemView

### DIFF
--- a/Sources/StreamChatSwiftUI/ChatMessageList/MessageContainerView.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/MessageContainerView.swift
@@ -1,0 +1,204 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import StreamChat
+import SwiftUI
+
+/// The inner content of a message item: avatar, bubble, reactions, replies, and delivery status.
+struct MessageContainerView<Factory: ViewFactory>: View {
+    @ObservedObject var messageViewModel: MessageViewModel
+
+    @Injected(\.utils) private var utils
+    @Injected(\.tokens) private var tokens
+
+    let factory: Factory
+    let channel: ChatChannel
+    let message: ChatMessage
+    let contentWidth: CGFloat
+    let showsAllInfo: Bool
+    let shownAsPreview: Bool
+    let isLast: Bool
+    @Binding var scrolledId: String?
+    let onGesture: (_ showsMessageActions: Bool) -> Void
+
+    var body: some View {
+        HStack(alignment: .bottom, spacing: tokens.spacingXs) {
+            if !messageViewModel.isRightAligned
+                && utils.messageListConfig.messageDisplayOptions.showAvatars(for: channel, incoming: true) {
+                avatarView
+            }
+
+            VStack(
+                alignment: messageViewModel.isRightAligned ? .trailing : .leading,
+                spacing: tokens.spacingXxs
+            ) {
+                if messageViewModel.annotationsShown {
+                    factory.makeMessageTopView(
+                        options: MessageTopViewOptions(
+                            message: message,
+                            channel: channel,
+                            messageViewModel: messageViewModel,
+                            usesInvertedStyle: shownAsPreview
+                        )
+                    )
+                }
+
+                messageBubbleContent
+                    .padding(
+                        .top,
+                        messageViewModel.topReactionsShown && messageViewModel.annotationsShown ? messageListConfig.messageDisplayOptions
+                            .reactionsTopPadding(message) : 0
+                    )
+                    .accessibilityElement(children: .contain)
+                    .accessibilityIdentifier("MessageView")
+
+                if messageViewModel.threadRepliesShown {
+                    factory.makeMessageRepliesView(
+                        options: MessageRepliesViewOptions(
+                            channel: channel,
+                            message: message,
+                            replyCount: message.replyCount,
+                            usesInvertedStyle: shownAsPreview
+                        )
+                    )
+                    .accessibilityElement(children: .contain)
+                    .accessibility(identifier: "MessageRepliesView")
+                }
+
+                if messageViewModel.bottomReactionsShown {
+                    factory.makeBottomReactionsView(
+                        options: ReactionsBottomViewOptions(
+                            message: message,
+                            showsAllInfo: showsAllInfo,
+                            onTap: {
+                                onGesture(false)
+                            },
+                            onLongPress: {
+                                onGesture(false)
+                            }
+                        )
+                    )
+                }
+
+                if showsAllInfo && !message.isDeleted {
+                    deliveryStatusView
+                }
+            }
+
+            if messageViewModel.isRightAligned
+                && utils.messageListConfig.messageDisplayOptions.showAvatars(for: channel, incoming: false) {
+                avatarView
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: messageViewModel.isRightAligned ? .trailing : .leading)
+        .padding(.horizontal, messageListConfig.messagePaddings.horizontal)
+        .padding(.bottom, showsAllInfo || messageViewModel.annotationsShown ? paddingValue : groupMessageInterItemSpacing)
+        .padding(.top, isLast ? paddingValue : 0)
+    }
+
+    // MARK: - Sub-views
+
+    @ViewBuilder
+    private var messageBubbleContent: some View {
+        Group {
+            if messageViewModel.usesScrollView {
+                ScrollView {
+                    MessageView(
+                        factory: factory,
+                        message: message,
+                        contentWidth: contentWidth,
+                        isFirst: showsAllInfo,
+                        scrolledId: $scrolledId
+                    )
+                }
+            } else {
+                MessageView(
+                    factory: factory,
+                    message: message,
+                    contentWidth: contentWidth,
+                    isFirst: showsAllInfo,
+                    scrolledId: $scrolledId
+                )
+            }
+        }
+        .overlay(
+            messageViewModel.topReactionsShown ?
+                factory.makeMessageReactionView(
+                    options: MessageReactionViewOptions(
+                        message: message,
+                        onTapGesture: {
+                            onGesture(false)
+                        },
+                        onLongPressGesture: {
+                            onGesture(false)
+                        }
+                    )
+                )
+                : nil,
+            alignment: messageViewModel.isRightAligned ? .trailing : .leading
+        )
+        .overlay(
+            messageViewModel.failureIndicatorShown ? SendFailureIndicator() : nil
+        )
+        .frame(maxWidth: contentWidth, alignment: messageViewModel.isRightAligned ? .trailing : .leading)
+    }
+
+    @ViewBuilder
+    private var avatarView: some View {
+        factory.makeUserAvatarView(
+            options: UserAvatarViewOptions(
+                user: message.author,
+                size: AvatarSize.medium,
+                showsIndicator: false
+            )
+        )
+        .opacity(isLast || showsAllInfo ? 1 : 0)
+    }
+
+    @ViewBuilder
+    private var deliveryStatusView: some View {
+        if message.isSentByCurrentUser && channel.config.readEventsEnabled {
+            HStack(spacing: tokens.spacingXxs) {
+                factory.makeMessageReadIndicatorView(
+                    options: MessageReadIndicatorViewOptions(
+                        channel: channel,
+                        message: message,
+                        usesInvertedStyle: shownAsPreview
+                    )
+                )
+
+                if messageViewModel.messageDateShown {
+                    factory.makeMessageDateView(
+                        options: MessageDateViewOptions(message: message, usesInvertedStyle: shownAsPreview)
+                    )
+                }
+            }
+            .padding(.bottom, tokens.spacingXxs)
+        } else if messageViewModel.authorAndDateShown {
+            factory.makeMessageAuthorAndDateView(
+                options: MessageAuthorAndDateViewOptions(message: message, usesInvertedStyle: shownAsPreview)
+            )
+            .padding(.bottom, tokens.spacingXxs)
+        } else if messageViewModel.messageDateShown {
+            factory.makeMessageDateView(
+                options: MessageDateViewOptions(message: message, usesInvertedStyle: shownAsPreview)
+            )
+            .padding(.bottom, tokens.spacingXxs)
+        }
+    }
+
+    // MARK: - Computed Properties
+
+    private var paddingValue: CGFloat {
+        messageListConfig.messagePaddings.singleBottom
+    }
+
+    private var groupMessageInterItemSpacing: CGFloat {
+        messageListConfig.messagePaddings.groupBottom
+    }
+
+    private var messageListConfig: MessageListConfig {
+        utils.messageListConfig
+    }
+}

--- a/Sources/StreamChatSwiftUI/ChatMessageList/MessageItemView.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/MessageItemView.swift
@@ -11,9 +11,7 @@ public struct MessageItemView<Factory: ViewFactory>: View {
     @StateObject var messageViewModel: MessageViewModel
     @Environment(\.highlightedMessageId) var highlightedMessageId
 
-    @Injected(\.chatClient) private var chatClient
     @Injected(\.colors) private var colors
-    @Injected(\.images) private var images
     @Injected(\.utils) private var utils
     @Injected(\.tokens) private var tokens
 
@@ -85,29 +83,40 @@ public struct MessageItemView<Factory: ViewFactory>: View {
             if messageViewModel.systemMessageShown {
                 factory.makeSystemMessageView(options: SystemMessageViewOptions(message: message))
             } else {
-                messageView
-                    .background(
-                        GeometryReader { proxy in
-                            Rectangle().fill(Color.clear)
-                                .onChange(of: computeFrame, perform: { _ in
-                                    frame = proxy.frame(in: .global)
-                                })
-                        }
-                    )
-                    .onTapGesture(count: 2) {
-                        if messageViewModel.isDoubleTapOverlayEnabled {
-                            handleGestureForMessage(showsMessageActions: true)
-                        }
+                MessageContainerView(
+                    messageViewModel: messageViewModel,
+                    factory: factory,
+                    channel: channel,
+                    message: message,
+                    contentWidth: contentWidth,
+                    showsAllInfo: showsAllInfo,
+                    shownAsPreview: shownAsPreview,
+                    isLast: isLast,
+                    scrolledId: $scrolledId,
+                    onGesture: { handleGestureForMessage(showsMessageActions: $0) }
+                )
+                .background(
+                    GeometryReader { proxy in
+                        Rectangle().fill(Color.clear)
+                            .onChange(of: computeFrame, perform: { _ in
+                                frame = proxy.frame(in: .global)
+                            })
                     }
-                    .onLongPressGesture(perform: {
+                )
+                .onTapGesture(count: 2) {
+                    if messageViewModel.isDoubleTapOverlayEnabled {
                         handleGestureForMessage(showsMessageActions: true)
-                    })
-                    .modifier(SwipeToReplyModifier(
-                        message: message,
-                        channel: channel,
-                        isSwipeToQuoteReplyPossible: !shownAsPreview && messageViewModel.isSwipeToQuoteReplyPossible,
-                        quotedMessage: $quotedMessage
-                    ))
+                    }
+                }
+                .onLongPressGesture(perform: {
+                    handleGestureForMessage(showsMessageActions: true)
+                })
+                .modifier(SwipeToReplyModifier(
+                    message: message,
+                    channel: channel,
+                    isSwipeToQuoteReplyPossible: !shownAsPreview && messageViewModel.isSwipeToQuoteReplyPossible,
+                    quotedMessage: $quotedMessage
+                ))
             }
         }
         .background(
@@ -132,174 +141,6 @@ public struct MessageItemView<Factory: ViewFactory>: View {
         .onChange(of: channel) { channel in messageViewModel.channel = channel }
     }
 
-    // MARK: - Message Content
-
-    private var messageView: some View {
-        HStack(alignment: .bottom, spacing: tokens.spacingXs) {
-            if !messageViewModel.isRightAligned
-                && utils.messageListConfig.messageDisplayOptions.showAvatars(for: channel, incoming: true) {
-                avatarView
-            }
-
-            VStack(
-                alignment: messageViewModel.isRightAligned ? .trailing : .leading,
-                spacing: tokens.spacingXxs
-            ) {
-                if messageViewModel.annotationsShown {
-                    factory.makeMessageTopView(
-                        options: MessageTopViewOptions(
-                            message: message,
-                            channel: channel,
-                            messageViewModel: messageViewModel,
-                            usesInvertedStyle: shownAsPreview
-                        )
-                    )
-                }
-
-                messageBubbleContent
-                    .padding(
-                        .top,
-                        messageViewModel.topReactionsShown && messageViewModel.annotationsShown ? messageListConfig.messageDisplayOptions
-                            .reactionsTopPadding(message) : 0
-                    )
-                    .accessibilityElement(children: .contain)
-                    .accessibilityIdentifier("MessageView")
-
-                if messageViewModel.threadRepliesShown {
-                    factory.makeMessageRepliesView(
-                        options: MessageRepliesViewOptions(
-                            channel: channel,
-                            message: message,
-                            replyCount: message.replyCount,
-                            usesInvertedStyle: shownAsPreview
-                        )
-                    )
-                    .accessibilityElement(children: .contain)
-                    .accessibility(identifier: "MessageRepliesView")
-                }
-
-                if messageViewModel.bottomReactionsShown {
-                    factory.makeBottomReactionsView(
-                        options: ReactionsBottomViewOptions(
-                            message: message,
-                            showsAllInfo: showsAllInfo,
-                            onTap: {
-                                handleGestureForMessage(showsMessageActions: false)
-                            },
-                            onLongPress: {
-                                handleGestureForMessage(showsMessageActions: false)
-                            }
-                        )
-                    )
-                }
-
-                if showsAllInfo && !message.isDeleted {
-                    deliveryStatusView
-                }
-            }
-
-            if messageViewModel.isRightAligned
-                && utils.messageListConfig.messageDisplayOptions.showAvatars(for: channel, incoming: false) {
-                avatarView
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: messageViewModel.isRightAligned ? .trailing : .leading)
-        .padding(.horizontal, messageListConfig.messagePaddings.horizontal)
-        .padding(.bottom, showsAllInfo || messageViewModel.annotationsShown ? paddingValue : groupMessageInterItemSpacing)
-        .padding(.top, isLast ? paddingValue : 0)
-    }
-
-    // MARK: - Sub-views
-
-    @ViewBuilder
-    private var messageBubbleContent: some View {
-        Group {
-            if messageViewModel.usesScrollView {
-                ScrollView {
-                    MessageView(
-                        factory: factory,
-                        message: message,
-                        contentWidth: contentWidth,
-                        isFirst: showsAllInfo,
-                        scrolledId: $scrolledId
-                    )
-                }
-            } else {
-                MessageView(
-                    factory: factory,
-                    message: message,
-                    contentWidth: contentWidth,
-                    isFirst: showsAllInfo,
-                    scrolledId: $scrolledId
-                )
-            }
-        }
-        .overlay(
-            messageViewModel.topReactionsShown ?
-                factory.makeMessageReactionView(
-                    options: MessageReactionViewOptions(
-                        message: message,
-                        onTapGesture: {
-                            handleGestureForMessage(showsMessageActions: false)
-                        },
-                        onLongPressGesture: {
-                            handleGestureForMessage(showsMessageActions: false)
-                        }
-                    )
-                )
-                : nil,
-            alignment: messageViewModel.isRightAligned ? .trailing : .leading
-        )
-        .overlay(
-            messageViewModel.failureIndicatorShown ? SendFailureIndicator() : nil
-        )
-        .frame(maxWidth: contentWidth, alignment: messageViewModel.isRightAligned ? .trailing : .leading)
-    }
-
-    @ViewBuilder
-    private var avatarView: some View {
-        factory.makeUserAvatarView(
-            options: UserAvatarViewOptions(
-                user: message.author,
-                size: AvatarSize.medium,
-                showsIndicator: false
-            )
-        )
-        .opacity(isLast || showsAllInfo ? 1 : 0)
-    }
-
-    @ViewBuilder
-    private var deliveryStatusView: some View {
-        if message.isSentByCurrentUser && channel.config.readEventsEnabled {
-            HStack(spacing: tokens.spacingXxs) {
-                factory.makeMessageReadIndicatorView(
-                    options: MessageReadIndicatorViewOptions(
-                        channel: channel,
-                        message: message,
-                        usesInvertedStyle: shownAsPreview
-                    )
-                )
-
-                if messageViewModel.messageDateShown {
-                    factory.makeMessageDateView(
-                        options: MessageDateViewOptions(message: message, usesInvertedStyle: shownAsPreview)
-                    )
-                }
-            }
-            .padding(.bottom, tokens.spacingXxs)
-        } else if messageViewModel.authorAndDateShown {
-            factory.makeMessageAuthorAndDateView(
-                options: MessageAuthorAndDateViewOptions(message: message, usesInvertedStyle: shownAsPreview)
-            )
-            .padding(.bottom, tokens.spacingXxs)
-        } else if messageViewModel.messageDateShown {
-            factory.makeMessageDateView(
-                options: MessageDateViewOptions(message: message, usesInvertedStyle: shownAsPreview)
-            )
-            .padding(.bottom, tokens.spacingXxs)
-        }
-    }
-
     // MARK: - Computed Properties
 
     private var contentWidth: CGFloat {
@@ -312,14 +153,6 @@ public struct MessageItemView<Factory: ViewFactory>: View {
 
     private var spacerWidth: CGFloat {
         messageListConfig.messageDisplayOptions.spacerWidth(width ?? 0)
-    }
-
-    private var paddingValue: CGFloat {
-        messageListConfig.messagePaddings.singleBottom
-    }
-
-    private var groupMessageInterItemSpacing: CGFloat {
-        messageListConfig.messagePaddings.groupBottom
     }
 
     private var messageListConfig: MessageListConfig {


### PR DESCRIPTION
### 🔗 Issue Links

_Provide all Linear and/or Github issues related to this PR, if applicable._

### 🎯 Goal

Fixes crash on device because messageView property is too complex and triggers runtime crash

### 📝 Summary

_Provide bullet points with the most important changes in the codebase._

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
