### PR TITLE
Fix scroll to bottom button not working when message list is actively scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Redesign the thread replies divider in the message replies list [#1354](https://github.com/GetStream/stream-chat-swiftui/pull/1354)
 
 ### 🐞 Fixed
+- Fix scroll to bottom button not working when the message list is actively scrolling [#1380](https://github.com/GetStream/stream-chat-swiftui/pull/1380)
 - Fix timestamp snapping back faster than delivery indicator on swipe-to-reply [#1360](https://github.com/GetStream/stream-chat-swiftui/pull/1360)
 - Fix tapping a non-first media attachment always opening the first item on initial tap [#1359](https://github.com/GetStream/stream-chat-swiftui/pull/1359)
 - Pinned message label now shows "Pinned by you" when the current user pinned the message [#1329](https://github.com/GetStream/stream-chat-swiftui/pull/1329)

--- a/Sources/StreamChatSwiftUI/ChatMessageList/MessageListView.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/MessageListView.swift
@@ -342,18 +342,16 @@ public struct MessageListView<Factory: ViewFactory>: View, KeyboardReadable {
                 .frame(maxWidth: .infinity)
                 .clipped()
                 .onChange(of: scrolledId) { scrolledId in
-                    DispatchQueue.main.async {
-                        if let scrolledId {
-                            let shouldJump = onJumpToMessage?(scrolledId) ?? false
-                            if !shouldJump {
-                                return
-                            }
-                            withAnimation {
-                                if messages.first?.id == scrolledId {
-                                    scrollView.scrollTo(bottomId, anchor: .bottom)
-                                } else {
-                                    scrollView.scrollTo(scrolledId, anchor: messageListConfig.scrollingAnchor)
-                                }
+                    if let scrolledId {
+                        let shouldJump = onJumpToMessage?(scrolledId) ?? false
+                        if !shouldJump {
+                            return
+                        }
+                        withAnimation {
+                            if messages.first?.id == scrolledId {
+                                scrollView.scrollTo(bottomId, anchor: .bottom)
+                            } else {
+                                scrollView.scrollTo(scrolledId, anchor: messageListConfig.scrollingAnchor)
                             }
                         }
                     }


### PR DESCRIPTION
### 🔗 Issue Links

[IOS-1532](https://linear.app/stream/issue/IOS-1532/v5-qa-scroll-to-bottom-button-does-not-work-while-scroll-bar-is)

### 🎯 Goal

Fix the scroll to bottom button not responding when tapped while the message list is actively decelerating.

### 📝 Summary

- Remove `DispatchQueue.main.async` wrapper from the `onChange(of: scrolledId)` handler in `MessageListView`.

### 🛠 Implementation

The `onChange(of: scrolledId)` handler was wrapped in `DispatchQueue.main.async`, which delayed the `scrollView.scrollTo()` call to the next run loop iteration. During that delay, the ongoing scroll deceleration would continue and override the programmatic scroll, making the button appear unresponsive.

By removing the async wrapper, `scrollView.scrollTo()` now fires synchronously inside the `onChange` handler, matching the v4 behavior and giving the programmatic scroll priority over any active deceleration.

### 🧪 Manual Testing Notes

1. Open a channel with enough messages to scroll.
2. Scroll up quickly and release so the list is still decelerating.
3. Tap the scroll to bottom button while the list is still moving.
4. Verify the list immediately scrolls to the bottom.
5. Test in both docked and floating composer placement modes.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the scroll to bottom button would not function correctly while the message list was actively being scrolled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->