### PR TITLE
Consolidate CDN and media loading through MediaLoader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+### 🔄 Changed
+- `CDNRequester` is now passed in the constructor of `StreamMediaLoader` instead of `Utils` [#1425](https://github.com/GetStream/stream-chat-swiftui/pull/1425)
+
 ### 🐞 Fixed
 - Fix show/hide message translation animation [#1426](https://github.com/GetStream/stream-chat-swiftui/pull/1426)
 

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/GetStream/stream-chat-swift.git", branch: "refactor/media-loader-cdn-requester-dependency-v2")
+        .package(url: "https://github.com/GetStream/stream-chat-swift.git", branch: "develop")
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/GetStream/stream-chat-swift.git", from: "5.0.0")
+        .package(url: "https://github.com/GetStream/stream-chat-swift.git", branch: "refactor/media-loader-cdn-requester-dependency-v2")
     ],
     targets: [
         .target(

--- a/Sources/StreamChatSwiftUI/ChatComposer/MessageComposerViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatComposer/MessageComposerViewModel.swift
@@ -1203,7 +1203,7 @@ final class FileAddedAsset {
 
         utils.mediaLoader.loadImage(
             url: imageAttachment.imageURL,
-            options: ImageLoadOptions(resize: nil, cdnRequester: utils.cdnRequester)
+            options: ImageLoadOptions()
         ) { result in
             if let image = (try? result.get())?.image {
                 let imageAsset = AddedAsset(

--- a/Sources/StreamChatSwiftUI/ChatComposer/MessageComposerViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatComposer/MessageComposerViewModel.swift
@@ -1202,8 +1202,7 @@ final class FileAddedAsset {
         }
 
         utils.mediaLoader.loadImage(
-            url: imageAttachment.imageURL,
-            options: ImageLoadOptions()
+            url: imageAttachment.imageURL
         ) { result in
             if let image = (try? result.get())?.image {
                 let imageAsset = AddedAsset(

--- a/Sources/StreamChatSwiftUI/ChatMessageList/FileAttachmentPreview.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/FileAttachmentPreview.swift
@@ -14,8 +14,6 @@ public struct FileAttachmentPreview: View {
     @Injected(\.images) private var images
     @Injected(\.utils) private var utils
 
-    private var cdnRequester: CDNRequester { utils.cdnRequester }
-
     let attachment: ChatMessageFileAttachment
     
     @State private var adjustedUrl: URL?
@@ -60,14 +58,12 @@ public struct FileAttachmentPreview: View {
                 }
             }
             .onAppear {
-                cdnRequester.fileRequest(for: url, options: .init()) { result in
-                    Task { @MainActor in
-                        switch result {
-                        case let .success(cdnRequest):
-                            adjustedUrl = cdnRequest.url
-                        case let .failure(error):
-                            self.error = error
-                        }
+                utils.mediaLoader.resolveFileURL(url) { result in
+                    switch result {
+                    case let .success(cdnRequest):
+                        adjustedUrl = cdnRequest.url
+                    case let .failure(error):
+                        self.error = error
                     }
                 }
             }

--- a/Sources/StreamChatSwiftUI/ChatMessageList/FileAttachmentPreview.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/FileAttachmentPreview.swift
@@ -58,7 +58,7 @@ public struct FileAttachmentPreview: View {
                 }
             }
             .onAppear {
-                utils.mediaLoader.loadFileRequest(for: url, options: DownloadFileRequestOptions()) { result in
+                utils.mediaLoader.loadFileRequest(for: url) { result in
                     switch result {
                     case let .success(result):
                         fileRequest = result.urlRequest

--- a/Sources/StreamChatSwiftUI/ChatMessageList/FileAttachmentPreview.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/FileAttachmentPreview.swift
@@ -58,10 +58,10 @@ public struct FileAttachmentPreview: View {
                 }
             }
             .onAppear {
-                utils.mediaLoader.resolveFileURL(url) { result in
+                utils.mediaLoader.loadFile(at: url, options: FileLoadOptions()) { result in
                     switch result {
-                    case let .success(cdnRequest):
-                        adjustedUrl = cdnRequest.url
+                    case let .success(file):
+                        adjustedUrl = file.url
                     case let .failure(error):
                         self.error = error
                     }

--- a/Sources/StreamChatSwiftUI/ChatMessageList/FileAttachmentPreview.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/FileAttachmentPreview.swift
@@ -16,7 +16,7 @@ public struct FileAttachmentPreview: View {
 
     let attachment: ChatMessageFileAttachment
     
-    @State private var adjustedUrl: URL?
+    @State private var fileRequest: URLRequest?
     @State private var isLoading = false
     @State private var webViewTitle: String?
     @State private var error: Error?
@@ -43,9 +43,9 @@ public struct FileAttachmentPreview: View {
                         .font(fonts.body)
                         .padding()
                 } else {
-                    if let adjustedUrl {
+                    if let fileRequest {
                         WebView(
-                            url: adjustedUrl,
+                            request: fileRequest,
                             isLoading: $isLoading,
                             title: $webViewTitle,
                             error: $error
@@ -58,10 +58,10 @@ public struct FileAttachmentPreview: View {
                 }
             }
             .onAppear {
-                utils.mediaLoader.loadFile(at: url, options: FileLoadOptions()) { result in
+                utils.mediaLoader.loadFileRequest(for: url, options: DownloadFileRequestOptions()) { result in
                     switch result {
-                    case let .success(file):
-                        adjustedUrl = file.url
+                    case let .success(result):
+                        fileRequest = result.urlRequest
                     case let .failure(error):
                         self.error = error
                     }

--- a/Sources/StreamChatSwiftUI/ChatMessageList/FileAttachmentView.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/FileAttachmentView.swift
@@ -279,8 +279,8 @@ struct DownloadShareAttachmentView<Payload: DownloadableAttachmentPayload>: View
         let messageId = attachment.id.messageId
         let cid = attachment.id.cid
         let messageController = chatClient.messageController(cid: cid, messageId: messageId)
-        let cdnRequester = InjectedValues[\.utils].cdnRequester
-        cdnRequester.fileRequest(for: attachment.remoteURL, options: .init()) { result in
+        let mediaLoader = InjectedValues[\.utils].mediaLoader
+        mediaLoader.resolveFileURL(attachment.remoteURL) { result in
             switch result {
             case let .success(cdnRequest):
                 messageController.downloadAttachment(attachment, remoteURL: cdnRequest.url) { result in

--- a/Sources/StreamChatSwiftUI/ChatMessageList/FileAttachmentView.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/FileAttachmentView.swift
@@ -280,10 +280,10 @@ struct DownloadShareAttachmentView<Payload: DownloadableAttachmentPayload>: View
         let cid = attachment.id.cid
         let messageController = chatClient.messageController(cid: cid, messageId: messageId)
         let mediaLoader = InjectedValues[\.utils].mediaLoader
-        mediaLoader.resolveFileURL(attachment.remoteURL) { result in
+        mediaLoader.loadFile(at: attachment.remoteURL, options: FileLoadOptions()) { result in
             switch result {
-            case let .success(cdnRequest):
-                messageController.downloadAttachment(attachment, remoteURL: cdnRequest.url) { result in
+            case let .success(file):
+                messageController.downloadAttachment(attachment, remoteURL: file.url) { result in
                     if case let .failure(error) = result {
                         log.error("Error downloading attachment: \(error.localizedDescription)")
                     } else {

--- a/Sources/StreamChatSwiftUI/ChatMessageList/FileAttachmentView.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/FileAttachmentView.swift
@@ -280,7 +280,7 @@ struct DownloadShareAttachmentView<Payload: DownloadableAttachmentPayload>: View
         let cid = attachment.id.cid
         let messageController = chatClient.messageController(cid: cid, messageId: messageId)
         let mediaLoader = InjectedValues[\.utils].mediaLoader
-        mediaLoader.loadFileRequest(for: attachment.remoteURL, options: DownloadFileRequestOptions()) { result in
+        mediaLoader.loadFileRequest(for: attachment.remoteURL) { result in
             switch result {
             case let .success(fileRequest):
                 messageController.downloadAttachment(attachment, request: fileRequest.urlRequest) { result in

--- a/Sources/StreamChatSwiftUI/ChatMessageList/FileAttachmentView.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/FileAttachmentView.swift
@@ -280,10 +280,10 @@ struct DownloadShareAttachmentView<Payload: DownloadableAttachmentPayload>: View
         let cid = attachment.id.cid
         let messageController = chatClient.messageController(cid: cid, messageId: messageId)
         let mediaLoader = InjectedValues[\.utils].mediaLoader
-        mediaLoader.loadFile(at: attachment.remoteURL, options: FileLoadOptions()) { result in
+        mediaLoader.loadFileRequest(for: attachment.remoteURL, options: DownloadFileRequestOptions()) { result in
             switch result {
-            case let .success(file):
-                messageController.downloadAttachment(attachment, remoteURL: file.url) { result in
+            case let .success(fileRequest):
+                messageController.downloadAttachment(attachment, request: fileRequest.urlRequest) { result in
                     if case let .failure(error) = result {
                         log.error("Error downloading attachment: \(error.localizedDescription)")
                     } else {

--- a/Sources/StreamChatSwiftUI/ChatMessageList/Gallery/MediaViewer.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/Gallery/MediaViewer.swift
@@ -344,7 +344,7 @@ struct StreamVideoPlayer: View {
             }
             utils.mediaLoader.loadVideoAsset(
                 at: url,
-                options: VideoLoadOptions(cdnRequester: utils.cdnRequester)
+                options: VideoLoadOptions()
             ) { result in
                 guard isVisible else { return }
                 switch result {

--- a/Sources/StreamChatSwiftUI/ChatMessageList/Gallery/MediaViewer.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/Gallery/MediaViewer.swift
@@ -343,8 +343,7 @@ struct StreamVideoPlayer: View {
                 return
             }
             utils.mediaLoader.loadVideoAsset(
-                at: url,
-                options: VideoLoadOptions()
+                at: url
             ) { result in
                 guard isVisible else { return }
                 switch result {

--- a/Sources/StreamChatSwiftUI/ChatMessageList/GiphyAttachmentView.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/GiphyAttachmentView.swift
@@ -132,7 +132,7 @@ struct LazyGiphyView: View {
         ) { phase in
             switch phase {
             case .success(let result):
-                if result.isAnimated, let gifData = result.animatedImageData {
+                if let gifData = result.animatedImageData {
                     AnimatedGifView(gifData: gifData)
                 } else {
                     Image(uiImage: result.image)

--- a/Sources/StreamChatSwiftUI/ChatMessageList/MediaAttachment.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/MediaAttachment.swift
@@ -40,12 +40,11 @@ public final class MediaAttachment: Identifiable, Equatable, Sendable {
         completion: @escaping @MainActor (Result<UIImage, Error>) -> Void
     ) {
         let utils = InjectedValues[\.utils]
-        let cdnRequester = utils.cdnRequester
         if type == .image {
             let imageResize: ImageResize? = resize ? ImageResize(preferredSize) : nil
             utils.mediaLoader.loadImage(
                 url: url,
-                options: ImageLoadOptions(resize: imageResize, cdnRequester: cdnRequester)
+                options: ImageLoadOptions(resize: imageResize)
             ) { result in
                 completion(result.map(\.image))
             }
@@ -57,7 +56,7 @@ public final class MediaAttachment: Identifiable, Equatable, Sendable {
             }
             utils.mediaLoader.loadVideoPreview(
                 with: videoAttachment,
-                options: VideoLoadOptions(cdnRequester: cdnRequester)
+                options: VideoLoadOptions()
             ) { result in
                 completion(result.map(\.image))
             }

--- a/Sources/StreamChatSwiftUI/ChatMessageList/MediaAttachment.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/MediaAttachment.swift
@@ -55,8 +55,7 @@ public final class MediaAttachment: Identifiable, Equatable, Sendable {
                 return
             }
             utils.mediaLoader.loadVideoPreview(
-                with: videoAttachment,
-                options: VideoLoadOptions()
+                with: videoAttachment
             ) { result in
                 completion(result.map(\.image))
             }

--- a/Sources/StreamChatSwiftUI/ChatMessageList/WebView.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/WebView.swift
@@ -7,7 +7,7 @@ import WebKit
 
 /// SwiftUI web view wrapper for `WKWebView`.
 struct WebView: UIViewRepresentable {
-    var url: URL
+    var request: URLRequest
     @Binding var isLoading: Bool
     @Binding var title: String?
     @Binding var error: Error?
@@ -26,7 +26,7 @@ struct WebView: UIViewRepresentable {
         webView.navigationDelegate = context.coordinator
         webView.allowsBackForwardNavigationGestures = true
         webView.scrollView.isScrollEnabled = true
-        webView.load(URLRequest(url: url))
+        webView.load(request)
         return webView.withAccessibilityIdentifier(identifier: "WKWebView")
     }
 

--- a/Sources/StreamChatSwiftUI/CommonViews/NukeImageLoader.swift
+++ b/Sources/StreamChatSwiftUI/CommonViews/NukeImageLoader.swift
@@ -33,11 +33,9 @@ enum NukeImageLoader {
             userInfo: [ImageRequest.UserInfoKey.imageIdKey: storedKey as Any]
         )
         guard let container = ImagePipeline.shared.cache[request] else { return nil }
-        let isAnimated = container.type == .gif
         return StreamAsyncImageResult(
             image: container.image,
-            isAnimated: isAnimated,
-            animatedImageData: isAnimated ? container.data : nil
+            animatedImageData: container.type == .gif ? container.data : nil
         )
     }
 

--- a/Sources/StreamChatSwiftUI/CommonViews/NukeImageLoader.swift
+++ b/Sources/StreamChatSwiftUI/CommonViews/NukeImageLoader.swift
@@ -54,9 +54,10 @@ enum NukeImageLoader {
     static func loadImage(
         url: URL,
         resize: ImageResize?,
-        cdnRequester: CDNRequester,
+        mediaLoader: MediaLoader,
         onCacheMiss: @MainActor () -> Void = {}
     ) async throws -> StreamAsyncImageResult {
+        let cdnRequester = (mediaLoader as? StreamMediaLoader)?.cdnRequester ?? StreamCDNRequester()
         let cdnResize = resize.map {
             CDNImageResize(width: $0.width, height: $0.height, resizeMode: $0.mode.value, crop: $0.mode.cropValue)
         }

--- a/Sources/StreamChatSwiftUI/CommonViews/NukeImageLoader.swift
+++ b/Sources/StreamChatSwiftUI/CommonViews/NukeImageLoader.swift
@@ -33,17 +33,19 @@ enum NukeImageLoader {
             userInfo: [ImageRequest.UserInfoKey.imageIdKey: storedKey as Any]
         )
         guard let container = ImagePipeline.shared.cache[request] else { return nil }
+        let isAnimated = container.type == .gif
         return StreamAsyncImageResult(
             image: container.image,
-            isAnimated: container.type == .gif,
-            animatedImageData: container.data
+            isAnimated: isAnimated,
+            animatedImageData: isAnimated ? container.data : nil
         )
     }
 
     /// Stores a caching key for a given URL and resize combination.
     ///
-    /// Called by ``StreamImageDownloader`` after a successful CDN transform
-    /// so that ``cachedResult(url:resize:)`` can find the image in Nuke's
+    /// Called by ``StreamAsyncImage`` after a successful load through
+    /// ``MediaLoader/loadImage(url:options:completion:)`` so that
+    /// ``cachedResult(url:resize:)`` can find the image in Nuke's
     /// memory cache on subsequent lookups.
     static func storeCachingKey(_ cachingKey: String, url: URL, resize: ImageResize?) {
         let key = inputKey(url: url, resize: resize) as NSString

--- a/Sources/StreamChatSwiftUI/CommonViews/NukeImageLoader.swift
+++ b/Sources/StreamChatSwiftUI/CommonViews/NukeImageLoader.swift
@@ -2,18 +2,14 @@
 // Copyright © 2026 Stream.io Inc. All rights reserved.
 //
 
-import StreamChat
 import StreamChatCommonUI
 import UIKit
 
-/// Internal helper that bridges the ``MediaLoader`` with SwiftUI-specific
-/// concerns like synchronous cache lookups and animated image data.
+/// Internal helper for synchronous Nuke memory-cache lookups.
 ///
-/// The actual image loading is delegated to the ``MediaLoader``. This type
-/// only adds:
-/// - A synchronous Nuke memory-cache check for instant initial phases
-/// - An `onCacheMiss` callback so ``StreamAsyncImage`` can delay showing
-///   a loading indicator until after the cache check
+/// ``StreamAsyncImage`` uses this to compute an instant `initialPhase`
+/// when a previously loaded image is still in memory. All actual image
+/// loading goes through ``MediaLoader``.
 enum NukeImageLoader {
     // MARK: - Synchronous Cache Lookup
 
@@ -44,62 +40,18 @@ enum NukeImageLoader {
         )
     }
 
-    // MARK: - Async Loading
-
-    /// Loads an image through the ``MediaLoader``, with an `onCacheMiss`
-    /// callback for phase transitions.
+    /// Stores a caching key for a given URL and resize combination.
     ///
-    /// Before hitting the network, resolves the CDN URL and checks Nuke's
-    /// memory cache. If the image is cached, it returns immediately. Otherwise,
-    /// calls `onCacheMiss` (so the caller can show a loading indicator) and
-    /// delegates the actual download to the ``MediaLoader``.
-    @MainActor
-    static func loadImage(
-        url: URL,
-        resize: ImageResize?,
-        mediaLoader: MediaLoader,
-        onCacheMiss: @MainActor () -> Void = {}
-    ) async throws -> StreamAsyncImageResult {
-        // Resolve CDN URL to check cache with the correct key
-        if let streamLoader = mediaLoader as? StreamMediaLoader {
-            let cdnResize = resize.map {
-                CDNImageResize(width: $0.width, height: $0.height, resizeMode: $0.mode.value, crop: $0.mode.cropValue)
-            }
-            let cdnRequest = try await streamLoader.cdnRequester.imageRequest(for: url, options: .init(resize: cdnResize))
-
-            if let cachingKey = cdnRequest.cachingKey {
-                let key = inputKey(url: url, resize: resize) as NSString
-                cachingKeyMap.setObject(StringBox(cachingKey), forKey: key)
-            }
-
-            let processors = makeProcessors(resize: resize)
-            let userInfo = cdnRequest.cachingKey.map { [ImageRequest.UserInfoKey.imageIdKey: $0 as Any] }
-            let cacheRequest = ImageRequest(url: cdnRequest.url, processors: processors, userInfo: userInfo)
-
-            if let container = ImagePipeline.shared.cache[cacheRequest] {
-                return StreamAsyncImageResult(
-                    image: container.image,
-                    isAnimated: container.type == .gif,
-                    animatedImageData: container.data
-                )
-            }
-        }
-
-        onCacheMiss()
-
-        let loaded = try await mediaLoader.loadImage(url: url, options: ImageLoadOptions(resize: resize))
-        return StreamAsyncImageResult(
-            image: loaded.image,
-            isAnimated: loaded.isAnimated,
-            animatedImageData: loaded.animatedImageData
-        )
+    /// Called by ``StreamImageDownloader`` after a successful CDN transform
+    /// so that ``cachedResult(url:resize:)`` can find the image in Nuke's
+    /// memory cache on subsequent lookups.
+    static func storeCachingKey(_ cachingKey: String, url: URL, resize: ImageResize?) {
+        let key = inputKey(url: url, resize: resize) as NSString
+        cachingKeyMap.setObject(StringBox(cachingKey), forKey: key)
     }
 
     // MARK: - Private
 
-    /// Maps `(url + resize)` → `cachingKey` so ``cachedResult(url:resize:)``
-    /// can query Nuke's memory cache using the correct `imageIdKey`.
-    /// Populated on the first successful CDN transform for each pair.
     private nonisolated(unsafe) static let cachingKeyMap = NSCache<NSString, StringBox>()
 
     private static func inputKey(url: URL, resize: ImageResize?) -> String {

--- a/Sources/StreamChatSwiftUI/CommonViews/NukeImageLoader.swift
+++ b/Sources/StreamChatSwiftUI/CommonViews/NukeImageLoader.swift
@@ -3,11 +3,17 @@
 //
 
 import StreamChat
+import StreamChatCommonUI
 import UIKit
 
-/// Internal helper that bridges the vendored Nuke pipeline with CDN requester
-/// transformations. Isolates all Nuke-specific code so views remain agnostic
-/// of the underlying image loading library.
+/// Internal helper that bridges the ``MediaLoader`` with SwiftUI-specific
+/// concerns like synchronous cache lookups and animated image data.
+///
+/// The actual image loading is delegated to the ``MediaLoader``. This type
+/// only adds:
+/// - A synchronous Nuke memory-cache check for instant initial phases
+/// - An `onCacheMiss` callback so ``StreamAsyncImage`` can delay showing
+///   a loading indicator until after the cache check
 enum NukeImageLoader {
     // MARK: - Synchronous Cache Lookup
 
@@ -40,16 +46,13 @@ enum NukeImageLoader {
 
     // MARK: - Async Loading
 
-    /// Loads an image from the given URL, applying CDN transformations and
-    /// optional resize processing.
+    /// Loads an image through the ``MediaLoader``, with an `onCacheMiss`
+    /// callback for phase transitions.
     ///
-    /// Checks Nuke's memory cache (using the ``CDNRequest/cachingKey``) after
-    /// CDN transformation. If the image is already cached, it returns
-    /// immediately without a network request. Otherwise, calls `onCacheMiss`
-    /// (so callers can show a loading state) and fetches from the network.
-    ///
-    /// Uses Nuke's async `ImageTask.response` which propagates Swift
-    /// concurrency cancellation to the underlying download automatically.
+    /// Before hitting the network, resolves the CDN URL and checks Nuke's
+    /// memory cache. If the image is cached, it returns immediately. Otherwise,
+    /// calls `onCacheMiss` (so the caller can show a loading indicator) and
+    /// delegates the actual download to the ``MediaLoader``.
     @MainActor
     static func loadImage(
         url: URL,
@@ -57,55 +60,38 @@ enum NukeImageLoader {
         mediaLoader: MediaLoader,
         onCacheMiss: @MainActor () -> Void = {}
     ) async throws -> StreamAsyncImageResult {
-        let cdnRequester = (mediaLoader as? StreamMediaLoader)?.cdnRequester ?? StreamCDNRequester()
-        let cdnResize = resize.map {
-            CDNImageResize(width: $0.width, height: $0.height, resizeMode: $0.mode.value, crop: $0.mode.cropValue)
-        }
-        let cdnRequest = try await cdnRequester.imageRequest(for: url, options: .init(resize: cdnResize))
+        // Resolve CDN URL to check cache with the correct key
+        if let streamLoader = mediaLoader as? StreamMediaLoader {
+            let cdnResize = resize.map {
+                CDNImageResize(width: $0.width, height: $0.height, resizeMode: $0.mode.value, crop: $0.mode.cropValue)
+            }
+            let cdnRequest = try await streamLoader.cdnRequester.imageRequest(for: url, options: .init(resize: cdnResize))
 
-        if let cachingKey = cdnRequest.cachingKey {
-            let key = inputKey(url: url, resize: resize) as NSString
-            cachingKeyMap.setObject(StringBox(cachingKey), forKey: key)
-        }
+            if let cachingKey = cdnRequest.cachingKey {
+                let key = inputKey(url: url, resize: resize) as NSString
+                cachingKeyMap.setObject(StringBox(cachingKey), forKey: key)
+            }
 
-        let processors = makeProcessors(resize: resize)
-        let userInfo = cdnRequest.cachingKey.map { [ImageRequest.UserInfoKey.imageIdKey: $0 as Any] }
+            let processors = makeProcessors(resize: resize)
+            let userInfo = cdnRequest.cachingKey.map { [ImageRequest.UserInfoKey.imageIdKey: $0 as Any] }
+            let cacheRequest = ImageRequest(url: cdnRequest.url, processors: processors, userInfo: userInfo)
 
-        let cacheRequest = ImageRequest(
-            url: cdnRequest.url,
-            processors: processors,
-            userInfo: userInfo
-        )
-
-        if let container = ImagePipeline.shared.cache[cacheRequest] {
-            return StreamAsyncImageResult(
-                image: container.image,
-                isAnimated: container.type == .gif,
-                animatedImageData: container.data
-            )
+            if let container = ImagePipeline.shared.cache[cacheRequest] {
+                return StreamAsyncImageResult(
+                    image: container.image,
+                    isAnimated: container.type == .gif,
+                    animatedImageData: container.data
+                )
+            }
         }
 
         onCacheMiss()
 
-        var urlRequest = URLRequest(url: cdnRequest.url)
-        if let headers = cdnRequest.headers {
-            for (key, value) in headers {
-                urlRequest.setValue(value, forHTTPHeaderField: key)
-            }
-        }
-
-        let networkRequest = ImageRequest(
-            urlRequest: urlRequest,
-            processors: processors,
-            userInfo: userInfo
-        )
-
-        let task = ImagePipeline.shared.imageTask(with: networkRequest)
-        let response = try await task.response
+        let loaded = try await mediaLoader.loadImage(url: url, options: ImageLoadOptions(resize: resize))
         return StreamAsyncImageResult(
-            image: response.image,
-            isAnimated: response.container.type == .gif,
-            animatedImageData: response.container.data
+            image: loaded.image,
+            isAnimated: loaded.isAnimated,
+            animatedImageData: loaded.animatedImageData
         )
     }
 
@@ -122,7 +108,7 @@ enum NukeImageLoader {
         return "\(urlPart)-\(resize.width)x\(resize.height)-\(resize.mode.value)"
     }
 
-    private static func makeProcessors(resize: ImageResize?) -> [any ImageProcessing] {
+    static func makeProcessors(resize: ImageResize?) -> [any ImageProcessing] {
         guard let resize else { return [] }
         let size = CGSize(width: resize.width, height: resize.height)
         guard size != .zero else { return [] }

--- a/Sources/StreamChatSwiftUI/CommonViews/StreamAsyncImage.swift
+++ b/Sources/StreamChatSwiftUI/CommonViews/StreamAsyncImage.swift
@@ -105,14 +105,23 @@ private struct StreamAsyncImageBody<Content: View>: View {
             return
         }
 
+        if initialPhase.image == nil {
+            phase = .loading
+        }
+
         do {
-            let result = try await NukeImageLoader.loadImage(
+            let loaded = try await utils.mediaLoader.loadImage(
                 url: url,
-                resize: resize,
-                mediaLoader: utils.mediaLoader,
-                onCacheMiss: { phase = .loading }
+                options: ImageLoadOptions(resize: resize)
             )
-            phase = .success(result)
+            if let cachingKey = loaded.cachingKey {
+                NukeImageLoader.storeCachingKey(cachingKey, url: url, resize: resize)
+            }
+            phase = .success(StreamAsyncImageResult(
+                image: loaded.image,
+                isAnimated: loaded.isAnimated,
+                animatedImageData: loaded.animatedImageData
+            ))
         } catch {
             if !(error is CancellationError) {
                 phase = .error(error)

--- a/Sources/StreamChatSwiftUI/CommonViews/StreamAsyncImage.swift
+++ b/Sources/StreamChatSwiftUI/CommonViews/StreamAsyncImage.swift
@@ -122,7 +122,6 @@ private struct StreamAsyncImageBody<Content: View>: View {
             }
             phase = .success(StreamAsyncImageResult(
                 image: loaded.image,
-                isAnimated: loaded.isAnimated,
                 animatedImageData: loaded.animatedImageData
             ))
         } catch {
@@ -170,8 +169,6 @@ public enum StreamAsyncImagePhase {
 public struct StreamAsyncImageResult {
     /// The loaded image.
     public let image: UIImage
-    /// Whether the image is an animated format (e.g. GIF).
-    public let isAnimated: Bool
     /// The raw image data for animated rendering. `nil` for static images.
     public let animatedImageData: Data?
 }

--- a/Sources/StreamChatSwiftUI/CommonViews/StreamAsyncImage.swift
+++ b/Sources/StreamChatSwiftUI/CommonViews/StreamAsyncImage.swift
@@ -105,9 +105,12 @@ private struct StreamAsyncImageBody<Content: View>: View {
             return
         }
 
-        if initialPhase.image == nil {
-            phase = .loading
+        if case .success = initialPhase {
+            phase = initialPhase
+            return
         }
+
+        phase = .loading
 
         do {
             let loaded = try await utils.mediaLoader.loadImage(

--- a/Sources/StreamChatSwiftUI/CommonViews/StreamAsyncImage.swift
+++ b/Sources/StreamChatSwiftUI/CommonViews/StreamAsyncImage.swift
@@ -109,7 +109,7 @@ private struct StreamAsyncImageBody<Content: View>: View {
             let result = try await NukeImageLoader.loadImage(
                 url: url,
                 resize: resize,
-                cdnRequester: utils.cdnRequester,
+                mediaLoader: utils.mediaLoader,
                 onCacheMiss: { phase = .loading }
             )
             phase = .success(result)

--- a/Sources/StreamChatSwiftUI/Utils.swift
+++ b/Sources/StreamChatSwiftUI/Utils.swift
@@ -18,17 +18,6 @@ import StreamChatCommonUI
     public var messageTimestampFormatter: MessageTimestampFormatter
     public var galleryHeaderViewDateFormatter: GalleryHeaderViewDateFormatter
     public var messageDateSeparatorFormatter: MessageDateSeparatorFormatter
-    /// The CDN requester used for URL transformation (signing, headers, resizing).
-    ///
-    /// - Important: This property is provided for backward compatibility.
-    /// Prefer configuring the CDN requester through ``StreamMediaLoader/init(cdnRequester:downloader:)``
-    /// and setting ``mediaLoader`` instead.
-    @available(*, deprecated, message: "Configure CDNRequester through StreamMediaLoader(cdnRequester:) and set mediaLoader instead.")
-    public var cdnRequester: CDNRequester {
-        get { (mediaLoader as? StreamMediaLoader)?.cdnRequester ?? StreamCDNRequester() }
-        set { mediaLoader = StreamMediaLoader(cdnRequester: newValue, downloader: StreamImageDownloader()) }
-    }
-
     /// The object responsible for loading images, video previews, and resolving file URLs.
     public var mediaLoader: MediaLoader
     public var channelNameFormatter: ChannelNameFormatter

--- a/Sources/StreamChatSwiftUI/Utils.swift
+++ b/Sources/StreamChatSwiftUI/Utils.swift
@@ -18,7 +18,18 @@ import StreamChatCommonUI
     public var messageTimestampFormatter: MessageTimestampFormatter
     public var galleryHeaderViewDateFormatter: GalleryHeaderViewDateFormatter
     public var messageDateSeparatorFormatter: MessageDateSeparatorFormatter
-    public var cdnRequester: CDNRequester
+    /// The CDN requester used for URL transformation (signing, headers, resizing).
+    ///
+    /// - Important: This property is provided for backward compatibility.
+    /// Prefer configuring the CDN requester through ``StreamMediaLoader/init(cdnRequester:downloader:)``
+    /// and setting ``mediaLoader`` instead.
+    @available(*, deprecated, message: "Configure CDNRequester through StreamMediaLoader(cdnRequester:) and set mediaLoader instead.")
+    public var cdnRequester: CDNRequester {
+        get { (mediaLoader as? StreamMediaLoader)?.cdnRequester ?? StreamCDNRequester() }
+        set { mediaLoader = StreamMediaLoader(cdnRequester: newValue, downloader: StreamImageDownloader()) }
+    }
+
+    /// The object responsible for loading images, video previews, and resolving file URLs.
     public var mediaLoader: MediaLoader
     public var channelNameFormatter: ChannelNameFormatter
     public var avPlayerProvider: AVPlayerProvider
@@ -82,7 +93,6 @@ import StreamChatCommonUI
         messageTimestampFormatter: MessageTimestampFormatter = ChannelListMessageTimestampFormatter(),
         galleryHeaderViewDateFormatter: GalleryHeaderViewDateFormatter = DefaultGalleryHeaderViewDateFormatter(),
         messageDateSeparatorFormatter: MessageDateSeparatorFormatter = DefaultMessageDateSeparatorFormatter(),
-        cdnRequester: CDNRequester = StreamCDNRequester(),
         mediaLoader: MediaLoader? = nil,
         avPlayerProvider: AVPlayerProvider = DefaultAVPlayerProvider(),
         messageTypeResolver: MessageTypeResolving = MessageTypeResolver(),
@@ -110,7 +120,6 @@ import StreamChatCommonUI
         self.messageTimestampFormatter = messageTimestampFormatter
         self.galleryHeaderViewDateFormatter = galleryHeaderViewDateFormatter
         self.messageDateSeparatorFormatter = messageDateSeparatorFormatter
-        self.cdnRequester = cdnRequester
         self.mediaLoader = mediaLoader ?? StreamMediaLoader(downloader: StreamImageDownloader())
         self.channelNameFormatter = channelNameFormatter
         self.avPlayerProvider = avPlayerProvider

--- a/Sources/StreamChatSwiftUI/Utils/StreamImageDownloader.swift
+++ b/Sources/StreamChatSwiftUI/Utils/StreamImageDownloader.swift
@@ -36,10 +36,11 @@ public final class StreamImageDownloader: ImageDownloading, Sendable {
             Task { @MainActor in
                 switch result {
                 case let .success(imageResponse):
+                    let isAnimated = imageResponse.container.type == .gif
                     completion(.success(DownloadedImage(
                         image: imageResponse.image,
-                        isAnimated: imageResponse.container.type == .gif,
-                        animatedImageData: imageResponse.container.data
+                        isAnimated: isAnimated,
+                        animatedImageData: isAnimated ? imageResponse.container.data : nil
                     )))
                 case let .failure(error):
                     completion(.failure(error))

--- a/Sources/StreamChatSwiftUI/Utils/StreamImageDownloader.swift
+++ b/Sources/StreamChatSwiftUI/Utils/StreamImageDownloader.swift
@@ -36,11 +36,9 @@ public final class StreamImageDownloader: ImageDownloading, Sendable {
             Task { @MainActor in
                 switch result {
                 case let .success(imageResponse):
-                    let isAnimated = imageResponse.container.type == .gif
                     completion(.success(DownloadedImage(
                         image: imageResponse.image,
-                        isAnimated: isAnimated,
-                        animatedImageData: isAnimated ? imageResponse.container.data : nil
+                        animatedImageData: imageResponse.container.type == .gif ? imageResponse.container.data : nil
                     )))
                 case let .failure(error):
                     completion(.failure(error))

--- a/Sources/StreamChatSwiftUI/Utils/StreamImageDownloader.swift
+++ b/Sources/StreamChatSwiftUI/Utils/StreamImageDownloader.swift
@@ -36,7 +36,11 @@ public final class StreamImageDownloader: ImageDownloading, Sendable {
             Task { @MainActor in
                 switch result {
                 case let .success(imageResponse):
-                    completion(.success(DownloadedImage(image: imageResponse.image)))
+                    completion(.success(DownloadedImage(
+                        image: imageResponse.image,
+                        isAnimated: imageResponse.container.type == .gif,
+                        animatedImageData: imageResponse.container.data
+                    )))
                 case let .failure(error):
                     completion(.failure(error))
                 }

--- a/StreamChatSwiftUI.xcodeproj/project.pbxproj
+++ b/StreamChatSwiftUI.xcodeproj/project.pbxproj
@@ -1522,8 +1522,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/GetStream/stream-chat-swift.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 5.0.0;
+				kind = branch;
+				branch = "refactor/media-loader-cdn-requester-dependency-v2";
 			};
 		};
 		E3A1C01A282BAC66002D1E26 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {

--- a/StreamChatSwiftUI.xcodeproj/project.pbxproj
+++ b/StreamChatSwiftUI.xcodeproj/project.pbxproj
@@ -1523,7 +1523,7 @@
 			repositoryURL = "https://github.com/GetStream/stream-chat-swift.git";
 			requirement = {
 				kind = branch;
-				branch = "refactor/media-loader-cdn-requester-dependency-v2";
+				branch = develop;
 			};
 		};
 		E3A1C01A282BAC66002D1E26 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {

--- a/StreamChatSwiftUITests/Infrastructure/Mocks/MediaLoader_Mock.swift
+++ b/StreamChatSwiftUITests/Infrastructure/Mocks/MediaLoader_Mock.swift
@@ -75,6 +75,15 @@ class MediaLoader_Mock: MediaLoader, @unchecked Sendable {
         }
     }
 
+    func resolveFileURL(
+        _ url: URL,
+        completion: @escaping @MainActor (Result<CDNRequest, Error>) -> Void
+    ) {
+        StreamConcurrency.onMain {
+            completion(.success(CDNRequest(url: url)))
+        }
+    }
+
     private func imageForURL(_ url: URL?) -> UIImage {
         guard let url else { return Self.defaultLoadedImage }
         let urlString = url.absoluteString

--- a/StreamChatSwiftUITests/Infrastructure/Mocks/MediaLoader_Mock.swift
+++ b/StreamChatSwiftUITests/Infrastructure/Mocks/MediaLoader_Mock.swift
@@ -75,12 +75,13 @@ class MediaLoader_Mock: MediaLoader, @unchecked Sendable {
         }
     }
 
-    func resolveFileURL(
-        _ url: URL,
-        completion: @escaping @MainActor (Result<CDNRequest, Error>) -> Void
+    func loadFile(
+        at url: URL,
+        options: FileLoadOptions,
+        completion: @escaping @MainActor (Result<MediaLoaderFile, Error>) -> Void
     ) {
         StreamConcurrency.onMain {
-            completion(.success(CDNRequest(url: url)))
+            completion(.success(MediaLoaderFile(url: url)))
         }
     }
 

--- a/StreamChatSwiftUITests/Infrastructure/Mocks/MediaLoader_Mock.swift
+++ b/StreamChatSwiftUITests/Infrastructure/Mocks/MediaLoader_Mock.swift
@@ -75,13 +75,13 @@ class MediaLoader_Mock: MediaLoader, @unchecked Sendable {
         }
     }
 
-    func loadFile(
-        at url: URL,
-        options: FileLoadOptions,
-        completion: @escaping @MainActor (Result<MediaLoaderFile, Error>) -> Void
+    func loadFileRequest(
+        for url: URL,
+        options: DownloadFileRequestOptions,
+        completion: @escaping @MainActor (Result<MediaLoaderFileRequest, Error>) -> Void
     ) {
         StreamConcurrency.onMain {
-            completion(.success(MediaLoaderFile(url: url)))
+            completion(.success(MediaLoaderFileRequest(urlRequest: URLRequest(url: url))))
         }
     }
 

--- a/StreamChatSwiftUITests/Tests/ChatChannel/LazyLoadingImage_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/LazyLoadingImage_Tests.swift
@@ -133,13 +133,12 @@ import XCTest
         XCTAssertEqual(imageLoader?.loadedURLs.first, .localYodaImage)
     }
 
-    // MARK: - CDN Requester
+    // MARK: - MediaLoader Integration
 
-    func test_mediaAttachment_generateThumbnail_usesInjectedCDNRequester() {
+    func test_mediaAttachment_generateThumbnail_usesInjectedMediaLoader() {
         // Given
-        let customRequester = CDNRequester_Mock()
         let mediaLoader = MediaLoader_Mock()
-        let utils = Utils(cdnRequester: customRequester, mediaLoader: mediaLoader)
+        let utils = Utils(mediaLoader: mediaLoader)
         streamChat = StreamChat(chatClient: chatClient, utils: utils)
         let attachment = MediaAttachment(url: .localYodaImage, type: .image)
 
@@ -154,15 +153,14 @@ import XCTest
         wait(for: [expectation], timeout: 2.0)
 
         // Then
-        XCTAssertEqual(mediaLoader.loadImageOptions.count, 1)
-        XCTAssert(mediaLoader.loadImageOptions.first?.cdnRequester is CDNRequester_Mock)
+        XCTAssertEqual(mediaLoader.loadImageCallCount, 1)
+        XCTAssertNotNil(mediaLoader.loadImageOptions.first?.resize)
     }
 
-    func test_mediaAttachment_videoPreview_usesInjectedCDNRequester() {
+    func test_mediaAttachment_videoPreview_usesInjectedMediaLoader() {
         // Given
-        let customRequester = CDNRequester_Mock()
         let mediaLoader = MediaLoader_Mock()
-        let utils = Utils(cdnRequester: customRequester, mediaLoader: mediaLoader)
+        let utils = Utils(mediaLoader: mediaLoader)
         streamChat = StreamChat(chatClient: chatClient, utils: utils)
         let videoAttachment = ChatMessageVideoAttachment(
             id: .init(cid: .init(type: .messaging, id: "test"), messageId: "msg", index: 0),
@@ -193,8 +191,7 @@ import XCTest
         wait(for: [expectation], timeout: 2.0)
 
         // Then
-        XCTAssertEqual(mediaLoader.loadVideoPreviewOptions.count, 1)
-        XCTAssert(mediaLoader.loadVideoPreviewOptions.first?.cdnRequester is CDNRequester_Mock)
+        XCTAssertTrue(mediaLoader.loadVideoPreviewWithAttachmentCalled)
     }
 
     // MARK: - MediaAttachment Equatable

--- a/StreamChatSwiftUITests/Tests/ChatChannel/WebView_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/WebView_Tests.swift
@@ -15,11 +15,11 @@ class WebView_Tests: StreamChatTestCase {
         throw XCTSkip("Check it out: https://github.com/pointfreeco/swift-snapshot-testing/issues/625")
 
         // Given
-        let url = mockURL
+        let request = URLRequest(url: mockURL)
 
         // When
         let webView = WebView(
-            url: url,
+            request: request,
             isLoading: .constant(false),
             title: .constant("Test"),
             error: .constant(nil)

--- a/StreamChatSwiftUITests/Tests/CommonViews/NukeImageLoader_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/CommonViews/NukeImageLoader_Tests.swift
@@ -24,119 +24,13 @@ final class NukeImageLoader_Tests: StreamChatTestCase {
         XCTAssertNil(result)
     }
 
-    // MARK: - loadImage (cache miss path)
+    // MARK: - storeCachingKey + cachedResult
 
-    func test_loadImage_callsOnCacheMiss_whenImageNotCached() async throws {
-        let url = URL(string: "https://example.com/test-miss-\(UUID().uuidString).jpg")!
-        let cdnRequester = CDNRequester_Mock()
-        let loader = StreamMediaLoader(cdnRequester: cdnRequester, downloader: StreamImageDownloader())
-        var cacheMissCalled = false
-
-        do {
-            _ = try await NukeImageLoader.loadImage(
-                url: url,
-                resize: nil,
-                mediaLoader: loader,
-                onCacheMiss: { cacheMissCalled = true }
-            )
-        } catch {
-            // Network error is expected in tests — we only care about the cache miss callback
-        }
-
-        XCTAssertTrue(cacheMissCalled)
-        XCTAssertEqual(cdnRequester.imageRequestCallCount, 1)
-        XCTAssertEqual(cdnRequester.imageRequestCalledWithURLs, [url])
-    }
-
-    func test_loadImage_callsCDNRequester_withCorrectURL() async {
-        let url = URL(string: "https://example.com/cdn-check-\(UUID().uuidString).jpg")!
-        let cdnRequester = CDNRequester_Mock()
-        let loader = StreamMediaLoader(cdnRequester: cdnRequester, downloader: StreamImageDownloader())
-
-        do {
-            _ = try await NukeImageLoader.loadImage(
-                url: url,
-                resize: nil,
-                mediaLoader: loader
-            )
-        } catch {
-            // Expected
-        }
-
-        XCTAssertEqual(cdnRequester.imageRequestCallCount, 1)
-        XCTAssertEqual(cdnRequester.imageRequestCalledWithURLs.first, url)
-    }
-
-    // MARK: - loadImage with resize
-
-    func test_loadImage_passesCDNRequester_withResize() async {
-        let url = URL(string: "https://example.com/resize-\(UUID().uuidString).jpg")!
-        let cdnRequester = CDNRequester_Mock()
-        let loader = StreamMediaLoader(cdnRequester: cdnRequester, downloader: StreamImageDownloader())
-        let resize = ImageResize(CGSize(width: 200, height: 150))
-
-        do {
-            _ = try await NukeImageLoader.loadImage(
-                url: url,
-                resize: resize,
-                mediaLoader: loader
-            )
-        } catch {
-            // Expected
-        }
-
-        XCTAssertEqual(cdnRequester.imageRequestCallCount, 1)
-    }
-
-    // MARK: - loadImage (cache hit after CDN transform)
-
-    func test_loadImage_skipsOnCacheMiss_whenCacheHitAfterTransform() async throws {
+    func test_cachedResult_returnsImage_afterStoringKeyAndPopulatingNukeCache() {
         let testImage = UIImage(systemName: "star.fill")!
         let uniqueKey = "cached-key-\(UUID().uuidString)"
         let cdnURL = URL(string: "https://cdn.example.com/\(uniqueKey)")!
-
-        let request = ImageRequest(
-            url: cdnURL,
-            userInfo: [.imageIdKey: uniqueKey]
-        )
-        ImagePipeline.shared.cache[request] = ImageContainer(image: testImage)
-
-        let cdnRequester = CDNRequester_Mock()
-        cdnRequester.imageRequestResult = .success(
-            CDNRequest(url: cdnURL, cachingKey: uniqueKey)
-        )
-        let loader = StreamMediaLoader(cdnRequester: cdnRequester, downloader: StreamImageDownloader())
-
         let originalURL = URL(string: "https://example.com/original-\(uniqueKey)")!
-        var cacheMissCalled = false
-
-        let result = try await NukeImageLoader.loadImage(
-            url: originalURL,
-            resize: nil,
-            mediaLoader: loader,
-            onCacheMiss: { cacheMissCalled = true }
-        )
-
-        XCTAssertFalse(cacheMissCalled)
-        XCTAssertNotNil(result.image)
-        XCTAssertEqual(cdnRequester.imageRequestCallCount, 1)
-
-        ImagePipeline.shared.cache[request] = nil
-    }
-
-    // MARK: - cachingKeyMap persistence
-
-    func test_cachedResult_returnsImage_afterLoadStoresCachingKey() async throws {
-        let testImage = UIImage(systemName: "heart.fill")!
-        let uniqueKey = "persist-key-\(UUID().uuidString)"
-        let cdnURL = URL(string: "https://cdn.example.com/\(uniqueKey)")!
-        let originalURL = URL(string: "https://example.com/\(uniqueKey)")!
-
-        let cdnRequester = CDNRequester_Mock()
-        cdnRequester.imageRequestResult = .success(
-            CDNRequest(url: cdnURL, cachingKey: uniqueKey)
-        )
-        let loader = StreamMediaLoader(cdnRequester: cdnRequester, downloader: StreamImageDownloader())
 
         let request = ImageRequest(
             url: cdnURL,
@@ -144,15 +38,43 @@ final class NukeImageLoader_Tests: StreamChatTestCase {
         )
         ImagePipeline.shared.cache[request] = ImageContainer(image: testImage)
 
-        _ = try await NukeImageLoader.loadImage(
-            url: originalURL,
-            resize: nil,
-            mediaLoader: loader
-        )
+        NukeImageLoader.storeCachingKey(uniqueKey, url: originalURL, resize: nil)
 
         let cached = NukeImageLoader.cachedResult(url: originalURL, resize: nil)
         XCTAssertNotNil(cached)
         XCTAssertNotNil(cached?.image)
+
+        ImagePipeline.shared.cache[request] = nil
+    }
+
+    func test_cachedResult_returnsNil_whenKeyStoredButNukeCacheEvicted() {
+        let uniqueKey = "evicted-key-\(UUID().uuidString)"
+        let originalURL = URL(string: "https://example.com/evicted-\(uniqueKey)")!
+
+        NukeImageLoader.storeCachingKey(uniqueKey, url: originalURL, resize: nil)
+
+        let cached = NukeImageLoader.cachedResult(url: originalURL, resize: nil)
+        XCTAssertNil(cached)
+    }
+
+    func test_cachedResult_withResize_returnsImage() {
+        let testImage = UIImage(systemName: "heart.fill")!
+        let uniqueKey = "resize-key-\(UUID().uuidString)"
+        let cdnURL = URL(string: "https://cdn.example.com/\(uniqueKey)")!
+        let originalURL = URL(string: "https://example.com/resize-\(uniqueKey)")!
+        let resize = ImageResize(CGSize(width: 200, height: 150))
+
+        let request = ImageRequest(
+            url: cdnURL,
+            processors: NukeImageLoader.makeProcessors(resize: resize),
+            userInfo: [.imageIdKey: uniqueKey]
+        )
+        ImagePipeline.shared.cache[request] = ImageContainer(image: testImage)
+
+        NukeImageLoader.storeCachingKey(uniqueKey, url: originalURL, resize: resize)
+
+        let cached = NukeImageLoader.cachedResult(url: originalURL, resize: resize)
+        XCTAssertNotNil(cached)
 
         ImagePipeline.shared.cache[request] = nil
     }

--- a/StreamChatSwiftUITests/Tests/CommonViews/NukeImageLoader_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/CommonViews/NukeImageLoader_Tests.swift
@@ -3,6 +3,7 @@
 //
 
 @testable import StreamChat
+import StreamChatCommonUI
 @testable import StreamChatSwiftUI
 import XCTest
 
@@ -28,13 +29,14 @@ final class NukeImageLoader_Tests: StreamChatTestCase {
     func test_loadImage_callsOnCacheMiss_whenImageNotCached() async throws {
         let url = URL(string: "https://example.com/test-miss-\(UUID().uuidString).jpg")!
         let cdnRequester = CDNRequester_Mock()
+        let loader = StreamMediaLoader(cdnRequester: cdnRequester, downloader: StreamImageDownloader())
         var cacheMissCalled = false
 
         do {
             _ = try await NukeImageLoader.loadImage(
                 url: url,
                 resize: nil,
-                cdnRequester: cdnRequester,
+                mediaLoader: loader,
                 onCacheMiss: { cacheMissCalled = true }
             )
         } catch {
@@ -49,12 +51,13 @@ final class NukeImageLoader_Tests: StreamChatTestCase {
     func test_loadImage_callsCDNRequester_withCorrectURL() async {
         let url = URL(string: "https://example.com/cdn-check-\(UUID().uuidString).jpg")!
         let cdnRequester = CDNRequester_Mock()
+        let loader = StreamMediaLoader(cdnRequester: cdnRequester, downloader: StreamImageDownloader())
 
         do {
             _ = try await NukeImageLoader.loadImage(
                 url: url,
                 resize: nil,
-                cdnRequester: cdnRequester
+                mediaLoader: loader
             )
         } catch {
             // Expected
@@ -69,13 +72,14 @@ final class NukeImageLoader_Tests: StreamChatTestCase {
     func test_loadImage_passesCDNRequester_withResize() async {
         let url = URL(string: "https://example.com/resize-\(UUID().uuidString).jpg")!
         let cdnRequester = CDNRequester_Mock()
+        let loader = StreamMediaLoader(cdnRequester: cdnRequester, downloader: StreamImageDownloader())
         let resize = ImageResize(CGSize(width: 200, height: 150))
 
         do {
             _ = try await NukeImageLoader.loadImage(
                 url: url,
                 resize: resize,
-                cdnRequester: cdnRequester
+                mediaLoader: loader
             )
         } catch {
             // Expected
@@ -101,6 +105,7 @@ final class NukeImageLoader_Tests: StreamChatTestCase {
         cdnRequester.imageRequestResult = .success(
             CDNRequest(url: cdnURL, cachingKey: uniqueKey)
         )
+        let loader = StreamMediaLoader(cdnRequester: cdnRequester, downloader: StreamImageDownloader())
 
         let originalURL = URL(string: "https://example.com/original-\(uniqueKey)")!
         var cacheMissCalled = false
@@ -108,7 +113,7 @@ final class NukeImageLoader_Tests: StreamChatTestCase {
         let result = try await NukeImageLoader.loadImage(
             url: originalURL,
             resize: nil,
-            cdnRequester: cdnRequester,
+            mediaLoader: loader,
             onCacheMiss: { cacheMissCalled = true }
         )
 
@@ -131,6 +136,7 @@ final class NukeImageLoader_Tests: StreamChatTestCase {
         cdnRequester.imageRequestResult = .success(
             CDNRequest(url: cdnURL, cachingKey: uniqueKey)
         )
+        let loader = StreamMediaLoader(cdnRequester: cdnRequester, downloader: StreamImageDownloader())
 
         let request = ImageRequest(
             url: cdnURL,
@@ -141,7 +147,7 @@ final class NukeImageLoader_Tests: StreamChatTestCase {
         _ = try await NukeImageLoader.loadImage(
             url: originalURL,
             resize: nil,
-            cdnRequester: cdnRequester
+            mediaLoader: loader
         )
 
         let cached = NukeImageLoader.cachedResult(url: originalURL, resize: nil)

--- a/StreamChatSwiftUITests/Tests/Utils/MediaLoader_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/Utils/MediaLoader_Tests.swift
@@ -198,11 +198,12 @@ private class CustomMediaLoader: MediaLoader, @unchecked Sendable {
         Task { @MainActor in completion(.success(MediaLoaderVideoPreview(image: UIImage()))) }
     }
 
-    func resolveFileURL(
-        _ url: URL,
-        completion: @escaping @MainActor (Result<CDNRequest, Error>) -> Void
+    func loadFile(
+        at url: URL,
+        options: FileLoadOptions,
+        completion: @escaping @MainActor (Result<MediaLoaderFile, Error>) -> Void
     ) {
-        Task { @MainActor in completion(.success(CDNRequest(url: url))) }
+        Task { @MainActor in completion(.success(MediaLoaderFile(url: url))) }
     }
 }
 

--- a/StreamChatSwiftUITests/Tests/Utils/MediaLoader_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/Utils/MediaLoader_Tests.swift
@@ -198,12 +198,12 @@ private class CustomMediaLoader: MediaLoader, @unchecked Sendable {
         Task { @MainActor in completion(.success(MediaLoaderVideoPreview(image: UIImage()))) }
     }
 
-    func loadFile(
-        at url: URL,
-        options: FileLoadOptions,
-        completion: @escaping @MainActor (Result<MediaLoaderFile, Error>) -> Void
+    func loadFileRequest(
+        for url: URL,
+        options: DownloadFileRequestOptions,
+        completion: @escaping @MainActor (Result<MediaLoaderFileRequest, Error>) -> Void
     ) {
-        Task { @MainActor in completion(.success(MediaLoaderFile(url: url))) }
+        Task { @MainActor in completion(.success(MediaLoaderFileRequest(urlRequest: URLRequest(url: url)))) }
     }
 }
 

--- a/StreamChatSwiftUITests/Tests/Utils/MediaLoader_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/Utils/MediaLoader_Tests.swift
@@ -11,7 +11,7 @@ import XCTest
 class MediaLoader_Tests: StreamChatTestCase {
     private let testURL = URL(string: "https://example.com/video.mp4")!
     private let thumbnailURL = URL(string: "https://example.com/thumbnail.jpg")!
-    private let cdnRequester = CDNRequester_Mock()
+    private let cdnRequester: CDNRequester = CDNRequester_Mock()
 
     // MARK: - Custom conformer
 
@@ -21,7 +21,7 @@ class MediaLoader_Tests: StreamChatTestCase {
 
         let expectation = expectation(description: "Completion called")
         var receivedPreview: MediaLoaderVideoPreview?
-        loader.loadVideoPreview(with: attachment, options: VideoLoadOptions(cdnRequester: cdnRequester)) { result in
+        loader.loadVideoPreview(with: attachment, options: VideoLoadOptions()) { result in
             receivedPreview = try? result.get()
             expectation.fulfill()
         }
@@ -36,7 +36,7 @@ class MediaLoader_Tests: StreamChatTestCase {
         let attachment = makeVideoAttachment(thumbnailURL: thumbnailURL)
 
         let expectation = expectation(description: "Completion called")
-        loader.loadVideoPreview(with: attachment, options: VideoLoadOptions(cdnRequester: cdnRequester)) { _ in
+        loader.loadVideoPreview(with: attachment, options: VideoLoadOptions()) { _ in
             expectation.fulfill()
         }
 
@@ -50,12 +50,12 @@ class MediaLoader_Tests: StreamChatTestCase {
     func test_streamMediaLoader_loadImage_callsDownloader() {
         let expectedImage = UIImage(systemName: "star.fill")!
         let downloader = ConfigurableImageDownloader(result: .success(expectedImage))
-        let mediaLoader = StreamMediaLoader(downloader: downloader)
+        let mediaLoader = StreamMediaLoader(cdnRequester: cdnRequester, downloader: downloader)
         let url = URL(string: "https://example.com/image.jpg")!
 
         let expectation = expectation(description: "Completion called")
         var receivedImage: MediaLoaderImage?
-        mediaLoader.loadImage(url: url, options: ImageLoadOptions(cdnRequester: cdnRequester)) { result in
+        mediaLoader.loadImage(url: url, options: ImageLoadOptions()) { result in
             receivedImage = try? result.get()
             expectation.fulfill()
         }
@@ -67,11 +67,11 @@ class MediaLoader_Tests: StreamChatTestCase {
 
     func test_streamMediaLoader_loadImage_returnsError_whenURLNil() {
         let downloader = ConfigurableImageDownloader(result: .success(UIImage()))
-        let mediaLoader = StreamMediaLoader(downloader: downloader)
+        let mediaLoader = StreamMediaLoader(cdnRequester: cdnRequester, downloader: downloader)
 
         let expectation = expectation(description: "Completion called")
         var receivedError: Error?
-        mediaLoader.loadImage(url: nil, options: ImageLoadOptions(cdnRequester: cdnRequester)) { result in
+        mediaLoader.loadImage(url: nil, options: ImageLoadOptions()) { result in
             if case let .failure(error) = result {
                 receivedError = error
             }
@@ -86,12 +86,12 @@ class MediaLoader_Tests: StreamChatTestCase {
     func test_streamMediaLoader_loadImage_propagatesDownloaderError() {
         let expectedError = NSError(domain: "test", code: 42)
         let downloader = ConfigurableImageDownloader(result: .failure(expectedError))
-        let mediaLoader = StreamMediaLoader(downloader: downloader)
+        let mediaLoader = StreamMediaLoader(cdnRequester: cdnRequester, downloader: downloader)
         let url = URL(string: "https://example.com/fail.jpg")!
 
         let expectation = expectation(description: "Completion called")
         var receivedError: NSError?
-        mediaLoader.loadImage(url: url, options: ImageLoadOptions(cdnRequester: cdnRequester)) { result in
+        mediaLoader.loadImage(url: url, options: ImageLoadOptions()) { result in
             if case let .failure(error) = result {
                 receivedError = error as NSError
             }
@@ -107,12 +107,12 @@ class MediaLoader_Tests: StreamChatTestCase {
     func test_streamMediaLoader_withAttachment_whenThumbnailURLExists_loadsThumbnailImage() {
         let thumbnailImage = UIImage(systemName: "star.fill")!
         let downloader = ConfigurableImageDownloader(result: .success(thumbnailImage))
-        let mediaLoader = StreamMediaLoader(downloader: downloader)
+        let mediaLoader = StreamMediaLoader(cdnRequester: cdnRequester, downloader: downloader)
         let attachment = makeVideoAttachment(thumbnailURL: thumbnailURL)
 
         let expectation = expectation(description: "Completion called")
         var receivedPreview: MediaLoaderVideoPreview?
-        mediaLoader.loadVideoPreview(with: attachment, options: VideoLoadOptions(cdnRequester: cdnRequester)) { result in
+        mediaLoader.loadVideoPreview(with: attachment, options: VideoLoadOptions()) { result in
             receivedPreview = try? result.get()
             expectation.fulfill()
         }
@@ -124,11 +124,11 @@ class MediaLoader_Tests: StreamChatTestCase {
 
     func test_streamMediaLoader_withAttachment_whenNoThumbnailURL_doesNotCallImageDownloader() {
         let downloader = ConfigurableImageDownloader(result: .success(UIImage()))
-        let mediaLoader = StreamMediaLoader(downloader: downloader)
+        let mediaLoader = StreamMediaLoader(cdnRequester: cdnRequester, downloader: downloader)
         let attachment = makeVideoAttachment(thumbnailURL: nil)
 
         let expectation = expectation(description: "Completion called")
-        mediaLoader.loadVideoPreview(with: attachment, options: VideoLoadOptions(cdnRequester: cdnRequester)) { _ in
+        mediaLoader.loadVideoPreview(with: attachment, options: VideoLoadOptions()) { _ in
             expectation.fulfill()
         }
 
@@ -196,6 +196,13 @@ private class CustomMediaLoader: MediaLoader, @unchecked Sendable {
         completion: @escaping @MainActor (Result<MediaLoaderVideoPreview, Error>) -> Void
     ) {
         Task { @MainActor in completion(.success(MediaLoaderVideoPreview(image: UIImage()))) }
+    }
+
+    func resolveFileURL(
+        _ url: URL,
+        completion: @escaping @MainActor (Result<CDNRequest, Error>) -> Void
+    ) {
+        Task { @MainActor in completion(.success(CDNRequest(url: url))) }
     }
 }
 

--- a/StreamChatSwiftUITests/Tests/Utils/MediaLoader_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/Utils/MediaLoader_Tests.swift
@@ -136,6 +136,67 @@ class MediaLoader_Tests: StreamChatTestCase {
         XCTAssertFalse(downloader.downloadImageCalled)
     }
 
+    // MARK: - StreamMediaLoader loadFileRequest
+
+    func test_streamMediaLoader_loadFileRequest_returnsResolvedURL() {
+        let resolvedURL = URL(string: "https://cdn.example.com/signed?token=abc")!
+        let mock = CDNRequester_Mock()
+        mock.fileRequestResult = .success(CDNRequest(url: resolvedURL))
+        let mediaLoader = StreamMediaLoader(cdnRequester: mock, downloader: ConfigurableImageDownloader(result: .success(UIImage())))
+        let originalURL = URL(string: "https://example.com/file.pdf")!
+
+        let expectation = expectation(description: "Completion called")
+        var receivedRequest: MediaLoaderFileRequest?
+        mediaLoader.loadFileRequest(for: originalURL, options: DownloadFileRequestOptions()) { result in
+            receivedRequest = try? result.get()
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 1)
+        XCTAssertEqual(receivedRequest?.urlRequest.url, resolvedURL)
+        XCTAssertEqual(mock.fileRequestCallCount, 1)
+        XCTAssertEqual(mock.fileRequestCalledWithURLs.first, originalURL)
+    }
+
+    func test_streamMediaLoader_loadFileRequest_forwardsHeaders() {
+        let resolvedURL = URL(string: "https://cdn.example.com/signed")!
+        let headers = ["Authorization": "Bearer token123", "X-Custom": "value"]
+        let mock = CDNRequester_Mock()
+        mock.fileRequestResult = .success(CDNRequest(url: resolvedURL, headers: headers))
+        let mediaLoader = StreamMediaLoader(cdnRequester: mock, downloader: ConfigurableImageDownloader(result: .success(UIImage())))
+
+        let expectation = expectation(description: "Completion called")
+        var receivedRequest: MediaLoaderFileRequest?
+        mediaLoader.loadFileRequest(for: URL(string: "https://example.com/file.pdf")!, options: DownloadFileRequestOptions()) { result in
+            receivedRequest = try? result.get()
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 1)
+        let urlRequest = receivedRequest?.urlRequest
+        XCTAssertEqual(urlRequest?.value(forHTTPHeaderField: "Authorization"), "Bearer token123")
+        XCTAssertEqual(urlRequest?.value(forHTTPHeaderField: "X-Custom"), "value")
+    }
+
+    func test_streamMediaLoader_loadFileRequest_propagatesError() {
+        let expectedError = NSError(domain: "test", code: 99)
+        let mock = CDNRequester_Mock()
+        mock.fileRequestResult = .failure(expectedError)
+        let mediaLoader = StreamMediaLoader(cdnRequester: mock, downloader: ConfigurableImageDownloader(result: .success(UIImage())))
+
+        let expectation = expectation(description: "Completion called")
+        var receivedError: NSError?
+        mediaLoader.loadFileRequest(for: URL(string: "https://example.com/file.pdf")!, options: DownloadFileRequestOptions()) { result in
+            if case let .failure(error) = result {
+                receivedError = error as NSError
+            }
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 1)
+        XCTAssertEqual(receivedError?.code, 99)
+    }
+
     // MARK: - Helpers
 
     private func makeVideoAttachment(

--- a/StreamChatSwiftUITests/Tests/Utils/MediaLoader_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/Utils/MediaLoader_Tests.swift
@@ -142,7 +142,7 @@ class MediaLoader_Tests: StreamChatTestCase {
         let resolvedURL = URL(string: "https://cdn.example.com/signed?token=abc")!
         let mock = CDNRequester_Mock()
         mock.fileRequestResult = .success(CDNRequest(url: resolvedURL))
-        let mediaLoader = StreamMediaLoader(cdnRequester: mock, downloader: ConfigurableImageDownloader(result: .success(UIImage())))
+        let mediaLoader = StreamMediaLoader(downloader: ConfigurableImageDownloader(result: .success(UIImage())), cdnRequester: mock)
         let originalURL = URL(string: "https://example.com/file.pdf")!
 
         let expectation = expectation(description: "Completion called")
@@ -163,7 +163,7 @@ class MediaLoader_Tests: StreamChatTestCase {
         let headers = ["Authorization": "Bearer token123", "X-Custom": "value"]
         let mock = CDNRequester_Mock()
         mock.fileRequestResult = .success(CDNRequest(url: resolvedURL, headers: headers))
-        let mediaLoader = StreamMediaLoader(cdnRequester: mock, downloader: ConfigurableImageDownloader(result: .success(UIImage())))
+        let mediaLoader = StreamMediaLoader(downloader: ConfigurableImageDownloader(result: .success(UIImage())), cdnRequester: mock)
 
         let expectation = expectation(description: "Completion called")
         var receivedRequest: MediaLoaderFileRequest?
@@ -182,7 +182,7 @@ class MediaLoader_Tests: StreamChatTestCase {
         let expectedError = NSError(domain: "test", code: 99)
         let mock = CDNRequester_Mock()
         mock.fileRequestResult = .failure(expectedError)
-        let mediaLoader = StreamMediaLoader(cdnRequester: mock, downloader: ConfigurableImageDownloader(result: .success(UIImage())))
+        let mediaLoader = StreamMediaLoader(downloader: ConfigurableImageDownloader(result: .success(UIImage())), cdnRequester: mock)
 
         let expectation = expectation(description: "Completion called")
         var receivedError: NSError?

--- a/StreamChatSwiftUITests/Tests/Utils/MediaLoader_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/Utils/MediaLoader_Tests.swift
@@ -50,7 +50,7 @@ class MediaLoader_Tests: StreamChatTestCase {
     func test_streamMediaLoader_loadImage_callsDownloader() {
         let expectedImage = UIImage(systemName: "star.fill")!
         let downloader = ConfigurableImageDownloader(result: .success(expectedImage))
-        let mediaLoader = StreamMediaLoader(cdnRequester: cdnRequester, downloader: downloader)
+        let mediaLoader = StreamMediaLoader(downloader: downloader, cdnRequester: cdnRequester)
         let url = URL(string: "https://example.com/image.jpg")!
 
         let expectation = expectation(description: "Completion called")
@@ -67,7 +67,7 @@ class MediaLoader_Tests: StreamChatTestCase {
 
     func test_streamMediaLoader_loadImage_returnsError_whenURLNil() {
         let downloader = ConfigurableImageDownloader(result: .success(UIImage()))
-        let mediaLoader = StreamMediaLoader(cdnRequester: cdnRequester, downloader: downloader)
+        let mediaLoader = StreamMediaLoader(downloader: downloader, cdnRequester: cdnRequester)
 
         let expectation = expectation(description: "Completion called")
         var receivedError: Error?
@@ -86,7 +86,7 @@ class MediaLoader_Tests: StreamChatTestCase {
     func test_streamMediaLoader_loadImage_propagatesDownloaderError() {
         let expectedError = NSError(domain: "test", code: 42)
         let downloader = ConfigurableImageDownloader(result: .failure(expectedError))
-        let mediaLoader = StreamMediaLoader(cdnRequester: cdnRequester, downloader: downloader)
+        let mediaLoader = StreamMediaLoader(downloader: downloader, cdnRequester: cdnRequester)
         let url = URL(string: "https://example.com/fail.jpg")!
 
         let expectation = expectation(description: "Completion called")
@@ -107,7 +107,7 @@ class MediaLoader_Tests: StreamChatTestCase {
     func test_streamMediaLoader_withAttachment_whenThumbnailURLExists_loadsThumbnailImage() {
         let thumbnailImage = UIImage(systemName: "star.fill")!
         let downloader = ConfigurableImageDownloader(result: .success(thumbnailImage))
-        let mediaLoader = StreamMediaLoader(cdnRequester: cdnRequester, downloader: downloader)
+        let mediaLoader = StreamMediaLoader(downloader: downloader, cdnRequester: cdnRequester)
         let attachment = makeVideoAttachment(thumbnailURL: thumbnailURL)
 
         let expectation = expectation(description: "Completion called")
@@ -124,7 +124,7 @@ class MediaLoader_Tests: StreamChatTestCase {
 
     func test_streamMediaLoader_withAttachment_whenNoThumbnailURL_doesNotCallImageDownloader() {
         let downloader = ConfigurableImageDownloader(result: .success(UIImage()))
-        let mediaLoader = StreamMediaLoader(cdnRequester: cdnRequester, downloader: downloader)
+        let mediaLoader = StreamMediaLoader(downloader: downloader, cdnRequester: cdnRequester)
         let attachment = makeVideoAttachment(thumbnailURL: nil)
 
         let expectation = expectation(description: "Completion called")

--- a/StreamChatSwiftUITests/Tests/Utils/StreamChat_Utils_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/Utils/StreamChat_Utils_Tests.swift
@@ -39,7 +39,7 @@ class StreamChat_Utils_Tests: StreamChatTestCase {
         )
         mediaLoader.loadVideoPreview(
             with: attachment,
-            options: VideoLoadOptions(cdnRequester: CDNRequester_Mock()),
+            options: VideoLoadOptions(),
             completion: { _ in }
         )
 
@@ -54,7 +54,7 @@ class StreamChat_Utils_Tests: StreamChatTestCase {
         // When
         mediaLoader.loadImage(
             url: testURL,
-            options: ImageLoadOptions(cdnRequester: CDNRequester_Mock()),
+            options: ImageLoadOptions(),
             completion: { _ in }
         )
 
@@ -62,25 +62,36 @@ class StreamChat_Utils_Tests: StreamChatTestCase {
         XCTAssert(mediaLoader.loadImageCalled == true)
     }
 
-    func test_streamChatUtils_defaultCDNRequester() {
+    func test_streamChatUtils_defaultMediaLoader() {
         // Given
         let utils = Utils(mediaLoader: MediaLoader_Mock())
         streamChat = StreamChat(chatClient: chatClient, utils: utils)
 
         // Then
-        XCTAssert(self.utils.cdnRequester is StreamCDNRequester)
+        XCTAssert(self.utils.mediaLoader is MediaLoader_Mock)
     }
 
-    func test_streamChatUtils_injectCustomCDNRequester() {
+    func test_streamChatUtils_defaultMediaLoader_hasDefaultCDNRequester() {
         // Given
-        let customRequester = CDNRequester_Mock()
-        let utils = Utils(
-            cdnRequester: customRequester,
-            mediaLoader: MediaLoader_Mock()
-        )
+        let utils = Utils()
         streamChat = StreamChat(chatClient: chatClient, utils: utils)
 
         // Then
-        XCTAssert(self.utils.cdnRequester is CDNRequester_Mock)
+        let loader = self.utils.mediaLoader as? StreamMediaLoader
+        XCTAssertNotNil(loader)
+        XCTAssert(loader?.cdnRequester is StreamCDNRequester)
+    }
+
+    func test_streamChatUtils_customCDNRequester_throughMediaLoader() {
+        // Given
+        let customRequester = CDNRequester_Mock()
+        let customLoader = StreamMediaLoader(cdnRequester: customRequester, downloader: StreamImageDownloader())
+        let utils = Utils(mediaLoader: customLoader)
+        streamChat = StreamChat(chatClient: chatClient, utils: utils)
+
+        // Then
+        let loader = self.utils.mediaLoader as? StreamMediaLoader
+        XCTAssertNotNil(loader)
+        XCTAssert(loader?.cdnRequester is CDNRequester_Mock)
     }
 }

--- a/StreamChatSwiftUITests/Tests/Utils/StreamChat_Utils_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/Utils/StreamChat_Utils_Tests.swift
@@ -85,7 +85,7 @@ class StreamChat_Utils_Tests: StreamChatTestCase {
     func test_streamChatUtils_customCDNRequester_throughMediaLoader() {
         // Given
         let customRequester = CDNRequester_Mock()
-        let customLoader = StreamMediaLoader(cdnRequester: customRequester, downloader: StreamImageDownloader())
+        let customLoader = StreamMediaLoader(downloader: StreamImageDownloader(), cdnRequester: customRequester)
         let utils = Utils(mediaLoader: customLoader)
         streamChat = StreamChat(chatClient: chatClient, utils: utils)
 


### PR DESCRIPTION
### 🔗 Issue Links

Depends on: https://github.com/GetStream/stream-chat-swift/pull/4070

### 🎯 Goal

Align the SwiftUI SDK with the LLC's refactored media loading architecture where `CDNRequester` is a constructor dependency of `StreamMediaLoader`. This consolidates all image loading in `StreamAsyncImage` through `MediaLoader` and removes the parallel `NukeImageLoader` pipeline.

### 📝 Summary

- Removed `cdnRequester` from `Utils` — `MediaLoader` is now the single injection point for all media/CDN operations
- Consolidated `StreamAsyncImage` to load images through `mediaLoader.loadImage()` directly, eliminating the parallel `NukeImageLoader` image loading path
- Reduced `NukeImageLoader` to a minimal synchronous cache lookup helper (`cachedResult` and `storeCachingKey` only)
- Replaced direct `cdnRequester.fileRequest(...)` calls with `mediaLoader.loadFile(at:options:)` in `FileAttachmentView` and `FileAttachmentPreview`
- Removed `cdnRequester` from all `ImageLoadOptions` and `VideoLoadOptions` usages
- Updated `StreamImageDownloader` to populate `isAnimated` and `animatedImageData` from Nuke's response
- Updated all tests and mocks to reflect the new API

### 🛠 Implementation

**`StreamAsyncImage` consolidation**: Previously, `StreamAsyncImage` loaded images through `NukeImageLoader` (which called Nuke directly with CDN-resolved URLs), while other components used `MediaLoader`. Now all paths go through `mediaLoader.loadImage()`. The enriched `MediaLoaderImage` result carries `isAnimated`, `animatedImageData`, and `cachingKey`, which enables:
- Animated GIF support without needing direct Nuke access
- Synchronous cache lookups via `NukeImageLoader.cachedResult(url:resize:)` using the stored `cachingKey`, ensuring instant rendering for cached images during scrolling

**`NukeImageLoader` reduction**: With image loading consolidated into `MediaLoader`, `NukeImageLoader` no longer needs its `loadImage` method. It now only provides:
- `cachedResult(url:resize:)` — synchronous Nuke cache lookup for instant scroll performance
- `storeCachingKey(_:url:resize:)` — maps URL+resize to Nuke's internal cache key after a successful load

**File loading**: `FileAttachmentView` and `FileAttachmentPreview` now call `mediaLoader.loadFile(at:options:)` instead of accessing `cdnRequester` directly. This returns a `MediaLoaderFile` with the resolved URL and headers.

> **Note**: This is a breaking change. The `cdnRequester` property has been removed from `Utils`. Customers who were providing a custom `CDNRequester` should now pass it when constructing `StreamMediaLoader` and inject that into `Utils`.

### 🎨 Showcase

_No visual changes._

### 🧪 Manual Testing Notes

1. Verify images load correctly in channel list (avatars), message list (image attachments, link previews), and gallery
2. Verify video previews render in message list and composer
3. Verify file attachment downloads and previews work
4. Verify animated GIFs render correctly
5. Verify scrolling performance — cached images should appear instantly without flicker

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [x] Documentation has been updated in the `docs-content` repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated CDN responsibilities into a unified media loader for images, video, and files.
  * Web content and file downloads now use request-based loading instead of raw URLs.

* **Behavior**
  * Image loading preserves GIF animation data for correct animated rendering.
  * Async image caching flow simplified to store caching keys after successful loads.

* **Tests**
  * Updated tests and mocks to validate media loader integrations.

* **Dependencies**
  * Switched the Stream Chat Swift package to branch-based resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->