### PR TITLE
Fix show/hide message translation animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### 🐞 Fixed
+- Fix show/hide message translation animation [#1426](https://github.com/GetStream/stream-chat-swiftui/pull/1426)
 
 # [5.0.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/5.0.0)
 _April 16, 2026_

--- a/Sources/StreamChatSwiftUI/ChatMessageList/MessageTopView.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/MessageTopView.swift
@@ -77,14 +77,18 @@ struct MessageTopView: View {
                 title: messageViewModel.originalTextShown ? nil : L10n.Message.Annotation.translated,
                 buttonTitle: messageViewModel.originalTextShown ? L10n.Message.showTranslation : L10n.Message.showOriginal,
                 buttonAction: {
-                    if messageViewModel.originalTextShown {
-                        messageViewModel.hideOriginalText()
-                    } else {
-                        messageViewModel.showOriginalText()
+                    withAnimation(.easeInOut(duration: 0.25)) {
+                        if messageViewModel.originalTextShown {
+                            messageViewModel.hideOriginalText()
+                        } else {
+                            messageViewModel.showOriginalText()
+                        }
                     }
                 },
                 usesInvertedStyle: usesInvertedStyle
             )
+            .id(messageViewModel.originalTextShown)
+            .transition(.opacity)
         } else {
             MessageAnnotationView(
                 icon: images.annotationTranslation,


### PR DESCRIPTION
### 🔗 Issue Links

Fixes [IOS-1636](https://linear.app/stream/issue/IOS-1636/swiftui-showhide-original-message-text-animation-looks-off)

### 🎯 Goal

Fix show/hide message translation animation

### 📝 Summary

- Animate the row as a whole

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

| Before | After |
| ------ | ----- |
|  <img src="https://github.com/user-attachments/assets/1b500628-07b6-4e96-a345-421905479afa" style="max-height:500px">   |  <img src="https://github.com/user-attachments/assets/3039b6db-7828-4c08-9dcb-d7b8fb0527b2" style="max-height:500px"> |
|  <img src="https://github.com/user-attachments/assets/388abedb-3184-4602-af7a-d301314bad9e" style="max-height:500px">   |  <img src="https://github.com/user-attachments/assets/9be13827-0bc2-491c-924a-a3262d0c30a7" style="max-height:500px">  |

### 🧪 Manual Testing Notes

1. Log out, use configuration to set language
2. Log in
3. Find a message from a participant

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
