### PR TITLE
Debounce SwiftUI Demo app user search to match UIKit demo app

### DIFF
--- a/DemoAppSwiftUI/ChannelHeader/NewChatViewModel.swift
+++ b/DemoAppSwiftUI/ChannelHeader/NewChatViewModel.swift
@@ -2,6 +2,7 @@
 // Copyright © 2026 Stream.io Inc. All rights reserved.
 //
 
+import Dispatch
 import StreamChat
 import StreamChatCommonUI
 import StreamChatSwiftUI
@@ -12,7 +13,7 @@ import SwiftUI
 
     @Published var searchText: String = "" {
         didSet {
-            searchUsers(with: searchText)
+            scheduleDebouncedUserSearch()
         }
     }
 
@@ -49,11 +50,16 @@ import SwiftUI
     private lazy var searchController: ChatUserSearchController = chatClient.userSearchController()
     private let lastSeenDateFormatter = DateUtils.timeAgo
 
+    /// Matches UIKit demo `CreateChatViewController.throttleTime` / `CreateGroupViewController.throttleTime`.
+    private let userSearchDebounceMilliseconds = 1000
+    private var userSearchDebounceWorkItem: DispatchWorkItem?
+    private var userSearchRequestGeneration: UInt64 = 0
+
     init() {
         chatUsers = searchController.userArray
         searchController.delegate = self
-        // Empty initial search to get all users
-        searchUsers(with: nil)
+        // Empty initial search to get all users (immediate — not debounced; same as UIKit `viewDidLoad`)
+        performUserSearch(term: nil)
     }
 
     func userTapped(_ user: ChatUser) {
@@ -117,13 +123,31 @@ import SwiftUI
 
     // MARK: - private
 
-    private func searchUsers(with term: String?) {
+    private func scheduleDebouncedUserSearch() {
+        state = .loading
+        userSearchDebounceWorkItem?.cancel()
+        let query = searchText
+        let work = DispatchWorkItem { [weak self] in
+            self?.performUserSearch(term: query.isEmpty ? nil : query)
+        }
+        userSearchDebounceWorkItem = work
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + .milliseconds(userSearchDebounceMilliseconds),
+            execute: work
+        )
+    }
+
+    private func performUserSearch(term: String?) {
+        userSearchRequestGeneration += 1
+        let generation = userSearchRequestGeneration
         state = .loading
         searchController.search(term: term) { [weak self] error in
+            guard let self else { return }
+            guard generation == self.userSearchRequestGeneration else { return }
             if error != nil {
-                self?.state = .error
+                self.state = .error
             } else {
-                self?.state = .loaded
+                self.state = self.chatUsers.isEmpty ? .noUsers : .loaded
             }
         }
     }

--- a/DemoAppSwiftUI/ChannelHeader/NewChatViewModel.swift
+++ b/DemoAppSwiftUI/ChannelHeader/NewChatViewModel.swift
@@ -55,6 +55,19 @@ import SwiftUI
     private var userSearchDebounceWorkItem: DispatchWorkItem?
     private var userSearchRequestGeneration: UInt64 = 0
 
+    private struct ActiveUserSearch: Equatable {
+        var apiTerm: String?
+    }
+
+    /// Last user-list query that finished successfully (`apiTerm == nil` is “all users”).
+    private enum UserListFetchCursor: Equatable {
+        case notYetFetched
+        case fetched(apiTerm: String?)
+    }
+
+    private var activeUserSearch: ActiveUserSearch?
+    private var userListFetchCursor: UserListFetchCursor = .notYetFetched
+
     init() {
         chatUsers = searchController.userArray
         searchController.delegate = self
@@ -124,6 +137,16 @@ import SwiftUI
     // MARK: - private
 
     private func scheduleDebouncedUserSearch() {
+        let nextTerm = normalizedUserSearchTerm(searchText)
+        if let active = activeUserSearch, matchesUserSearchTerm(active.apiTerm, nextTerm) {
+            return
+        }
+        if case let .fetched(prev) = userListFetchCursor,
+           matchesUserSearchTerm(prev, nextTerm),
+           state != .error {
+            return
+        }
+
         state = .loading
         userSearchDebounceWorkItem?.cancel()
         let query = searchText
@@ -138,17 +161,35 @@ import SwiftUI
     }
 
     private func performUserSearch(term: String?) {
+        if let active = activeUserSearch, matchesUserSearchTerm(active.apiTerm, term) {
+            return
+        }
+        activeUserSearch = ActiveUserSearch(apiTerm: term)
         userSearchRequestGeneration += 1
         let generation = userSearchRequestGeneration
         state = .loading
         searchController.search(term: term) { [weak self] error in
             guard let self else { return }
             guard generation == self.userSearchRequestGeneration else { return }
+            self.activeUserSearch = nil
             if error != nil {
                 self.state = .error
             } else {
+                self.userListFetchCursor = .fetched(apiTerm: term)
                 self.state = self.chatUsers.isEmpty ? .noUsers : .loaded
             }
+        }
+    }
+
+    private func normalizedUserSearchTerm(_ text: String) -> String? {
+        text.isEmpty ? nil : text
+    }
+
+    private func matchesUserSearchTerm(_ lhs: String?, _ rhs: String?) -> Bool {
+        switch (lhs, rhs) {
+        case (nil, nil): true
+        case let (l?, r?): l == r
+        default: false
         }
     }
 

--- a/DemoAppSwiftUI/CreateGroupViewModel.swift
+++ b/DemoAppSwiftUI/CreateGroupViewModel.swift
@@ -2,6 +2,7 @@
 // Copyright © 2026 Stream.io Inc. All rights reserved.
 //
 
+import Dispatch
 import StreamChat
 import StreamChatCommonUI
 import StreamChatSwiftUI
@@ -14,7 +15,7 @@ import SwiftUI
 
     @Published var searchText = "" {
         didSet {
-            searchUsers(with: searchText)
+            scheduleDebouncedUserSearch()
         }
     }
 
@@ -28,11 +29,16 @@ import SwiftUI
     private lazy var searchController: ChatUserSearchController = chatClient.userSearchController()
     private let lastSeenDateFormatter = DateUtils.timeAgo
 
+    /// Matches UIKit demo `CreateGroupViewController.throttleTime`.
+    private let userSearchDebounceMilliseconds = 1000
+    private var userSearchDebounceWorkItem: DispatchWorkItem?
+    private var userSearchRequestGeneration: UInt64 = 0
+
     init() {
         chatUsers = searchController.userArray
         searchController.delegate = self
-        // Empty initial search to get all users
-        searchUsers(with: nil)
+        // Empty initial search to get all users (immediate — not debounced)
+        performUserSearch(term: nil)
     }
 
     var canCreateGroup: Bool {
@@ -98,13 +104,31 @@ import SwiftUI
 
     // MARK: - private
 
-    private func searchUsers(with term: String?) {
+    private func scheduleDebouncedUserSearch() {
+        state = .loading
+        userSearchDebounceWorkItem?.cancel()
+        let query = searchText
+        let work = DispatchWorkItem { [weak self] in
+            self?.performUserSearch(term: query.isEmpty ? nil : query)
+        }
+        userSearchDebounceWorkItem = work
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + .milliseconds(userSearchDebounceMilliseconds),
+            execute: work
+        )
+    }
+
+    private func performUserSearch(term: String?) {
+        userSearchRequestGeneration += 1
+        let generation = userSearchRequestGeneration
         state = .loading
         searchController.search(term: term) { [weak self] error in
+            guard let self else { return }
+            guard generation == self.userSearchRequestGeneration else { return }
             if error != nil {
-                self?.state = .error
+                self.state = .error
             } else {
-                self?.state = .loaded
+                self.state = self.chatUsers.isEmpty ? .noUsers : .loaded
             }
         }
     }

--- a/DemoAppSwiftUI/CreateGroupViewModel.swift
+++ b/DemoAppSwiftUI/CreateGroupViewModel.swift
@@ -34,6 +34,18 @@ import SwiftUI
     private var userSearchDebounceWorkItem: DispatchWorkItem?
     private var userSearchRequestGeneration: UInt64 = 0
 
+    private struct ActiveUserSearch: Equatable {
+        var apiTerm: String?
+    }
+
+    private enum UserListFetchCursor: Equatable {
+        case notYetFetched
+        case fetched(apiTerm: String?)
+    }
+
+    private var activeUserSearch: ActiveUserSearch?
+    private var userListFetchCursor: UserListFetchCursor = .notYetFetched
+
     init() {
         chatUsers = searchController.userArray
         searchController.delegate = self
@@ -105,6 +117,16 @@ import SwiftUI
     // MARK: - private
 
     private func scheduleDebouncedUserSearch() {
+        let nextTerm = normalizedUserSearchTerm(searchText)
+        if let active = activeUserSearch, matchesUserSearchTerm(active.apiTerm, nextTerm) {
+            return
+        }
+        if case let .fetched(prev) = userListFetchCursor,
+           matchesUserSearchTerm(prev, nextTerm),
+           state != .error {
+            return
+        }
+
         state = .loading
         userSearchDebounceWorkItem?.cancel()
         let query = searchText
@@ -119,17 +141,35 @@ import SwiftUI
     }
 
     private func performUserSearch(term: String?) {
+        if let active = activeUserSearch, matchesUserSearchTerm(active.apiTerm, term) {
+            return
+        }
+        activeUserSearch = ActiveUserSearch(apiTerm: term)
         userSearchRequestGeneration += 1
         let generation = userSearchRequestGeneration
         state = .loading
         searchController.search(term: term) { [weak self] error in
             guard let self else { return }
             guard generation == self.userSearchRequestGeneration else { return }
+            self.activeUserSearch = nil
             if error != nil {
                 self.state = .error
             } else {
+                self.userListFetchCursor = .fetched(apiTerm: term)
                 self.state = self.chatUsers.isEmpty ? .noUsers : .loaded
             }
+        }
+    }
+
+    private func normalizedUserSearchTerm(_ text: String) -> String? {
+        text.isEmpty ? nil : text
+    }
+
+    private func matchesUserSearchTerm(_ lhs: String?, _ rhs: String?) -> Bool {
+        switch (lhs, rhs) {
+        case (nil, nil): true
+        case let (l?, r?): l == r
+        default: false
         }
     }
 }


### PR DESCRIPTION
### 🔗 Issue Links

Resolve https://linear.app/stream/issue/IOS-1262

### 🎯 Goal

Stop intermittent **“Error loading the users”** in the SwiftUI demo when searching for people to chat with / add to a group. Behavior should match the UIKit demo’s search pattern.

### 📝 Summary

- Debounce user search in **`NewChatViewModel`** and **`CreateGroupViewModel`** with **1000 ms** delay, matching **`CreateChatViewController`** / **`CreateGroupViewController`** in stream-chat-swift.
- Keep the **initial** `search(term: nil)` **immediate** on screen load (same as UIKit `viewDidLoad`).
- Add a **request generation** guard so completions from superseded searches don’t flip UI state.
- **`NewChatViewModel`**: after a successful fetch, use **`.noUsers`** when the result list is empty (aligned with UIKit empty state).

### 🛠 Implementation

SwiftUI was calling `ChatUserSearchController.search(term:)` on **every keystroke** via `searchText`’s `didSet`, while the UIKit demo batches changes with `DispatchWorkItem` and `asyncAfter(..., 1 second)`. That difference likely overloaded the backend (including repeated work for the default user-list query, which sorts by name in the SDK’s `UserListQuery.search(term:)`).

### 🧪 Manual Testing Notes

1. Run **DemoAppSwiftUI**, open **New Chat**.
2. Type quickly in the user search field: expect **spinner**, then results after ~1 s idle; no steady **“Error loading the users”** under normal backend load.
3. Open **Create a group** → **Add group members**, repeat search typing.
4. Confirm first load still shows users without an extra 1 s wait before the first request.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made user search in New Chat and Create Group more reliable by preventing stale results from replacing newer ones.
  * Added debounce to searches to reduce unnecessary requests and improve responsiveness while typing.
  * Improved loading and empty/error states so search feedback and initial user list behave more predictably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->