### PR TITLE
[CI] Clean up v5 artefacts

### DIFF
--- a/.github/workflows/sdk-size-metrics.yml
+++ b/.github/workflows/sdk-size-metrics.yml
@@ -12,7 +12,6 @@ on:
   push:
     branches:
       - develop
-      - v5
 
 env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1 # Disable cleanup for homebrew, we don't need it on CI

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -17,7 +17,6 @@ source_packages_path = 'spm_cache'
 is_localhost = !is_ci
 mock_server_driver_port = 4568
 swift_environment_path = File.absolute_path('../Sources/StreamChatSwiftUI/Generated/SystemEnvironment+Version.swift')
-size_analysis_base_branch = 'v5' # use default when v5 is released
 @force_check = false
 
 before_all do |lane|
@@ -473,7 +472,7 @@ lane :show_frameworks_sizes do |options|
   next unless is_check_required(sources: sources_matrix[:size], force_check: @force_check)
 
   sizes = options[:sizes] || frameworks_sizes
-  show_sdk_size(branch_sizes: sizes, github_repo: github_repo, base_branch: size_analysis_base_branch)
+  show_sdk_size(branch_sizes: sizes, github_repo: github_repo)
   update_img_shields_sdk_sizes(sizes: sizes, open_pr: options[:open_pr]) if options[:update_readme]
 end
 
@@ -523,5 +522,5 @@ lane :size_analyze do
     cloned_source_packages_path: source_packages_path
   )
 
-  show_detailed_sdk_size(sdk_names: sdk_names, threshold: 42, base_branch: size_analysis_base_branch)
+  show_detailed_sdk_size(sdk_names: sdk_names, threshold: 42)
 end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed branch-specific configuration from SDK size analysis workflows and build scripts, streamlining the size analysis process by eliminating explicit base branch references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->