### PR TITLE
Fix empty share sheet when sharing a video from the full-screen media viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Redesign the thread replies divider in the message replies list [#1354](https://github.com/GetStream/stream-chat-swiftui/pull/1354)
 
 ### 🐞 Fixed
+- Fix empty share sheet when sharing a video from the full-screen media viewer [#1402](https://github.com/GetStream/stream-chat-swiftui/pull/1402)
 - Fix swipe-to-reply icon layout for outgoing messages and RTL [#1402](https://github.com/GetStream/stream-chat-swiftui/pull/1402)
 - Fix unwanted border on the Edit button in Channel Info [#1402](https://github.com/GetStream/stream-chat-swiftui/pull/1402)
 - Fix send button icon not mirroring in RTL layouts [#1397](https://github.com/GetStream/stream-chat-swiftui/pull/1397)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Redesign the thread replies divider in the message replies list [#1354](https://github.com/GetStream/stream-chat-swiftui/pull/1354)
 
 ### 🐞 Fixed
-- Fix empty share sheet when sharing a video from the full-screen media viewer [#1402](https://github.com/GetStream/stream-chat-swiftui/pull/1402)
+- Fix empty share sheet when sharing a video from the full-screen media viewer [#1418](https://github.com/GetStream/stream-chat-swiftui/pull/1418)
 - Fix swipe-to-reply icon layout for outgoing messages and RTL [#1402](https://github.com/GetStream/stream-chat-swiftui/pull/1402)
 - Fix unwanted border on the Edit button in Channel Info [#1402](https://github.com/GetStream/stream-chat-swiftui/pull/1402)
 - Fix send button icon not mirroring in RTL layouts [#1397](https://github.com/GetStream/stream-chat-swiftui/pull/1397)

--- a/Sources/StreamChatSwiftUI/ChatMessageList/Gallery/MediaViewer.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/Gallery/MediaViewer.swift
@@ -156,6 +156,7 @@ public struct MediaViewer<Factory: ViewFactory>: View {
     /// Used when there is no in-memory ``UIImage`` (videos never populate ``loadedImages``; images may still be loading).
     private var sharingFallbackURL: URL? {
         guard loadedImages[selected] == nil,
+              selected >= 0,
               selected < mediaAttachments.count else { return nil }
         return mediaAttachments[selected].url
     }

--- a/Sources/StreamChatSwiftUI/ChatMessageList/Gallery/MediaViewer.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/Gallery/MediaViewer.swift
@@ -110,6 +110,7 @@ public struct MediaViewer<Factory: ViewFactory>: View {
                     viewFactory.makeMediaViewerFooterView(
                         options: MediaViewerFooterViewOptions(
                             shareContent: sharingContent,
+                            shareFallbackURL: sharingFallbackURL,
                             selected: selected,
                             totalCount: mediaAttachments.count,
                             gridShown: $gridShown
@@ -150,6 +151,13 @@ public struct MediaViewer<Factory: ViewFactory>: View {
         } else {
             []
         }
+    }
+
+    /// Used when there is no in-memory ``UIImage`` (videos never populate ``loadedImages``; images may still be loading).
+    private var sharingFallbackURL: URL? {
+        guard loadedImages[selected] == nil,
+              selected < mediaAttachments.count else { return nil }
+        return mediaAttachments[selected].url
     }
 }
 
@@ -192,12 +200,20 @@ public struct MediaViewerFooterView: View {
     @Injected(\.tokens) private var tokens
 
     let shareContent: [UIImage]
+    let shareFallbackURL: URL?
     let selected: Int
     let totalCount: Int
     @Binding var gridShown: Bool
 
-    public init(shareContent: [UIImage], selected: Int, totalCount: Int, gridShown: Binding<Bool>) {
+    public init(
+        shareContent: [UIImage],
+        shareFallbackURL: URL? = nil,
+        selected: Int,
+        totalCount: Int,
+        gridShown: Binding<Bool>
+    ) {
         self.shareContent = shareContent
+        self.shareFallbackURL = shareFallbackURL
         self.selected = selected
         self.totalCount = totalCount
         _gridShown = gridShown
@@ -205,7 +221,7 @@ public struct MediaViewerFooterView: View {
 
     public var body: some View {
         HStack {
-            ShareButtonView(content: shareContent)
+            ShareButtonView(content: shareActivityItems)
 
             Spacer()
 
@@ -227,6 +243,16 @@ public struct MediaViewerFooterView: View {
         .padding(.horizontal, tokens.spacingSm)
         .frame(height: 48 + tokens.spacingSm * 2)
         .background(Color(colors.backgroundCoreElevation1))
+    }
+
+    private var shareActivityItems: [Any] {
+        if !shareContent.isEmpty {
+            return shareContent
+        }
+        if let shareFallbackURL {
+            return [shareFallbackURL]
+        }
+        return []
     }
 }
 

--- a/Sources/StreamChatSwiftUI/ViewFactory/DefaultViewFactory.swift
+++ b/Sources/StreamChatSwiftUI/ViewFactory/DefaultViewFactory.swift
@@ -395,6 +395,7 @@ extension ViewFactory {
     ) -> some View {
         MediaViewerFooterView(
             shareContent: options.shareContent,
+            shareFallbackURL: options.shareFallbackURL,
             selected: options.selected,
             totalCount: options.totalCount,
             gridShown: options.gridShown

--- a/Sources/StreamChatSwiftUI/ViewFactory/Options/AttachmentViewFactoryOptions.swift
+++ b/Sources/StreamChatSwiftUI/ViewFactory/Options/AttachmentViewFactoryOptions.swift
@@ -310,6 +310,8 @@ public final class MediaViewerToolbarModifierOptions: Sendable {
 public final class MediaViewerFooterViewOptions: Sendable {
     /// The content available for sharing (e.g. loaded images).
     public let shareContent: [UIImage]
+    /// URL to share when ``shareContent`` is empty (e.g. video attachments, or an image still loading).
+    public let shareFallbackURL: URL?
     /// The currently selected media index (zero-based).
     public let selected: Int
     /// The total number of media attachments.
@@ -317,8 +319,15 @@ public final class MediaViewerFooterViewOptions: Sendable {
     /// Binding that controls whether the grid sheet is shown.
     public let gridShown: Binding<Bool>
 
-    public init(shareContent: [UIImage], selected: Int, totalCount: Int, gridShown: Binding<Bool>) {
+    public init(
+        shareContent: [UIImage],
+        shareFallbackURL: URL? = nil,
+        selected: Int,
+        totalCount: Int,
+        gridShown: Binding<Bool>
+    ) {
         self.shareContent = shareContent
+        self.shareFallbackURL = shareFallbackURL
         self.selected = selected
         self.totalCount = totalCount
         self.gridShown = gridShown


### PR DESCRIPTION
### 🔗 Issue Links

Resolve https://linear.app/stream/issue/IOS-1625/

### 🎯 Goal

Fix the share action in the full-screen media viewer when the selected item is a **video** (or an image that has not finished loading). The share sheet was built with **no activity items**, which produced an empty / broken sheet.

### 📝 Summary

- Add optional `shareFallbackURL` to `MediaViewerFooterViewOptions` and thread it through `DefaultViewFactory`.
- In `MediaViewer`, when there is no in-memory `UIImage` for the current page, pass the selected `MediaAttachment` URL as the fallback.
- In `MediaViewerFooterView`, build share items as `[Any]`: prefer loaded images, otherwise `[URL]` for the fallback.

### 🛠 Implementation

`sharingContent` only ever came from `loadedImages[selected]`, which is populated for **images** via `LazyLoadingImage`. **Videos** never write into `loadedImages`, so the footer always passed an empty array into `ShareButtonView` / `UIActivityViewController`, which matches the “empty tab with logo and close” behavior on recent iOS.

The fix keeps the existing image path unchanged when a bitmap is available. If not, we reuse the same URL already carried by `MediaAttachment` (remote CDN URL, or local file URL while uploading). That gives the activity controller a non-empty `activityItems` array so the system share sheet can render. This mirrors the idea used elsewhere (e.g. sharing a video URL as a link rather than a file).

### 🎨 Showcase

| Before | After |
| ------ | ----- |
| <img width="828" height="1792" alt="photo_2026-04-15 16 41 17" src="https://github.com/user-attachments/assets/ba27076f-a587-43e7-9206-542d256a08e3" /> | <img width="828" height="1792" alt="photo_2026-04-15 16 41 20" src="https://github.com/user-attachments/assets/4d423e13-8b86-41e9-aab7-35f0f925ff0d" />  |

### 🧪 Manual Testing Notes

1. Open a channel in **DemoAppSwiftUI** (or any app using the default media viewer).
2. Send or open a message with a **video** attachment.
3. Tap the video to open the **full-screen** media viewer.
4. Tap **Share** in the footer.
5. **Expected:** The standard iOS share sheet appears with share targets; the shared item is the video URL (link), not an empty sheet.

Optional: repeat with an **image** before it finishes loading—share should still offer the image URL as fallback instead of an empty sheet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed empty share sheet when sharing videos from the full-screen media viewer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->