### PR TITLE
fix(demo): resolve forceRTL Binding MainActor isolation in AppConfigurationView

### DIFF
--- a/DemoAppSwiftUI/AppConfiguration/AppConfigurationView.swift
+++ b/DemoAppSwiftUI/AppConfiguration/AppConfigurationView.swift
@@ -11,12 +11,7 @@ struct AppConfigurationView: View {
     @State private var reactionsStyle = AppConfiguration.default.reactionsStyle
     @State private var reactionsPlacement = AppConfiguration.default.reactionsPlacement
     @State private var appStyle = AppConfiguration.default.appStyle
-
-    var forceRTL: Binding<Bool> = Binding {
-        AppConfiguration.default.forceRTL
-    } set: { newValue in
-        AppConfiguration.default.forceRTL = newValue
-    }
+    @State private var forceRTL = AppConfiguration.default.forceRTL
 
     var body: some View {
         NavigationView {
@@ -44,13 +39,14 @@ struct AppConfigurationView: View {
                     }
                 }
                 Section("Layout") {
-                    Toggle("Force RTL (preview)", isOn: forceRTL)
+                    Toggle("Force RTL (preview)", isOn: $forceRTL)
                 }
             }
             .navigationBarTitleDisplayMode(.inline)
             .navigationTitle("App Configuration")
         }
         .onChange(of: channelPinningEnabled, perform: { AppConfiguration.default.isChannelPinningFeatureEnabled = $0 })
+        .onChange(of: forceRTL) { AppConfiguration.default.forceRTL = $0 }
         .onChange(of: reactionsStyle) { newStyle in
             AppConfiguration.default.reactionsStyle = newStyle
             InjectedValues[\.utils].messageListConfig = AppConfiguration.makeMessageListConfig()


### PR DESCRIPTION
### 📝 Summary

Binding(get:set:) uses @Sendable closures, which cannot access @MainActor AppConfiguration.default. Use @State and onChange instead, consistent with other toggles in the same view.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of RTL (right-to-left) mode configuration to enhance code maintainability and state management efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->