### PR TITLE
Bump stream-chat-swift to latest develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+### 🔄 Changed
+- Bump `stream-chat-swift` dependency to `develop` @ `ca835ce6621c027a6f97cf37ffe30d18d4d59be6`
+
 ### ✅ Added
 - Redesign attachment uploading progress and error state indicators [#1408](https://github.com/GetStream/stream-chat-swiftui/pull/1408)
 - Add inline upload progress and retry UI for file attachments [#1408](https://github.com/GetStream/stream-chat-swiftui/pull/1408)

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,10 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/GetStream/stream-chat-swift.git", from: "5.0.0-beta")
+        .package(
+            url: "https://github.com/GetStream/stream-chat-swift.git",
+            revision: "ca835ce6621c027a6f97cf37ffe30d18d4d59be6"
+        )
     ],
     targets: [
         .target(

--- a/StreamChatSwiftUI.xcodeproj/project.pbxproj
+++ b/StreamChatSwiftUI.xcodeproj/project.pbxproj
@@ -1524,7 +1524,7 @@
 			repositoryURL = "https://github.com/GetStream/stream-chat-swift.git";
 			requirement = {
 				kind = revision;
-				revision = f7295d3d6f83c2aad95b38055b27981efe3d8225;
+				revision = ca835ce6621c027a6f97cf37ffe30d18d4d59be6;
 			};
 		};
 		E3A1C01A282BAC66002D1E26 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### 🔗 Issue Links

N/A — dependency alignment after LLC (`stream-chat-swift`) merge to `develop`.

### 🎯 Goal

Point the SwiftUI SDK at the current tip of `develop` on `GetStream/stream-chat-swift` so consumers pick up the merged LLC changes.

### 📝 Summary

- `Package.swift`: pin `stream-chat-swift` to revision `ca835ce6621c027a6f97cf37ffe30d18d4d59be6` (current `develop` as resolved from `git ls-remote`).
- `StreamChatSwiftUI.xcodeproj`: same revision for the Xcode SPM package reference.
- `CHANGELOG.md`: note under Upcoming.

### 🛠 Implementation

SPM uses `.package(..., revision:)` instead of `from:` so the resolved commit matches `develop` exactly. Xcode project `XCRemoteSwiftPackageReference` requirement updated from the previous revision to the same SHA.

### 🧪 Manual Testing Notes

Resolve packages in Xcode (or `xcodebuild` with the shared scheme) and build `StreamChatSwiftUI` to confirm the new LLC revision compiles.

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-98496c93-8685-4293-8e03-eb42188ee3f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-98496c93-8685-4293-8e03-eb42188ee3f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

