### PR TITLE
Add AVPlayerProvider and improve VideoPreviewLoader for custom CDN support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### ✅ Added
 - `AddedAsset` now has `originalWidth`, `originalHeight`, and `duration` (videos), set at selection time and passed into image/video attachment payloads for custom CDN uploads [#1255](https://github.com/GetStream/stream-chat-swiftui/pull/1255)
+- Introduce `AVPlayerProvider` in `Utils` to be able to provide a custom `AVPlayer` configuration [#1284](https://github.com/GetStream/stream-chat-swiftui/pull/1284)
+- Add new `loadPreviewForVideo()` to `VideoPreviewLoader` for remote video attachments and use remote thumbnails by default [#1284](https://github.com/GetStream/stream-chat-swiftui/pull/1284)
 
 ### 🐞 Fixed
 - Align video attachments' bubble corner radius and corner shape with image attachments [#1260](https://github.com/GetStream/stream-chat-swiftui/pull/1260)

--- a/Sources/StreamChatSwiftUI/ChatChannel/Gallery/GalleryView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Gallery/GalleryView.swift
@@ -159,6 +159,10 @@ struct StreamVideoPlayer: View {
         utils.fileCDN
     }
 
+    private var avPlayerProvider: AVPlayerProvider {
+        utils.avPlayerProvider
+    }
+
     let url: URL
 
     @State var avPlayer: AVPlayer?
@@ -180,12 +184,19 @@ struct StreamVideoPlayer: View {
                 avPlayer?.play()
                 return
             }
-            fileCDN.player(for: url) { result in
+            fileCDN.adjustedURL(for: url) { result in
                 switch result {
-                case let .success(player):
-                    self.avPlayer = player
-                    try? AVAudioSession.sharedInstance().setCategory(.playback, options: [])
-                    self.avPlayer?.play()
+                case let .success(url):
+                    self.avPlayerProvider.player(for: url) { result in
+                        switch result {
+                        case let .success(player):
+                            self.avPlayer = player
+                            try? AVAudioSession.sharedInstance().setCategory(.playback, options: [])
+                            self.avPlayer?.play()
+                        case let .failure(error):
+                            self.error = error
+                        }
+                    }
                 case let .failure(error):
                     self.error = error
                 }

--- a/Sources/StreamChatSwiftUI/ChatChannel/Gallery/GalleryView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Gallery/GalleryView.swift
@@ -180,10 +180,10 @@ struct StreamVideoPlayer: View {
                 avPlayer?.play()
                 return
             }
-            fileCDN.adjustedURL(for: url) { result in
+            fileCDN.player(for: url) { result in
                 switch result {
-                case let .success(url):
-                    self.avPlayer = AVPlayer(url: url)
+                case let .success(player):
+                    self.avPlayer = player
                     try? AVAudioSession.sharedInstance().setCategory(.playback, options: [])
                     self.avPlayer?.play()
                 case let .failure(error):

--- a/Sources/StreamChatSwiftUI/ChatChannel/Gallery/VideoPlayerView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Gallery/VideoPlayerView.swift
@@ -18,6 +18,10 @@ public struct VideoPlayerView<Factory: ViewFactory>: View {
         utils.fileCDN
     }
 
+    private var avPlayerProvider: AVPlayerProvider {
+        utils.avPlayerProvider
+    }
+
     private let viewFactory: Factory
     let attachment: ChatMessageVideoAttachment
     let author: ChatUser
@@ -55,12 +59,19 @@ public struct VideoPlayerView<Factory: ViewFactory>: View {
             )
         }
         .onAppear {
-            fileCDN.player(for: attachment.payload.videoURL) { result in
+            fileCDN.adjustedURL(for: attachment.payload.videoURL) { result in
                 switch result {
-                case let .success(player):
-                    self.avPlayer = player
-                    try? AVAudioSession.sharedInstance().setCategory(.playback, options: [])
-                    self.avPlayer?.play()
+                case let .success(url):
+                    self.avPlayerProvider.player(for: url) { result in
+                        switch result {
+                        case let .success(player):
+                            self.avPlayer = player
+                            try? AVAudioSession.sharedInstance().setCategory(.playback, options: [])
+                            self.avPlayer?.play()
+                        case let .failure(error):
+                            self.error = error
+                        }
+                    }
                 case let .failure(error):
                     self.error = error
                 }

--- a/Sources/StreamChatSwiftUI/ChatChannel/Gallery/VideoPlayerView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Gallery/VideoPlayerView.swift
@@ -55,10 +55,10 @@ public struct VideoPlayerView<Factory: ViewFactory>: View {
             )
         }
         .onAppear {
-            fileCDN.adjustedURL(for: attachment.payload.videoURL) { result in
+            fileCDN.player(for: attachment.payload.videoURL) { result in
                 switch result {
-                case let .success(url):
-                    self.avPlayer = AVPlayer(url: url)
+                case let .success(player):
+                    self.avPlayer = player
                     try? AVAudioSession.sharedInstance().setCategory(.playback, options: [])
                     self.avPlayer?.play()
                 case let .failure(error):

--- a/Sources/StreamChatSwiftUI/ChatChannel/MessageList/VideoAttachmentView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/MessageList/VideoAttachmentView.swift
@@ -204,7 +204,7 @@ struct VideoAttachmentContentView<Factory: ViewFactory>: View {
             )
         }
         .onAppear {
-            videoPreviewLoader.loadPreviewForVideo(at: attachment.videoURL) { result in
+            videoPreviewLoader.loadPreviewForVideo(with: attachment) { result in
                 switch result {
                 case let .success(image):
                     self.previewImage = image

--- a/Sources/StreamChatSwiftUI/Utils.swift
+++ b/Sources/StreamChatSwiftUI/Utils.swift
@@ -2,6 +2,7 @@
 // Copyright © 2026 Stream.io Inc. All rights reserved.
 //
 
+import AVKit
 import Foundation
 import StreamChat
 
@@ -23,6 +24,7 @@ public class Utils {
     public var imageProcessor: ImageProcessor
     public var imageMerger: ImageMerging
     public var fileCDN: FileCDN
+    public var avPlayerProvider: AVPlayerProvider
     public var channelNamer: ChatChannelNamer
     public var chatUserNamer: ChatUserNamer
     public var channelAvatarsMerger: ChannelAvatarsMerging
@@ -86,6 +88,7 @@ public class Utils {
         imageProcessor: ImageProcessor = NukeImageProcessor(),
         imageMerger: ImageMerging = DefaultImageMerger(),
         fileCDN: FileCDN = DefaultFileCDN(),
+        avPlayerProvider: AVPlayerProvider = DefaultAVPlayerProvider(),
         channelAvatarsMerger: ChannelAvatarsMerging = ChannelAvatarsMerger(),
         messageTypeResolver: MessageTypeResolving = MessageTypeResolver(),
         messageActionResolver: MessageActionsResolving = MessageActionsResolver(),
@@ -115,6 +118,7 @@ public class Utils {
         self.imageProcessor = imageProcessor
         self.imageMerger = imageMerger
         self.fileCDN = fileCDN
+        self.avPlayerProvider = avPlayerProvider
         self.channelNamer = channelNamer
         self.chatUserNamer = chatUserNamer
         self.channelAvatarsMerger = channelAvatarsMerger
@@ -138,5 +142,35 @@ public class Utils {
     
     public static var defaultSortReactions: (MessageReactionType, MessageReactionType) -> Bool {
         { $0.rawValue < $1.rawValue }
+    }
+}
+
+/// Provides a custom `AVPlayer` for a given video URL.
+///
+/// Conform to this protocol to provide a custom player configuration,
+/// such as injecting authentication headers via a custom `AVURLAsset`.
+///
+/// The URL passed to ``player(for:completion:)`` has already been resolved
+/// through ``FileCDN/adjustedURL(for:completion:)``.
+public protocol AVPlayerProvider {
+    /// Creates and returns an `AVPlayer` for the given video URL.
+    /// - Parameters:
+    ///   - url: A video URL already resolved through `FileCDN`.
+    ///   - completion: A completion that is called when the player is ready or an error occurred.
+    func player(
+        for url: URL,
+        completion: @escaping ((Result<AVPlayer, Error>) -> Void)
+    )
+}
+
+/// The default implementation that creates an `AVPlayer` directly from the provided URL.
+public final class DefaultAVPlayerProvider: AVPlayerProvider {
+    public init() {}
+
+    public func player(
+        for url: URL,
+        completion: @escaping ((Result<AVPlayer, Error>) -> Void)
+    ) {
+        completion(.success(AVPlayer(url: url)))
     }
 }

--- a/Sources/StreamChatSwiftUI/Utils/Common/FileCDN.swift
+++ b/Sources/StreamChatSwiftUI/Utils/Common/FileCDN.swift
@@ -2,6 +2,7 @@
 // Copyright © 2026 Stream.io Inc. All rights reserved.
 //
 
+import AVKit
 import Foundation
 import StreamChat
 
@@ -16,6 +17,35 @@ public protocol FileCDN: AnyObject {
         for url: URL,
         completion: @escaping ((Result<URL, Error>) -> Void)
     )
+
+    /// Creates and returns an `AVPlayer` for the given video URL.
+    ///
+    /// The default implementation calls ``adjustedURL(for:completion:)`` and creates
+    /// an `AVPlayer` from the resulting URL. Override this method to provide a custom
+    /// player configuration, such as injecting authentication headers via a custom `AVURLAsset`.
+    /// - Parameters:
+    ///   - url: A video URL.
+    ///   - completion: A completion that is called when the player is ready or an error occurred.
+    func player(
+        for url: URL,
+        completion: @escaping ((Result<AVPlayer, Error>) -> Void)
+    )
+}
+
+extension FileCDN {
+    public func player(
+        for url: URL,
+        completion: @escaping ((Result<AVPlayer, Error>) -> Void)
+    ) {
+        adjustedURL(for: url) { result in
+            switch result {
+            case let .success(adjustedURL):
+                completion(.success(AVPlayer(url: adjustedURL)))
+            case let .failure(error):
+                completion(.failure(error))
+            }
+        }
+    }
 }
 
 /// The `DefaultFileCDN` implemenation used by default.

--- a/Sources/StreamChatSwiftUI/Utils/Common/FileCDN.swift
+++ b/Sources/StreamChatSwiftUI/Utils/Common/FileCDN.swift
@@ -2,7 +2,6 @@
 // Copyright © 2026 Stream.io Inc. All rights reserved.
 //
 
-import AVKit
 import Foundation
 import StreamChat
 
@@ -17,35 +16,6 @@ public protocol FileCDN: AnyObject {
         for url: URL,
         completion: @escaping ((Result<URL, Error>) -> Void)
     )
-
-    /// Creates and returns an `AVPlayer` for the given video URL.
-    ///
-    /// The default implementation calls ``adjustedURL(for:completion:)`` and creates
-    /// an `AVPlayer` from the resulting URL. Override this method to provide a custom
-    /// player configuration, such as injecting authentication headers via a custom `AVURLAsset`.
-    /// - Parameters:
-    ///   - url: A video URL.
-    ///   - completion: A completion that is called when the player is ready or an error occurred.
-    func player(
-        for url: URL,
-        completion: @escaping ((Result<AVPlayer, Error>) -> Void)
-    )
-}
-
-extension FileCDN {
-    public func player(
-        for url: URL,
-        completion: @escaping ((Result<AVPlayer, Error>) -> Void)
-    ) {
-        adjustedURL(for: url) { result in
-            switch result {
-            case let .success(adjustedURL):
-                completion(.success(AVPlayer(url: adjustedURL)))
-            case let .failure(error):
-                completion(.failure(error))
-            }
-        }
-    }
 }
 
 /// The `DefaultFileCDN` implemenation used by default.

--- a/Sources/StreamChatSwiftUI/Utils/Common/VideoPreviewLoader.swift
+++ b/Sources/StreamChatSwiftUI/Utils/Common/VideoPreviewLoader.swift
@@ -13,6 +13,27 @@ public protocol VideoPreviewLoader: AnyObject {
     ///   - url: A video URL.
     ///   - completion: A completion that is called when a preview is loaded. Must be invoked on main queue.
     func loadPreviewForVideo(at url: URL, completion: @escaping (Result<UIImage, Error>) -> Void)
+
+    /// Loads a preview for the given video attachment.
+    ///
+    /// The default implementation calls ``loadPreviewForVideo(at:completion:)`` with the video URL.
+    /// Override this method to use the attachment's thumbnail URL or other metadata for preview generation.
+    /// - Parameters:
+    ///   - attachment: A video attachment containing the video URL and optional thumbnail URL.
+    ///   - completion: A completion that is called when a preview is loaded. Must be invoked on main queue.
+    func loadPreviewForVideo(
+        with attachment: ChatMessageVideoAttachment,
+        completion: @escaping (Result<UIImage, Error>) -> Void
+    )
+}
+
+extension VideoPreviewLoader {
+    public func loadPreviewForVideo(
+        with attachment: ChatMessageVideoAttachment,
+        completion: @escaping (Result<UIImage, Error>) -> Void
+    ) {
+        loadPreviewForVideo(at: attachment.videoURL, completion: completion)
+    }
 }
 
 /// The `VideoPreviewLoader` implemenation used by default.
@@ -41,6 +62,40 @@ public final class DefaultVideoPreviewLoader: VideoPreviewLoader {
             return call(completion, with: .success(cached))
         }
 
+        generateVideoPreview(for: url, completion: completion)
+    }
+
+    public func loadPreviewForVideo(
+        with attachment: ChatMessageVideoAttachment,
+        completion: @escaping (Result<UIImage, Error>) -> Void
+    ) {
+        let videoURL = attachment.videoURL
+        if let cached = cache[videoURL] {
+            return call(completion, with: .success(cached))
+        }
+
+        if let thumbnailURL = attachment.payload.thumbnailURL {
+            utils.imageLoader.loadImage(
+                url: thumbnailURL,
+                imageCDN: utils.imageCDN,
+                resize: false,
+                preferredSize: nil
+            ) { [weak self] result in
+                guard let self else { return }
+                switch result {
+                case let .success(image):
+                    self.cache[videoURL] = image
+                    self.call(completion, with: .success(image))
+                case .failure:
+                    self.generateVideoPreview(for: videoURL, completion: completion)
+                }
+            }
+        } else {
+            generateVideoPreview(for: videoURL, completion: completion)
+        }
+    }
+
+    private func generateVideoPreview(for url: URL, completion: @escaping (Result<UIImage, Error>) -> Void) {
         utils.fileCDN.adjustedURL(for: url) { result in
             let adjustedUrl: URL
             switch result {

--- a/Sources/StreamChatSwiftUI/Utils/Common/VideoPreviewLoader.swift
+++ b/Sources/StreamChatSwiftUI/Utils/Common/VideoPreviewLoader.swift
@@ -18,7 +18,6 @@ public protocol VideoPreviewLoader: AnyObject {
     ///
     /// The default implementation calls ``loadPreviewForVideo(at:completion:)`` with the video URL.
     /// Override this method to use the attachment's thumbnail URL or other metadata for preview generation.
-    /// 
     /// - Parameters:
     ///   - attachment: A video attachment containing the video URL and optional thumbnail URL.
     ///   - completion: A completion that is called when a preview is loaded. Must be invoked on main queue.

--- a/Sources/StreamChatSwiftUI/Utils/Common/VideoPreviewLoader.swift
+++ b/Sources/StreamChatSwiftUI/Utils/Common/VideoPreviewLoader.swift
@@ -8,16 +8,17 @@ import UIKit
 
 /// A protocol the video preview uploader implementation must conform to.
 public protocol VideoPreviewLoader: AnyObject {
-    /// Loads a preview for the video at given URL.
+    /// Loads a preview for a local video attachment at a given URL.
     /// - Parameters:
-    ///   - url: A video URL.
+    ///   - url: The video URL.
     ///   - completion: A completion that is called when a preview is loaded. Must be invoked on main queue.
     func loadPreviewForVideo(at url: URL, completion: @escaping (Result<UIImage, Error>) -> Void)
 
-    /// Loads a preview for the given video attachment.
+    /// Loads a preview for the given remote video attachment.
     ///
     /// The default implementation calls ``loadPreviewForVideo(at:completion:)`` with the video URL.
     /// Override this method to use the attachment's thumbnail URL or other metadata for preview generation.
+    /// 
     /// - Parameters:
     ///   - attachment: A video attachment containing the video URL and optional thumbnail URL.
     ///   - completion: A completion that is called when a preview is loaded. Must be invoked on main queue.

--- a/StreamChatSwiftUI.xcodeproj/project.pbxproj
+++ b/StreamChatSwiftUI.xcodeproj/project.pbxproj
@@ -282,6 +282,7 @@
 				Tests/Utils/StringExtensions_Tests.swift,
 				Tests/Utils/URLUtils_Tests.swift,
 				Tests/Utils/VideoDurationFormatter_Tests.swift,
+				Tests/Utils/VideoPreviewLoader_Tests.swift,
 				Tests/Utils/ViewFactory_Tests.swift,
 			);
 			target = 8465FBBC2746873A00AF091E /* StreamChatSwiftUITests */;

--- a/StreamChatSwiftUITests/Infrastructure/Mocks/VideoPreviewLoader_Mock.swift
+++ b/StreamChatSwiftUITests/Infrastructure/Mocks/VideoPreviewLoader_Mock.swift
@@ -2,6 +2,7 @@
 // Copyright © 2026 Stream.io Inc. All rights reserved.
 //
 
+@testable import StreamChat
 import StreamChatSwiftUI
 import UIKit
 import XCTest

--- a/StreamChatSwiftUITests/Infrastructure/Mocks/VideoPreviewLoader_Mock.swift
+++ b/StreamChatSwiftUITests/Infrastructure/Mocks/VideoPreviewLoader_Mock.swift
@@ -9,9 +9,19 @@ import XCTest
 /// Mock implementation of `VideoPreviewLoader`.
 class VideoPreviewLoader_Mock: VideoPreviewLoader {
     var loadPreviewVideoCalled = false
+    var loadPreviewVideoWithAttachmentCalled = false
 
     func loadPreviewForVideo(at url: URL, completion: @escaping (Result<UIImage, Error>) -> Void) {
         loadPreviewVideoCalled = true
+
+        completion(.success(ImageLoader_Mock.defaultLoadedImage))
+    }
+
+    func loadPreviewForVideo(
+        with attachment: ChatMessageVideoAttachment,
+        completion: @escaping (Result<UIImage, Error>) -> Void
+    ) {
+        loadPreviewVideoWithAttachmentCalled = true
 
         completion(.success(ImageLoader_Mock.defaultLoadedImage))
     }

--- a/StreamChatSwiftUITests/Tests/Utils/VideoPreviewLoader_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/Utils/VideoPreviewLoader_Tests.swift
@@ -1,0 +1,167 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+@testable import StreamChatSwiftUI
+import XCTest
+
+class VideoPreviewLoader_Tests: StreamChatTestCase {
+
+    private let testURL = URL(string: "https://example.com/video.mp4")!
+    private let thumbnailURL = URL(string: "https://example.com/thumbnail.jpg")!
+
+    // MARK: - Default Extension (URL-only conformer)
+
+    func test_loadPreviewForVideoWithAttachment_defaultExtensionCallsURLMethod() {
+        // Given
+        let loader = URLOnlyVideoPreviewLoader()
+        let attachment = makeVideoAttachment(thumbnailURL: thumbnailURL)
+
+        // When
+        let expectation = expectation(description: "Completion called")
+        var receivedImage: UIImage?
+        loader.loadPreviewForVideo(with: attachment) { result in
+            receivedImage = try? result.get()
+            expectation.fulfill()
+        }
+
+        // Then
+        waitForExpectations(timeout: 1)
+        XCTAssertTrue(loader.loadPreviewAtURLCalled)
+        XCTAssertNotNil(receivedImage)
+    }
+
+    func test_loadPreviewForVideoWithAttachment_defaultExtensionPassesCorrectURL() {
+        // Given
+        let loader = URLOnlyVideoPreviewLoader()
+        let attachment = makeVideoAttachment(thumbnailURL: thumbnailURL)
+
+        // When
+        let expectation = expectation(description: "Completion called")
+        loader.loadPreviewForVideo(with: attachment) { _ in
+            expectation.fulfill()
+        }
+
+        // Then
+        waitForExpectations(timeout: 1)
+        XCTAssertEqual(loader.receivedURL, attachment.videoURL)
+    }
+
+    // MARK: - Custom conformer implementing both methods
+
+    func test_loadPreviewForVideoWithAttachment_customImplementationCalled() {
+        // Given
+        let loader = FullVideoPreviewLoader()
+        let attachment = makeVideoAttachment(thumbnailURL: thumbnailURL)
+
+        // When
+        let expectation = expectation(description: "Completion called")
+        var receivedImage: UIImage?
+        loader.loadPreviewForVideo(with: attachment) { result in
+            receivedImage = try? result.get()
+            expectation.fulfill()
+        }
+
+        // Then
+        waitForExpectations(timeout: 1)
+        XCTAssertTrue(loader.loadPreviewWithAttachmentCalled)
+        XCTAssertFalse(loader.loadPreviewAtURLCalled)
+        XCTAssertNotNil(receivedImage)
+    }
+
+    func test_loadPreviewForVideoAtURL_customImplementationStillWorks() {
+        // Given
+        let loader = FullVideoPreviewLoader()
+
+        // When
+        let expectation = expectation(description: "Completion called")
+        var receivedImage: UIImage?
+        loader.loadPreviewForVideo(at: testURL) { result in
+            receivedImage = try? result.get()
+            expectation.fulfill()
+        }
+
+        // Then
+        waitForExpectations(timeout: 1)
+        XCTAssertTrue(loader.loadPreviewAtURLCalled)
+        XCTAssertFalse(loader.loadPreviewWithAttachmentCalled)
+        XCTAssertNotNil(receivedImage)
+    }
+
+    func test_loadPreviewForVideoWithAttachment_receivesCorrectAttachment() {
+        // Given
+        let loader = FullVideoPreviewLoader()
+        let attachment = makeVideoAttachment(thumbnailURL: thumbnailURL)
+
+        // When
+        let expectation = expectation(description: "Completion called")
+        loader.loadPreviewForVideo(with: attachment) { _ in
+            expectation.fulfill()
+        }
+
+        // Then
+        waitForExpectations(timeout: 1)
+        XCTAssertEqual(loader.receivedAttachment?.videoURL, attachment.videoURL)
+        XCTAssertEqual(loader.receivedAttachment?.payload.thumbnailURL, thumbnailURL)
+    }
+
+    // MARK: - Helpers
+
+    private func makeVideoAttachment(
+        thumbnailURL: URL? = nil
+    ) -> ChatMessageVideoAttachment {
+        let attachmentFile = AttachmentFile(type: .mp4, size: 0, mimeType: "video/mp4")
+        return ChatMessageVideoAttachment(
+            id: .unique,
+            type: .video,
+            payload: VideoAttachmentPayload(
+                title: "test",
+                videoRemoteURL: testURL,
+                thumbnailURL: thumbnailURL,
+                file: attachmentFile,
+                extraData: nil
+            ),
+            downloadingState: nil,
+            uploadingState: nil
+        )
+    }
+}
+
+// MARK: - Test Doubles
+
+/// A conformer that only implements the URL-based method.
+/// The attachment-based method should use the default protocol extension.
+private class URLOnlyVideoPreviewLoader: VideoPreviewLoader {
+    var loadPreviewAtURLCalled = false
+    var receivedURL: URL?
+
+    func loadPreviewForVideo(at url: URL, completion: @escaping (Result<UIImage, Error>) -> Void) {
+        loadPreviewAtURLCalled = true
+        receivedURL = url
+        completion(.success(UIImage()))
+    }
+}
+
+/// A conformer that implements both methods independently.
+private class FullVideoPreviewLoader: VideoPreviewLoader {
+    var loadPreviewAtURLCalled = false
+    var loadPreviewWithAttachmentCalled = false
+    var receivedURL: URL?
+    var receivedAttachment: ChatMessageVideoAttachment?
+
+    func loadPreviewForVideo(at url: URL, completion: @escaping (Result<UIImage, Error>) -> Void) {
+        loadPreviewAtURLCalled = true
+        receivedURL = url
+        completion(.success(UIImage()))
+    }
+
+    func loadPreviewForVideo(
+        with attachment: ChatMessageVideoAttachment,
+        completion: @escaping (Result<UIImage, Error>) -> Void
+    ) {
+        loadPreviewWithAttachmentCalled = true
+        receivedAttachment = attachment
+        completion(.success(UIImage()))
+    }
+}

--- a/StreamChatSwiftUITests/Tests/Utils/VideoPreviewLoader_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/Utils/VideoPreviewLoader_Tests.swift
@@ -105,6 +105,146 @@ class VideoPreviewLoader_Tests: StreamChatTestCase {
         XCTAssertEqual(loader.receivedAttachment?.payload.thumbnailURL, thumbnailURL)
     }
 
+    // MARK: - DefaultVideoPreviewLoader with attachment
+
+    func test_defaultLoader_withAttachment_whenThumbnailURLExists_loadsThumbnailImage() {
+        // Given
+        let imageLoader = ConfigurableImageLoader(result: .success(ConfigurableImageLoader.thumbnailImage))
+        streamChat = StreamChat(
+            chatClient: chatClient,
+            utils: Utils(imageLoader: imageLoader)
+        )
+        let loader = DefaultVideoPreviewLoader()
+        let attachment = makeVideoAttachment(thumbnailURL: thumbnailURL)
+
+        // When
+        let expectation = expectation(description: "Completion called")
+        var receivedImage: UIImage?
+        loader.loadPreviewForVideo(with: attachment) { result in
+            receivedImage = try? result.get()
+            expectation.fulfill()
+        }
+
+        // Then
+        waitForExpectations(timeout: 1)
+        XCTAssertTrue(imageLoader.loadImageCalled)
+        XCTAssertEqual(imageLoader.receivedURL, thumbnailURL)
+        XCTAssertEqual(receivedImage, ConfigurableImageLoader.thumbnailImage)
+    }
+
+    func test_defaultLoader_withAttachment_whenThumbnailURLExists_cachesResult() {
+        // Given
+        let imageLoader = ConfigurableImageLoader(result: .success(ConfigurableImageLoader.thumbnailImage))
+        streamChat = StreamChat(
+            chatClient: chatClient,
+            utils: Utils(imageLoader: imageLoader)
+        )
+        let loader = DefaultVideoPreviewLoader()
+        let attachment = makeVideoAttachment(thumbnailURL: thumbnailURL)
+
+        // When - first call to populate cache
+        let firstExpectation = expectation(description: "First completion called")
+        loader.loadPreviewForVideo(with: attachment) { _ in
+            firstExpectation.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+
+        // Reset tracker
+        imageLoader.loadImageCalled = false
+        imageLoader.receivedURL = nil
+
+        // When - second call should hit cache
+        let secondExpectation = expectation(description: "Second completion called")
+        var receivedImage: UIImage?
+        loader.loadPreviewForVideo(with: attachment) { result in
+            receivedImage = try? result.get()
+            secondExpectation.fulfill()
+        }
+
+        // Then
+        waitForExpectations(timeout: 1)
+        XCTAssertFalse(imageLoader.loadImageCalled)
+        XCTAssertEqual(receivedImage, ConfigurableImageLoader.thumbnailImage)
+    }
+
+    func test_defaultLoader_withAttachment_whenNoThumbnailURL_doesNotCallImageLoader() {
+        // Given
+        let imageLoader = ConfigurableImageLoader(result: .success(ConfigurableImageLoader.thumbnailImage))
+        streamChat = StreamChat(
+            chatClient: chatClient,
+            utils: Utils(imageLoader: imageLoader)
+        )
+        let loader = DefaultVideoPreviewLoader()
+        let attachment = makeVideoAttachment(thumbnailURL: nil)
+
+        // When
+        let expectation = expectation(description: "Completion called")
+        loader.loadPreviewForVideo(with: attachment) { _ in
+            expectation.fulfill()
+        }
+
+        // Then
+        waitForExpectations(timeout: 5)
+        XCTAssertFalse(imageLoader.loadImageCalled)
+    }
+
+    func test_defaultLoader_withAttachment_whenThumbnailLoadFails_fallsBackToVideoPreview() {
+        // Given
+        let imageLoader = ConfigurableImageLoader(result: .failure(NSError(domain: "test", code: -1)))
+        streamChat = StreamChat(
+            chatClient: chatClient,
+            utils: Utils(imageLoader: imageLoader)
+        )
+        let loader = DefaultVideoPreviewLoader()
+        let attachment = makeVideoAttachment(thumbnailURL: thumbnailURL)
+
+        // When
+        let expectation = expectation(description: "Completion called")
+        var receivedImage: UIImage?
+        loader.loadPreviewForVideo(with: attachment) { result in
+            receivedImage = try? result.get()
+            expectation.fulfill()
+        }
+
+        // Then - image loader was called but failed, so it fell back to video frame extraction
+        waitForExpectations(timeout: 5)
+        XCTAssertTrue(imageLoader.loadImageCalled)
+        XCTAssertNotEqual(receivedImage, ConfigurableImageLoader.thumbnailImage)
+    }
+
+    func test_defaultLoader_withAttachment_whenCached_returnsCachedWithoutLoadingThumbnail() {
+        // Given
+        let imageLoader = ConfigurableImageLoader(result: .success(ConfigurableImageLoader.thumbnailImage))
+        streamChat = StreamChat(
+            chatClient: chatClient,
+            utils: Utils(imageLoader: imageLoader)
+        )
+        let loader = DefaultVideoPreviewLoader()
+        let attachment = makeVideoAttachment(thumbnailURL: thumbnailURL)
+
+        // Pre-populate via the URL-based method (which also populates the cache for the same URL)
+        let setupExpectation = expectation(description: "Setup completion called")
+        loader.loadPreviewForVideo(with: attachment) { _ in
+            setupExpectation.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+
+        imageLoader.loadImageCalled = false
+
+        // When - second call with attachment should use cache
+        let expectation = expectation(description: "Completion called")
+        var receivedImage: UIImage?
+        loader.loadPreviewForVideo(with: attachment) { result in
+            receivedImage = try? result.get()
+            expectation.fulfill()
+        }
+
+        // Then
+        waitForExpectations(timeout: 1)
+        XCTAssertFalse(imageLoader.loadImageCalled)
+        XCTAssertNotNil(receivedImage)
+    }
+
     // MARK: - Helpers
 
     private func makeVideoAttachment(
@@ -162,5 +302,41 @@ private class FullVideoPreviewLoader: VideoPreviewLoader {
         loadPreviewWithAttachmentCalled = true
         receivedAttachment = attachment
         completion(.success(UIImage()))
+    }
+}
+
+/// Configurable image loader that can be set to succeed or fail.
+private class ConfigurableImageLoader: ImageLoading {
+    static let thumbnailImage = UIImage(systemName: "star.fill")!
+
+    var loadImageCalled = false
+    var receivedURL: URL?
+    private let result: Result<UIImage, Error>
+
+    init(result: Result<UIImage, Error>) {
+        self.result = result
+    }
+
+    func loadImage(
+        url: URL?,
+        imageCDN: ImageCDN,
+        resize: Bool,
+        preferredSize: CGSize?,
+        completion: @escaping ((Result<UIImage, Error>) -> Void)
+    ) {
+        loadImageCalled = true
+        receivedURL = url
+        completion(result)
+    }
+
+    func loadImages(
+        from urls: [URL],
+        placeholders: [UIImage],
+        loadThumbnails: Bool,
+        thumbnailSize: CGSize,
+        imageCDN: ImageCDN,
+        completion: @escaping (([UIImage]) -> Void)
+    ) {
+        completion([])
     }
 }

--- a/StreamChatSwiftUITests/Tests/Utils/VideoPreviewLoader_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/Utils/VideoPreviewLoader_Tests.swift
@@ -7,7 +7,6 @@
 import XCTest
 
 class VideoPreviewLoader_Tests: StreamChatTestCase {
-
     private let testURL = URL(string: "https://example.com/video.mp4")!
     private let thumbnailURL = URL(string: "https://example.com/thumbnail.jpg")!
 


### PR DESCRIPTION
### 🔗 Issue Links

_N/A_

### 🎯 Goal

Allow customers to customize how `AVPlayer` instances are created for video playback, and improve video preview loading by leveraging thumbnail URLs from attachments.

### 📝 Summary

- Introduce `AVPlayerProvider` protocol and `DefaultAVPlayerProvider` to allow custom `AVPlayer` creation.
- Add `loadPreviewForVideo(with:completion:)` to `VideoPreviewLoader` protocol to accept a full `ChatMessageVideoAttachment` and be able to use remote thumbnails.
- For remote video attachments, use the `thumbnailURL` for video preview images.

### 🛠 Implementation

**AVPlayerProvider**

A new `AVPlayerProvider` protocol is added in `Utils.swift` with a single method: `player(for:completion:)`. The URL passed to the provider has already been resolved through `FileCDN.adjustedURL(for:)`, so the provider only needs to handle player creation.

The `DefaultAVPlayerProvider` simply creates an `AVPlayer` from the given URL. Customers can provide a custom implementation to inject authentication headers via a custom `AVURLAsset`:

```swift
class CustomAVPlayerProvider: AVPlayerProvider {
    func player(for url: URL, completion: @escaping ((Result<AVPlayer, Error>) -> Void)) {
        let headers = ["Authorization": "Bearer <token>"]
        let asset = AVURLAsset(url: url, options: ["AVURLAssetHTTPHeaderFieldsKey": headers])
        completion(.success(AVPlayer(playerItem: AVPlayerItem(asset: asset))))
    }
}

let utils = Utils(avPlayerProvider: CustomAVPlayerProvider())
```

Both `GalleryView` (`StreamVideoPlayer`) and `VideoPlayerView` now follow a two-step flow: resolve the URL via `FileCDN`, then create the player via `AVPlayerProvider`.

**VideoPreviewLoader**

A new `loadPreviewForVideo(with:completion:)` method is added to the `VideoPreviewLoader` protocol. A default protocol extension calls the existing URL-based method, so custom conformers that only implement `loadPreviewForVideo(at:completion:)` continue to work without changes.

The new method is used for remote video attachments and uses the thumbnail URL if available for the video preview image.

### 🧪 Manual Testing Notes

- Upload a video
- Generated thumbnail should come from the server.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New provider API for AV player customization.
  * Video preview loading enhanced to use remote thumbnails and caching.

* **Refactor**
  * Internal improvements to video playback initialization and preview loading for more robust behavior.

* **Tests**
  * Added comprehensive tests covering video preview loading paths and attachment handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->