### PR TITLE
Fix Sendable errors when building with Xcode 26.4

### DIFF
--- a/Sources/StreamChatSwiftUI/Utils/Common/ImageCDN.swift
+++ b/Sources/StreamChatSwiftUI/Utils/Common/ImageCDN.swift
@@ -5,7 +5,7 @@
 import UIKit
 
 /// ImageCDN is providing set of functions to improve handling of images from CDN.
-public protocol ImageCDN {
+public protocol ImageCDN: Sendable {
     /// Customised (filtered) key for image cache.
     /// - Parameter imageURL: URL of the image that should be customised (filtered).
     /// - Returns: String to be used as an image cache key.
@@ -30,7 +30,7 @@ extension ImageCDN {
     }
 }
 
-open class StreamImageCDN: ImageCDN {
+open class StreamImageCDN: ImageCDN, @unchecked Sendable {
     public static let streamCDNURL = "stream-io-cdn.com"
 
     // Initializer required for subclasses

--- a/Sources/StreamChatSwiftUI/Utils/ImageLoading.swift
+++ b/Sources/StreamChatSwiftUI/Utils/ImageLoading.swift
@@ -5,7 +5,7 @@
 import UIKit
 
 /// ImageLoading is providing set of functions for downloading of images from URLs.
-public protocol ImageLoading: AnyObject {
+public protocol ImageLoading: AnyObject, Sendable {
     /// Load images from a given URLs
     /// - Parameters:
     ///   - urls: The URLs to load the images from

--- a/Sources/StreamChatSwiftUI/Utils/NukeImageLoader.swift
+++ b/Sources/StreamChatSwiftUI/Utils/NukeImageLoader.swift
@@ -7,7 +7,7 @@ import UIKit
 
 /// The class which is resposible for loading images from URLs.
 /// Internally uses `Nuke`'s shared object of `ImagePipeline` to load the image.
-open class NukeImageLoader: ImageLoading {
+open class NukeImageLoader: ImageLoading, @unchecked Sendable {
     public init() {
         // Public init.
     }

--- a/StreamChatSwiftUITests/Infrastructure/Mocks/ImageLoader_Mock.swift
+++ b/StreamChatSwiftUITests/Infrastructure/Mocks/ImageLoader_Mock.swift
@@ -9,7 +9,7 @@ import UIKit
 import XCTest
 
 /// Mock implementation of `ImageLoading`.
-class ImageLoader_Mock: ImageLoading {
+class ImageLoader_Mock: ImageLoading, @unchecked Sendable {
     static let defaultLoadedImage = XCTestCase.TestImages.yoda.image
     var loadImageCalled = false
 
@@ -43,7 +43,7 @@ class ImageLoader_Mock: ImageLoading {
 }
 
 /// Mock implementation of `ImageLoading` that returns different TestImages based on URL.
-class TestImagesLoader_Mock: ImageLoading {
+class TestImagesLoader_Mock: ImageLoading, @unchecked Sendable {
     var loadImageCalled = false
     var loadImagesCalled = false
 

--- a/StreamChatSwiftUITests/Tests/Utils/VideoPreviewLoader_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/Utils/VideoPreviewLoader_Tests.swift
@@ -309,7 +309,7 @@ private class FullVideoPreviewLoader: VideoPreviewLoader {
 }
 
 /// Configurable image loader that can be set to succeed or fail.
-private class ConfigurableImageLoader: ImageLoading {
+private class ConfigurableImageLoader: ImageLoading, @unchecked Sendable {
     static let thumbnailImage = UIImage(systemName: "star.fill")!
 
     var loadImageCalled = false


### PR DESCRIPTION
### 🔗 Issue Links

Fixes [IOS-1545](https://linear.app/stream/issue/IOS-1545/xcode-264-compatibility)

### 🎯 Goal

Fix build errors when building with Xcode 26.4

### 📝 Summary

- Xcode 26.4 fails with build errors while Xcode 26.3 does not

### 🛠 Implementation

Fixes build errors:
```
/stream-chat-swiftui/Sources/StreamChatSwiftUI/CommonViews/StreamAsyncImage.swift:47:48 Sending 'imageCDN' risks causing data races

/stream-chat-swiftui/Sources/StreamChatSwiftUI/CommonViews/StreamAsyncImage.swift:47:48 Sending value of non-Sendable type 'any ImageLoading' risks causing data races
```

### 🎨 Showcase

### 🧪 Manual Testing Notes

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal concurrency safety measures across image loading components to improve code reliability and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->