### PR TITLE
Fix delays when removing reactions in reaction details

### DIFF
--- a/Sources/StreamChatSwiftUI/ChatMessageList/Reactions/ReactionsDetailViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/Reactions/ReactionsDetailViewModel.swift
@@ -109,6 +109,7 @@ class ReactionsDetailViewModel: ObservableObject, ChatReactionListControllerDele
     func messageController(_ controller: ChatMessageController, didChangeMessage change: EntityChange<ChatMessage>) {
         if let message = controller.message {
             self.message = message
+            syncCurrentUserReactions(from: message)
         }
     }
 
@@ -145,5 +146,27 @@ class ReactionsDetailViewModel: ObservableObject, ChatReactionListControllerDele
 
     private var userReactionIDs: Set<MessageReactionType> {
         Set(message.currentUserReactions.map(\.type))
+    }
+
+    private func syncCurrentUserReactions(from message: ChatMessage) {
+        guard let currentUserId = chatClient.currentUserId else { return }
+
+        let currentUserReactions = message.currentUserReactions
+            .sorted { $0.updatedAt > $1.updatedAt }
+        let hadCurrentUserReactions = reactions.contains { $0.author.id == currentUserId }
+
+        guard hadCurrentUserReactions || !currentUserReactions.isEmpty else { return }
+
+        let mergedReactions = reactions
+            .filter { $0.author.id != currentUserId }
+            + currentUserReactions
+
+        let sortedReactions = mergedReactions.sorted { first, second in
+            first.updatedAt > second.updatedAt
+        }
+
+        if reactions != sortedReactions {
+            reactions = sortedReactions
+        }
     }
 }

--- a/StreamChatSwiftUITests/Tests/ChatChannel/ReactionsDetailViewModel_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/ReactionsDetailViewModel_Tests.swift
@@ -8,6 +8,8 @@
 import XCTest
 
 @MainActor final class ReactionsDetailViewModel_Tests: StreamChatTestCase {
+    private let currentUserId = StreamChatTestCase.currentUserId
+
     // MARK: - Init
 
     func test_init_thenSynchronizeCalled() {
@@ -610,6 +612,98 @@ import XCTest
 
         // Then
         XCTAssertEqual(viewModel.message.text, "Updated text")
+    }
+
+    func test_messageControllerDidChangeMessage_thenCurrentUserReactionIsInsertedImmediately() {
+        // Given
+        let cid = ChannelId.unique
+        let like = MessageReactionType(rawValue: "like")
+        let love = MessageReactionType(rawValue: "love")
+        let message = ChatMessage.mock(cid: cid)
+        let controller = makeReactionListController(messageId: message.id)
+        let existingReaction = ChatMessageReaction.mock(
+            id: "existing",
+            type: love,
+            updatedAt: Date(timeIntervalSince1970: 100),
+            author: .mock(id: "other-user")
+        )
+        controller.reactions_simulated = [existingReaction]
+
+        let viewModel = ReactionsDetailViewModel(message: message, reactionListController: controller)
+        viewModel.controller(controller, didChangeReactions: [])
+
+        let messageController = ChatMessageControllerSUI_Mock.mock(
+            chatClient: chatClient,
+            currentUserId: currentUserId,
+            cid: cid,
+            messageId: message.id
+        )
+        let currentUserReaction = ChatMessageReaction.mock(
+            id: "current-user-reaction",
+            type: like,
+            updatedAt: Date(timeIntervalSince1970: 200),
+            author: .mock(id: currentUserId, name: "You")
+        )
+        let updatedMessage = ChatMessage.mock(
+            id: message.id,
+            cid: cid,
+            reactionScores: [like: 1, love: 1],
+            reactionCounts: [like: 1, love: 1],
+            currentUserReactions: [currentUserReaction]
+        )
+        messageController.message_mock = updatedMessage
+
+        // When
+        viewModel.messageController(messageController, didChangeMessage: .update(updatedMessage))
+
+        // Then
+        XCTAssertEqual(viewModel.reactions.map(\.id), ["current-user-reaction", "existing"])
+    }
+
+    func test_messageControllerDidChangeMessage_thenCurrentUserReactionIsRemovedImmediately() {
+        // Given
+        let cid = ChannelId.unique
+        let like = MessageReactionType(rawValue: "like")
+        let love = MessageReactionType(rawValue: "love")
+        let message = ChatMessage.mock(cid: cid)
+        let controller = makeReactionListController(messageId: message.id)
+        let currentUserReaction = ChatMessageReaction.mock(
+            id: "current-user-reaction",
+            type: like,
+            updatedAt: Date(timeIntervalSince1970: 200),
+            author: .mock(id: currentUserId, name: "You")
+        )
+        let existingReaction = ChatMessageReaction.mock(
+            id: "existing",
+            type: love,
+            updatedAt: Date(timeIntervalSince1970: 100),
+            author: .mock(id: "other-user")
+        )
+        controller.reactions_simulated = [currentUserReaction, existingReaction]
+
+        let viewModel = ReactionsDetailViewModel(message: message, reactionListController: controller)
+        viewModel.controller(controller, didChangeReactions: [])
+
+        let messageController = ChatMessageControllerSUI_Mock.mock(
+            chatClient: chatClient,
+            currentUserId: currentUserId,
+            cid: cid,
+            messageId: message.id
+        )
+        let updatedMessage = ChatMessage.mock(
+            id: message.id,
+            cid: cid,
+            reactionScores: [love: 1],
+            reactionCounts: [love: 1],
+            currentUserReactions: []
+        )
+        messageController.message_mock = updatedMessage
+
+        // When
+        viewModel.messageController(messageController, didChangeMessage: .update(updatedMessage))
+
+        // Then
+        XCTAssertEqual(viewModel.reactions.map(\.id), ["existing"])
     }
 
     func test_messageControllerDidChangeReactions_thenReactionsUpdated() {


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1624/fix-delays-when-removing-reactions-in-reaction-details.

### 🎯 Goal

_Describe why we are making this change._

### 📝 Summary

_Provide bullet points with the most important changes in the codebase._

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed reaction updates to ensure user reactions are properly synchronized when messages change.

* **Tests**
  * Added tests for message reaction update behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->