### PR TITLE
Fix composer prompt views opening action sheet when returning from channel info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### 🐞 Fixed
+- Fix attachment picker re-presenting after navigating back to the channel [#1434](https://github.com/GetStream/stream-chat-swiftui/pull/1434)
 
 # [5.1.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/5.1.0)
 _April 23, 2026_
@@ -12,7 +13,6 @@ _April 23, 2026_
 - `CDNRequester` is now passed in the constructor of `StreamMediaLoader` instead of `Utils` [#1425](https://github.com/GetStream/stream-chat-swiftui/pull/1425)
 
 ### 🐞 Fixed
-- Fix attachment picker re-presenting after navigating back to the channel [#1434](https://github.com/GetStream/stream-chat-swiftui/pull/1434)
 - Fix voice recording gesture and "hold to record" tip firing while the mic button is hidden [#1433](https://github.com/GetStream/stream-chat-swiftui/pull/1433)
 - Fix swipe-to-reply gesture conflicting with message list scrolling [#1431](https://github.com/GetStream/stream-chat-swiftui/pull/1431)
 - Fix double grey checkmarks not showing for delivered messages in the message list [#1432](https://github.com/GetStream/stream-chat-swiftui/pull/1432)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `CDNRequester` is now passed in the constructor of `StreamMediaLoader` instead of `Utils` [#1425](https://github.com/GetStream/stream-chat-swiftui/pull/1425)
 
 ### 🐞 Fixed
+- Fix attachment picker re-presenting after navigating back to the channel [#1434](https://github.com/GetStream/stream-chat-swiftui/pull/1434)
 - Fix voice recording gesture and "hold to record" tip firing while the mic button is hidden [#1433](https://github.com/GetStream/stream-chat-swiftui/pull/1433)
 - Fix swipe-to-reply gesture conflicting with message list scrolling [#1431](https://github.com/GetStream/stream-chat-swiftui/pull/1431)
 - Fix double grey checkmarks not showing for delivered messages in the message list [#1432](https://github.com/GetStream/stream-chat-swiftui/pull/1432)

--- a/Sources/StreamChatSwiftUI/ChatComposer/AttachmentPicker/AttachmentCameraPickerView.swift
+++ b/Sources/StreamChatSwiftUI/ChatComposer/AttachmentPicker/AttachmentCameraPickerView.swift
@@ -36,7 +36,7 @@ struct AttachmentCameraPickerView: View {
                 .fullScreenCover(isPresented: $cameraPickerShown) {
                     CameraImagePickerView(cameraImageAdded: cameraImageAdded)
                 }
-                .onAppear {
+                .onLoad {
                     openCamera()
                 }
             }

--- a/Sources/StreamChatSwiftUI/ChatComposer/AttachmentPicker/AttachmentFilePickerView.swift
+++ b/Sources/StreamChatSwiftUI/ChatComposer/AttachmentPicker/AttachmentFilePickerView.swift
@@ -22,7 +22,7 @@ struct AttachmentFilePickerView: View {
                 onFilesPicked(urls)
             })
         }
-        .onAppear {
+        .onLoad {
             filePickerShown = true
         }
     }

--- a/Sources/StreamChatSwiftUI/ChatComposer/AttachmentPicker/AttachmentPollPickerView.swift
+++ b/Sources/StreamChatSwiftUI/ChatComposer/AttachmentPicker/AttachmentPollPickerView.swift
@@ -24,7 +24,7 @@ struct AttachmentPollPickerView: View {
                 messageController: messageController
             )
         }
-        .onAppear {
+        .onLoad {
             showsCreatePoll = true
         }
     }


### PR DESCRIPTION
### 🔗 Issue Links

N/A

### 🎯 Goal

In the `MessageComposerView`, the prompt views for camera, files and poll auto-presented their sheet/full-screen cover every time `.onAppear` fired. That's fine the first time the user taps the tab, but `.onAppear` also fires when the chat channel view reappears after a navigation pop (e.g. returning from the Channel Info screen), causing the sheet/cover to pop up again unexpectedly.

### 📝 Summary

- Replace `.onAppear` with the existing `.onLoad` modifier in `AttachmentFilePickerView`, `AttachmentCameraPickerView`, and `AttachmentPollPickerView` so the picker is only auto-presented on the first appearance.

### 🛠 Implementation

`OnLoadViewModifier` already guards its action with an `@State hasLoaded` flag, which is exactly the semantics these views want. Swapping `.onAppear` for `.onLoad` makes the auto-presentation fire once per view lifetime instead of on every re-appearance, preserving the original "user tapped the tab → open the picker" UX while preventing the re-present on navigation pop.

### 🎨 Showcase

N/A — behavioral fix, no visual change.

### 🧪 Manual Testing Notes

1. Open a channel.
2. Tap the attachment icon in the composer to expand the picker tray.
3. Switch to the Camera, Files, or Polls tab — the corresponding sheet/cover should present as before.
4. Dismiss the sheet.
5. Tap the channel header to open the Channel Info screen.
6. Tap Back to return to the channel.
7. The sheet/cover should **not** re-present. Previously, it would.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where attachment picker controls—including camera capture, file selection, and poll creation options—would incorrectly reappear after navigating back to a channel. These picker interfaces are now properly initialized and dismissed at the appropriate times, preventing unexpected re-presentation when returning to previously viewed conversations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->