### PR TITLE
Fix timestamp animation glitch on swipe-to-reply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Redesign the thread replies divider in the message replies list [#1354](https://github.com/GetStream/stream-chat-swiftui/pull/1354)
 
 ### 🐞 Fixed
-<<<<<<< fix/timestamp-label-animation-glitch-when-swiping-reply
 - Fix timestamp snapping back faster than delivery indicator on swipe-to-reply [#1360](https://github.com/GetStream/stream-chat-swiftui/pull/1360)
-=======
 - Fix tapping a non-first media attachment always opening the first item on initial tap [#1359](https://github.com/GetStream/stream-chat-swiftui/pull/1359)
->>>>>>> develop
 - Pinned message label now shows "Pinned by you" when the current user pinned the message [#1329](https://github.com/GetStream/stream-chat-swiftui/pull/1329)
 - Fix single media attachment without sharp tail corner when no caption [#1330](https://github.com/GetStream/stream-chat-swiftui/pull/1330)
 - Fix editing a voice message removing the voice recording attachment [#1327](https://github.com/GetStream/stream-chat-swiftui/pull/1327)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Redesign the thread replies divider in the message replies list [#1354](https://github.com/GetStream/stream-chat-swiftui/pull/1354)
 
 ### 🐞 Fixed
+- Fix timestamp snapping back faster than delivery indicator on swipe-to-reply [#1360](https://github.com/GetStream/stream-chat-swiftui/pull/1360)
 - Pinned message label now shows "Pinned by you" when the current user pinned the message [#1329](https://github.com/GetStream/stream-chat-swiftui/pull/1329)
 - Fix single media attachment without sharp tail corner when no caption [#1330](https://github.com/GetStream/stream-chat-swiftui/pull/1330)
 - Fix editing a voice message removing the voice recording attachment [#1327](https://github.com/GetStream/stream-chat-swiftui/pull/1327)

--- a/Sources/StreamChatSwiftUI/ChatMessageList/MessageListHelperViews.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/MessageListHelperViews.swift
@@ -95,7 +95,7 @@ struct MessageDateView: View {
         Text(text)
             .font(fonts.footnote)
             .foregroundColor(usesInvertedStyle ? colors.textOnAccent.toColor : colors.chatTextTimestamp.toColor)
-            .animation(nil)
+            .animation(nil, value: text)
             .accessibilityLabel(Text(accessibilityLabel))
             .accessibilityIdentifier("MessageDateView")
     }


### PR DESCRIPTION
### 🔗 Issue Links

[IOS-1512](https://linear.app/stream/issue/IOS-1512/v5-qa-swipe-to-reply-timestamp-swipes-back-faster-than-delivery)

### 🎯 Goal

Fix the visual glitch where the timestamp snaps back to its original position faster than the delivery indicator and message bubble when the swipe-to-reply gesture ends.

### 📝 Summary

- Replace the deprecated `.animation(nil)` with `.animation(nil, value: text)` on `MessageDateView` so that the swipe-to-reply spring animation propagates to the timestamp.

### 🧪 Manual Testing Notes

1. Open a conversation with messages.
2. Swipe right on a message to trigger the reply gesture.
3. Release the swipe and observe the message animating back.
4. Verify the timestamp and delivery indicator animate back in sync with the message bubble.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where timestamps would snap back faster than the delivery indicator during swipe-to-reply interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->