### PR TITLE
[CI] Bump Xcode version and enable e2e test cron checks on iOS 26

### DIFF
--- a/.github/workflows/cron-checks.yml
+++ b/.github/workflows/cron-checks.yml
@@ -21,9 +21,9 @@ jobs:
     strategy:
       matrix:
         include:
-          # - ios: "26.2"  # TODO: IOS-1181
-          #   device: "iPhone 17 Pro"
-          #   setup_runtime: false
+          - ios: "26.2"
+            device: "iPhone 17 Pro"
+            setup_runtime: false
           - ios: "18.5"
             device: "iPhone 16 Pro"
             setup_runtime: false
@@ -35,7 +35,7 @@ jobs:
     env:
       GITHUB_EVENT: ${{ toJson(github.event) }}
       ALLURE_TOKEN: ${{ secrets.ALLURE_TOKEN }}
-      XCODE_VERSION: "26.2"
+      XCODE_VERSION: "26.3"
       IOS_SIMULATOR_DEVICE: "${{ matrix.device }} (${{ matrix.ios }})"
     steps:
     - uses: actions/checkout@v4.1.1

--- a/.github/workflows/smoke-checks.yml
+++ b/.github/workflows/smoke-checks.yml
@@ -164,7 +164,6 @@ jobs:
       - build-test-app-and-frameworks
     env:
       LAUNCH_ID: ${{ needs.allure_testops_launch.outputs.launch_id }}
-      IOS_SIMULATOR_DEVICE: "iPhone 16 Pro (18.5)" # TODO: IOS-1181
     strategy:
       matrix:
         batch: [0, 1]

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -8,7 +8,7 @@ require 'xcodeproj'
 import 'Sonarfile'
 import 'Allurefile'
 
-xcode_version = ENV['XCODE_VERSION'] || '26.2'
+xcode_version = ENV['XCODE_VERSION'] || '26.3'
 xcode_project = 'StreamChatSwiftUI.xcodeproj'
 sdk_names = ['StreamChatSwiftUI']
 github_repo = ENV['GITHUB_REPOSITORY'] || 'GetStream/stream-chat-swiftui'


### PR DESCRIPTION
Resolve https://linear.app/stream/issue/IOS-1181

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD testing infrastructure with Xcode version 26.3 and iOS 17 Pro simulator configuration for improved testing reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->