### PR TITLE
Fix swipe-to-reply gesture conflicting with message list scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `CDNRequester` is now passed in the constructor of `StreamMediaLoader` instead of `Utils` [#1425](https://github.com/GetStream/stream-chat-swiftui/pull/1425)
 
 ### 🐞 Fixed
+- Fix swipe-to-reply gesture conflicting with message list scrolling [#1431](https://github.com/GetStream/stream-chat-swiftui/pull/1431)
 - Fix SDK not compiling with Xcode 16 [#1430](https://github.com/GetStream/stream-chat-swiftui/pull/1430)
 - Fix show/hide message translation animation [#1426](https://github.com/GetStream/stream-chat-swiftui/pull/1426)
 - Fix tapping a media attachment in the reactions overlay opening the fullscreen gallery [#1424](https://github.com/GetStream/stream-chat-swiftui/pull/1424)

--- a/Sources/StreamChatSwiftUI/ChatMessageList/MessageItemView.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/MessageItemView.swift
@@ -257,9 +257,15 @@ struct SwipeToReplyModifier: ViewModifier {
 
     @State private var offsetX: CGFloat
     @State private var swipeExcludedFrames: [CGRect] = []
-    @GestureState private var offset: CGSize = .zero
 
     private let replyThreshold: CGFloat = 60
+
+    /// How much larger the horizontal drag component must be than the
+    /// vertical component before the drag is recognised as a swipe-to-reply.
+    /// Values > 1 bias ambiguous/diagonal drags toward the enclosing
+    /// scroll view, so the list keeps scrolling unless the user's motion is
+    /// clearly horizontal.
+    private let horizontalDominanceRatio: CGFloat = 2
 
     init(
         message: ChatMessage,
@@ -285,13 +291,19 @@ struct SwipeToReplyModifier: ViewModifier {
         content
             .coordinateSpace(name: "swipeToReply")
             .offset(x: min(offsetX, maximumHorizontalSwipeDisplacement))
-            .gesture(
+            // `.simultaneousGesture` so the enclosing `ScrollView`'s pan
+            // recognizer always keeps running alongside. We never update
+            // `offsetX` unless the motion is clearly horizontal, so vertical
+            // and ambiguous/diagonal drags are effectively no-ops here and
+            // the list keeps scrolling cleanly.
+            .simultaneousGesture(
                 DragGesture(
                     minimumDistance: minimumSwipeDistance,
                     coordinateSpace: .named("swipeToReply")
                 )
-                .updating($offset) { (value, gestureState, _) in
-                    guard isSwipeToQuoteReplyPossible else {
+                .onChanged { value in
+                    guard isSwipeToQuoteReplyPossible,
+                          channel.config.quotesEnabled else {
                         return
                     }
 
@@ -299,29 +311,23 @@ struct SwipeToReplyModifier: ViewModifier {
                         return
                     }
 
-                    let diff = CGSize(
-                        width: value.location.x - value.startLocation.x,
-                        height: value.location.y - value.startLocation.y
-                    )
+                    // Re-evaluate direction on every event instead of
+                    // locking it once, so stale state can never survive
+                    // across gestures and block scrolling on a fresh drag.
+                    // Require horizontal motion to dominate vertical motion
+                    // by `horizontalDominanceRatio` before we move the
+                    // bubble; otherwise stay put and let the scroll view
+                    // handle the pan.
+                    let dx = abs(value.translation.width)
+                    let dy = abs(value.translation.height)
+                    guard dx > dy * horizontalDominanceRatio else { return }
 
-                    if diff == .zero {
-                        gestureState = .zero
-                    } else {
-                        gestureState = value.translation
-                    }
+                    dragChanged(to: value.translation.width)
+                }
+                .onEnded { _ in
+                    setOffsetX(value: 0)
                 }
             )
-            .onChange(of: offset, perform: { _ in
-                if !channel.config.quotesEnabled {
-                    return
-                }
-
-                if offset == .zero {
-                    setOffsetX(value: 0)
-                } else {
-                    dragChanged(to: offset.width)
-                }
-            })
             .onPreferenceChange(SwipeToReplyExcludedFrameKey.self) { frames in
                 swipeExcludedFrames = frames
             }

--- a/Sources/StreamChatSwiftUI/ChatMessageList/MessageItemView.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/MessageItemView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 public struct MessageItemView<Factory: ViewFactory>: View {
     @StateObject var messageViewModel: MessageViewModel
     @Environment(\.highlightedMessageId) var highlightedMessageId
-    @Environment(\.messageListIsScrolling) private var messageListIsScrolling
 
     @Injected(\.colors) private var colors
     @Injected(\.utils) private var utils
@@ -113,8 +112,7 @@ public struct MessageItemView<Factory: ViewFactory>: View {
                     isDoubleTapEnabled: messageViewModel.isDoubleTapOverlayEnabled,
                     onActionsTriggered: { handleGestureForMessage(showsMessageActions: true) }
                 ))
-                .modifier(ConditionalSwipeToReplyModifier(
-                    isEnabled: !messageListIsScrolling,
+                .modifier(SwipeToReplyModifier(
                     message: message,
                     channel: channel,
                     isSwipeToQuoteReplyPossible: !shownAsPreview && messageViewModel.isSwipeToQuoteReplyPossible,
@@ -359,47 +357,16 @@ struct SwipeToReplyModifier: ViewModifier {
     }
 }
 
-struct ConditionalSwipeToReplyModifier: ViewModifier {
-    let isEnabled: Bool
-    let message: ChatMessage
-    let channel: ChatChannel
-    let isSwipeToQuoteReplyPossible: Bool
-    @Binding var quotedMessage: ChatMessage?
-
-    @ViewBuilder
-    func body(content: Content) -> some View {
-        if isEnabled {
-            content.modifier(SwipeToReplyModifier(
-                message: message,
-                channel: channel,
-                isSwipeToQuoteReplyPossible: isSwipeToQuoteReplyPossible,
-                quotedMessage: $quotedMessage
-            ))
-        } else {
-            content
-        }
-    }
-}
-
 // MARK: - Environment
 
 private struct HighlightedMessageIdKey: EnvironmentKey {
     static let defaultValue: String? = nil
 }
 
-private struct MessageListIsScrollingKey: EnvironmentKey {
-    static let defaultValue = false
-}
-
 extension EnvironmentValues {
     var highlightedMessageId: String? {
         get { self[HighlightedMessageIdKey.self] }
         set { self[HighlightedMessageIdKey.self] = newValue }
-    }
-
-    var messageListIsScrolling: Bool {
-        get { self[MessageListIsScrollingKey.self] }
-        set { self[MessageListIsScrollingKey.self] = newValue }
     }
 }
 

--- a/Sources/StreamChatSwiftUI/ChatMessageList/MessageItemView.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/MessageItemView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 public struct MessageItemView<Factory: ViewFactory>: View {
     @StateObject var messageViewModel: MessageViewModel
     @Environment(\.highlightedMessageId) var highlightedMessageId
+    @Environment(\.messageListIsScrolling) private var messageListIsScrolling
 
     @Injected(\.colors) private var colors
     @Injected(\.utils) private var utils
@@ -112,7 +113,8 @@ public struct MessageItemView<Factory: ViewFactory>: View {
                     isDoubleTapEnabled: messageViewModel.isDoubleTapOverlayEnabled,
                     onActionsTriggered: { handleGestureForMessage(showsMessageActions: true) }
                 ))
-                .modifier(SwipeToReplyModifier(
+                .modifier(ConditionalSwipeToReplyModifier(
+                    isEnabled: !messageListIsScrolling,
                     message: message,
                     channel: channel,
                     isSwipeToQuoteReplyPossible: !shownAsPreview && messageViewModel.isSwipeToQuoteReplyPossible,
@@ -357,16 +359,47 @@ struct SwipeToReplyModifier: ViewModifier {
     }
 }
 
+struct ConditionalSwipeToReplyModifier: ViewModifier {
+    let isEnabled: Bool
+    let message: ChatMessage
+    let channel: ChatChannel
+    let isSwipeToQuoteReplyPossible: Bool
+    @Binding var quotedMessage: ChatMessage?
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if isEnabled {
+            content.modifier(SwipeToReplyModifier(
+                message: message,
+                channel: channel,
+                isSwipeToQuoteReplyPossible: isSwipeToQuoteReplyPossible,
+                quotedMessage: $quotedMessage
+            ))
+        } else {
+            content
+        }
+    }
+}
+
 // MARK: - Environment
 
 private struct HighlightedMessageIdKey: EnvironmentKey {
     static let defaultValue: String? = nil
 }
 
+private struct MessageListIsScrollingKey: EnvironmentKey {
+    static let defaultValue = false
+}
+
 extension EnvironmentValues {
     var highlightedMessageId: String? {
         get { self[HighlightedMessageIdKey.self] }
         set { self[HighlightedMessageIdKey.self] = newValue }
+    }
+
+    var messageListIsScrolling: Bool {
+        get { self[MessageListIsScrollingKey.self] }
+        set { self[MessageListIsScrollingKey.self] = newValue }
     }
 }
 

--- a/Sources/StreamChatSwiftUI/ChatMessageList/MessageItemView.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/MessageItemView.swift
@@ -260,13 +260,6 @@ struct SwipeToReplyModifier: ViewModifier {
 
     private let replyThreshold: CGFloat = 60
 
-    /// How much larger the horizontal drag component must be than the
-    /// vertical component before the drag is recognised as a swipe-to-reply.
-    /// Values > 1 bias ambiguous/diagonal drags toward the enclosing
-    /// scroll view, so the list keeps scrolling unless the user's motion is
-    /// clearly horizontal.
-    private let horizontalDominanceRatio: CGFloat = 2
-
     init(
         message: ChatMessage,
         channel: ChatChannel,
@@ -291,11 +284,6 @@ struct SwipeToReplyModifier: ViewModifier {
         content
             .coordinateSpace(name: "swipeToReply")
             .offset(x: min(offsetX, maximumHorizontalSwipeDisplacement))
-            // `.simultaneousGesture` so the enclosing `ScrollView`'s pan
-            // recognizer always keeps running alongside. We never update
-            // `offsetX` unless the motion is clearly horizontal, so vertical
-            // and ambiguous/diagonal drags are effectively no-ops here and
-            // the list keeps scrolling cleanly.
             .simultaneousGesture(
                 DragGesture(
                     minimumDistance: minimumSwipeDistance,
@@ -310,17 +298,6 @@ struct SwipeToReplyModifier: ViewModifier {
                     if swipeExcludedFrames.contains(where: { $0.contains(value.startLocation) }) {
                         return
                     }
-
-                    // Re-evaluate direction on every event instead of
-                    // locking it once, so stale state can never survive
-                    // across gestures and block scrolling on a fresh drag.
-                    // Require horizontal motion to dominate vertical motion
-                    // by `horizontalDominanceRatio` before we move the
-                    // bubble; otherwise stay put and let the scroll view
-                    // handle the pan.
-                    let dx = abs(value.translation.width)
-                    let dy = abs(value.translation.height)
-                    guard dx > dy * horizontalDominanceRatio else { return }
 
                     dragChanged(to: value.translation.width)
                 }

--- a/Sources/StreamChatSwiftUI/ChatMessageList/MessageListConfig.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/MessageListConfig.swift
@@ -203,7 +203,7 @@ public final class MessageDisplayOptions {
         overlayDateLabelSize: CGFloat = 40,
         lastInGroupHeaderSize: CGFloat = 0,
         newMessagesSeparatorSize: CGFloat = 50,
-        minimumSwipeGestureDistance: CGFloat = 30,
+        minimumSwipeGestureDistance: CGFloat = 20,
         currentUserMessageTransition: AnyTransition = .identity,
         otherUserMessageTransition: AnyTransition = .identity,
         shouldAnimateReactions: Bool = true,

--- a/Sources/StreamChatSwiftUI/ChatMessageList/MessageListConfig.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/MessageListConfig.swift
@@ -203,7 +203,7 @@ public final class MessageDisplayOptions {
         overlayDateLabelSize: CGFloat = 40,
         lastInGroupHeaderSize: CGFloat = 0,
         newMessagesSeparatorSize: CGFloat = 50,
-        minimumSwipeGestureDistance: CGFloat = 20,
+        minimumSwipeGestureDistance: CGFloat = 30,
         currentUserMessageTransition: AnyTransition = .identity,
         otherUserMessageTransition: AnyTransition = .identity,
         shouldAnimateReactions: Bool = true,

--- a/Sources/StreamChatSwiftUI/ChatMessageList/MessageListView.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/MessageListView.swift
@@ -36,7 +36,6 @@ public struct MessageListView<Factory: ViewFactory>: View, KeyboardReadable {
     @State private var keyboardShown = false
     @State private var pendingKeyboardUpdate: Bool?
     @State private var scrollDirection = ScrollDirection.up
-    @State private var isScrolling = false
     @State private var unreadMessagesBannerShown = false
     @State private var unreadButtonDismissed = false
 
@@ -276,7 +275,6 @@ public struct MessageListView<Factory: ViewFactory>: View, KeyboardReadable {
                         .id(listId)
                     }
                     .delayedRendering()
-                    .environment(\.messageListIsScrolling, isScrolling)
                     .modifier(factory.styles.makeMessageListModifier(options: MessageListModifierOptions()))
                     .modifier(ScrollTargetLayoutModifier(enabled: loadingNextMessages))
                     .overlay(
@@ -291,7 +289,6 @@ public struct MessageListView<Factory: ViewFactory>: View, KeyboardReadable {
                     )
                 }
                 .modifier(ScrollPositionModifier(scrollPosition: loadingNextMessages ? $scrollPosition : .constant(nil)))
-                .modifier(ScrollPhaseTrackingModifier(isScrolling: $isScrolling))
                 .background(
                     factory.makeMessageListBackground(
                         options: MessageListBackgroundOptions(
@@ -519,31 +516,6 @@ struct ScrollPositionModifier: ViewModifier {
         if #available(iOS 17, *) {
             content
                 .scrollPosition(id: $scrollPosition, anchor: .top)
-        } else {
-            content
-        }
-        #else
-        content
-        #endif
-    }
-}
-
-struct ScrollPhaseTrackingModifier: ViewModifier {
-    @Binding var isScrolling: Bool
-
-    func body(content: Content) -> some View {
-        #if swift(>=5.9)
-        if #available(iOS 18, *) {
-            content
-                .onScrollPhaseChange { _, newPhase in
-                    let isCurrentlyScrolling = newPhase.isScrolling
-                    if isScrolling != isCurrentlyScrolling {
-                        isScrolling = isCurrentlyScrolling
-                    }
-                }
-                .onDisappear {
-                    isScrolling = false
-                }
         } else {
             content
         }

--- a/Sources/StreamChatSwiftUI/ChatMessageList/MessageListView.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/MessageListView.swift
@@ -36,6 +36,7 @@ public struct MessageListView<Factory: ViewFactory>: View, KeyboardReadable {
     @State private var keyboardShown = false
     @State private var pendingKeyboardUpdate: Bool?
     @State private var scrollDirection = ScrollDirection.up
+    @State private var isScrolling = false
     @State private var unreadMessagesBannerShown = false
     @State private var unreadButtonDismissed = false
 
@@ -275,6 +276,7 @@ public struct MessageListView<Factory: ViewFactory>: View, KeyboardReadable {
                         .id(listId)
                     }
                     .delayedRendering()
+                    .environment(\.messageListIsScrolling, isScrolling)
                     .modifier(factory.styles.makeMessageListModifier(options: MessageListModifierOptions()))
                     .modifier(ScrollTargetLayoutModifier(enabled: loadingNextMessages))
                     .overlay(
@@ -289,6 +291,7 @@ public struct MessageListView<Factory: ViewFactory>: View, KeyboardReadable {
                     )
                 }
                 .modifier(ScrollPositionModifier(scrollPosition: loadingNextMessages ? $scrollPosition : .constant(nil)))
+                .modifier(ScrollPhaseTrackingModifier(isScrolling: $isScrolling))
                 .background(
                     factory.makeMessageListBackground(
                         options: MessageListBackgroundOptions(
@@ -516,6 +519,31 @@ struct ScrollPositionModifier: ViewModifier {
         if #available(iOS 17, *) {
             content
                 .scrollPosition(id: $scrollPosition, anchor: .top)
+        } else {
+            content
+        }
+        #else
+        content
+        #endif
+    }
+}
+
+struct ScrollPhaseTrackingModifier: ViewModifier {
+    @Binding var isScrolling: Bool
+
+    func body(content: Content) -> some View {
+        #if swift(>=5.9)
+        if #available(iOS 18, *) {
+            content
+                .onScrollPhaseChange { _, newPhase in
+                    let isCurrentlyScrolling = newPhase.isScrolling
+                    if isScrolling != isCurrentlyScrolling {
+                        isScrolling = isCurrentlyScrolling
+                    }
+                }
+                .onDisappear {
+                    isScrolling = false
+                }
         } else {
             content
         }


### PR DESCRIPTION
### 🔗 Issue Links

https://linear.app/stream/issue/IOS-1644/v5-qa-swipe-to-reply-overrides-message-list-scrolling

### 🎯 Goal

The swipe-to-reply gesture on a message item was competing with the message list's vertical scroll gesture: vertical or diagonal drags sometimes got recognized as a swipe-to-reply, and the list occasionally refused to scroll, particularly on iOS 18+ where `ScrollView` gesture coordination is stricter.

This PR keeps the swipe-to-reply available across the whole message item view (not just the bubble) while making sure the scroll view always wins on any non-clearly-horizontal drag.

### 📝 Summary

- Switched `SwipeToReplyModifier` from `.gesture(DragGesture(...).updating($offset))` + `onChange(of: offset)` to `.simultaneousGesture(DragGesture(...).onChanged/onEnded)`.
- Bumped the default `MessageDisplayOptions.minimumSwipeGestureDistance` from `20` to `30`.

### 🛠 Implementation

- `.simultaneousGesture` lets the swipe-to-reply drag coexist with the `ScrollView`'s internal pan recognizer instead of competing with it, so scrolling is never blocked by the swipe gesture being attached.
- Raising the minimum swipe distance to `30` gives the scroll view a larger unambiguous window at the start of a drag before the swipe-to-reply can even recognize. In practice this means small vertical or diagonal movements now resolve to scroll, and only drags that are clearly intentional horizontal gestures trigger the reply.
- Replacing `@GestureState` + `onChange(of: offset)` with direct `onChanged` / `onEnded` handlers simplifies the state flow and removes a potential source of multi-per-frame state updates.

### 🎨 Showcase

| Before | After |
| ------ | ----- |
|  n/a   |  n/a  |

### 🧪 Manual Testing Notes

- Scroll the list vertically and diagonally, both slowly and fast — scrolling should always feel responsive and never get "eaten" by the swipe gesture.
- While the list is idle, swipe a message horizontally (starting both on and outside the bubble, anywhere within the item view) — the reply indicator appears and, past the threshold, the message becomes the quoted reply.
- Verify on both iOS 18+ and earlier versions.

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed swipe-to-reply gesture conflicting with message list scrolling
  * Refined swipe gesture sensitivity for improved reliability and responsiveness

<!-- end of auto-generated comment: release notes by coderabbit.ai -->