### PR TITLE
Fix double grey checkmarks not showing for delivered messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `CDNRequester` is now passed in the constructor of `StreamMediaLoader` instead of `Utils` [#1425](https://github.com/GetStream/stream-chat-swiftui/pull/1425)
 
 ### 🐞 Fixed
-- Fix double grey checkmarks not showing for delivered messages in the message list
+- Fix double grey checkmarks not showing for delivered messages in the message list [#1432](https://github.com/GetStream/stream-chat-swiftui/pull/1432)
 - Fix SDK not compiling with Xcode 16 [#1430](https://github.com/GetStream/stream-chat-swiftui/pull/1430)
 - Fix show/hide message translation animation [#1426](https://github.com/GetStream/stream-chat-swiftui/pull/1426)
 - Fix tapping a media attachment in the reactions overlay opening the fullscreen gallery [#1424](https://github.com/GetStream/stream-chat-swiftui/pull/1424)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `CDNRequester` is now passed in the constructor of `StreamMediaLoader` instead of `Utils` [#1425](https://github.com/GetStream/stream-chat-swiftui/pull/1425)
 
 ### 🐞 Fixed
+- Fix double grey checkmarks not showing for delivered messages in the message list
 - Fix SDK not compiling with Xcode 16 [#1430](https://github.com/GetStream/stream-chat-swiftui/pull/1430)
 - Fix show/hide message translation animation [#1426](https://github.com/GetStream/stream-chat-swiftui/pull/1426)
 - Fix tapping a media attachment in the reactions overlay opening the fullscreen gallery [#1424](https://github.com/GetStream/stream-chat-swiftui/pull/1424)

--- a/Sources/StreamChatSwiftUI/ViewFactory/DefaultViewFactory.swift
+++ b/Sources/StreamChatSwiftUI/ViewFactory/DefaultViewFactory.swift
@@ -898,8 +898,10 @@ extension ViewFactory {
             currentUserId: chatClient.currentUserId,
             message: options.message
         )
+        let showDelivered = options.message.deliveryStatus(for: options.channel) == .delivered
         return MessageReadIndicatorView(
             readUsers: readUsers,
+            showDelivered: showDelivered,
             localState: options.message.localState,
             usesInvertedStyle: options.usesInvertedStyle
         )

--- a/StreamChatSwiftUITests/Tests/Utils/ViewFactory_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/Utils/ViewFactory_Tests.swift
@@ -549,6 +549,68 @@ import XCTest
         XCTAssert(view is MessageReadIndicatorView)
     }
 
+    func test_viewFactory_makeMessageReadIndicatorView_whenMessageDelivered_showsDelivered() throws {
+        // Given
+        let viewFactory = DefaultViewFactory.shared
+        let date = Date(timeIntervalSince1970: 100)
+        let message = ChatMessage.mock(
+            id: .unique,
+            cid: .unique,
+            text: "Test",
+            author: .mock(id: Self.currentUserId),
+            createdAt: date.addingTimeInterval(-100),
+            localState: nil,
+            isSentByCurrentUser: true
+        )
+        let channel = ChatChannel.mock(
+            cid: .unique,
+            reads: [
+                .mock(
+                    lastReadAt: .distantPast,
+                    lastReadMessageId: nil,
+                    unreadMessagesCount: 0,
+                    user: .mock(id: .unique),
+                    lastDeliveredAt: date,
+                    lastDeliveredMessageId: message.id
+                )
+            ]
+        )
+
+        // When
+        let view = viewFactory.makeMessageReadIndicatorView(
+            options: MessageReadIndicatorViewOptions(channel: channel, message: message)
+        )
+
+        // Then
+        let indicator = try XCTUnwrap(view as? MessageReadIndicatorView)
+        XCTAssertTrue(indicator.showDelivered)
+        XCTAssertTrue(indicator.readUsers.isEmpty)
+    }
+
+    func test_viewFactory_makeMessageReadIndicatorView_whenMessageNotDelivered_doesNotShowDelivered() throws {
+        // Given
+        let viewFactory = DefaultViewFactory.shared
+        let message = ChatMessage.mock(
+            id: .unique,
+            cid: .unique,
+            text: "Test",
+            author: .mock(id: Self.currentUserId),
+            createdAt: Date(timeIntervalSince1970: 100),
+            localState: nil,
+            isSentByCurrentUser: true
+        )
+        let channel = ChatChannel.mock(cid: .unique)
+
+        // When
+        let view = viewFactory.makeMessageReadIndicatorView(
+            options: MessageReadIndicatorViewOptions(channel: channel, message: message)
+        )
+
+        // Then
+        let indicator = try XCTUnwrap(view as? MessageReadIndicatorView)
+        XCTAssertFalse(indicator.showDelivered)
+    }
+
     func test_viewFactory_makeSystemMessageView() {
         // Given
         let viewFactory = DefaultViewFactory.shared


### PR DESCRIPTION
### 🔗 Issue Links

- [IOS-1645](https://linear.app/stream/issue/IOS-1645/v5-qa-no-double-grey-checkmarks-icon-on-delivered-message-only-a)

### 🎯 Goal

The delivered state was rendering as a single (sent) grey checkmark on the message list instead of the expected double grey checkmarks. Only "sent" (single) and "read" (double blue) were visible, while "delivered" was indistinguishable from "sent" — a regression from the previously shipped behavior (see [#1038](https://github.com/GetStream/stream-chat-swiftui/pull/1038)).

### 📝 Summary

- Forward `message.deliveryStatus(for: channel) == .delivered` to `MessageReadIndicatorView` from `DefaultViewFactory.makeMessageReadIndicatorView`
- Add unit tests that assert the factory wires `showDelivered` correctly for both delivered and non-delivered messages

### 🛠 Implementation

During the v5 migration of factory methods to options-based signatures, the `showDelivered` argument was silently dropped from the `DefaultViewFactory` implementation of `makeMessageReadIndicatorView`, defaulting to `false`. The view itself still supports the delivered state — only the wiring in the factory was broken, which is why the channel list preview was unaffected (it constructs `MessageReadIndicatorView` directly with the correct flag).

The fix recomputes `showDelivered` from `options.message.deliveryStatus(for: options.channel)` and forwards it to the view, restoring the double-grey-checkmark rendering for the delivered state.

Two new unit tests in `ViewFactory_Tests` cast the factory's returned view back to `MessageReadIndicatorView` and assert that `showDelivered` is `true` when the channel has a delivered read for the message and `false` otherwise. This locks in the wiring so the regression can't reoccur silently.

### 🧪 Manual Testing Notes

1. Open a DM channel with delivery events enabled.
2. Send a message while the other user is offline — the message should show double grey checkmarks (delivered).
3. Once the other user reads the message, the checkmarks turn blue (read).
4. Before any delivery confirmation (pending send), a single grey checkmark is shown (sent).

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo