### PR TITLE
Fix message list vertical scrolling broken on iOS 17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # Upcoming
 
 ### 🐞 Fixed
+- Fix message list vertical scrolling not working on iOS 17 [#1441](https://github.com/GetStream/stream-chat-swiftui/pull/1441)
 - Fix attachment picker re-presenting after navigating back to the channel [#1434](https://github.com/GetStream/stream-chat-swiftui/pull/1434)
 - Fix voice message playback breaking after sending while previewing a recording [#1438](https://github.com/GetStream/stream-chat-swiftui/pull/1438)
 - Fix Send button briefly flashing before the mic when confirming an edit [#1438](https://github.com/GetStream/stream-chat-swiftui/pull/1438)

--- a/Sources/StreamChatSwiftUI/ChatMessageList/MessageItemView.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/MessageItemView.swift
@@ -216,18 +216,25 @@ struct MessageActionsGestureModifier: ViewModifier {
         if shownAsPreview {
             content
         } else {
-            content
-                .onTapGesture(count: 2) {
-                    if isDoubleTapEnabled {
-                        onActionsTriggered()
-                    }
+            let withTap = content.onTapGesture(count: 2) {
+                if isDoubleTapEnabled {
+                    onActionsTriggered()
                 }
-                .highPriorityGesture(
-                    LongPressGesture(minimumDuration: longPressMinimumDuration)
-                        .onEnded { _ in
-                            onActionsTriggered()
-                        }
-                )
+            }
+            let longPress = LongPressGesture(minimumDuration: longPressMinimumDuration)
+                .onEnded { _ in
+                    onActionsTriggered()
+                }
+
+            // On iOS 17 a `.highPriorityGesture(LongPressGesture)` here ends
+            // up monopolising touches across the whole message item view,
+            // starving the parent `ScrollView`'s pan recognizer and breaking
+            // vertical scrolling.
+            if #available(iOS 18, *) {
+                withTap.highPriorityGesture(longPress)
+            } else {
+                withTap.gesture(longPress)
+            }
         }
     }
 }


### PR DESCRIPTION
### 🔗 Issue Links

https://linear.app/stream/issue/IOS-1654/swiftuiv5ios-17-scrolling-and-jumping-in-the-message-list-do-not-work

### 🎯 Goal

On iOS 17, vertical scrolling of the message list was completely broken: any touch on a message item was monopolised by the message-actions long-press gesture, so the parent `ScrollView`'s pan recognizer never got any input. iOS 18+ was unaffected.

### 📝 Summary

- In `MessageActionsGestureModifier`, attach the long-press via `.gesture(...)` instead of `.highPriorityGesture(...)` on iOS 17.
- iOS 18+ keeps the existing `.highPriorityGesture(...)` behavior.

### 🛠 Implementation

`.highPriorityGesture` tells SwiftUI "beat any descendant gesture for this view". On iOS 17 specifically, this priority claim ends up extending toward the enclosing `ScrollView`'s pan recognizer too, starving it of touches and breaking vertical scroll. iOS 18+ coordinates the high-priority long press with `ScrollView`'s pan correctly, so we keep the previous behavior there.


### 🧪 Manual Testing Notes

- On an iOS 17 simulator/device: open a channel, scroll the message list vertically and diagonally — scroll should be responsive again.
- Long-press a message — the message actions overlay should still open, although it loses the high-priority arbitration on iOS 17 (acceptable trade for working scroll).
- On iOS 18+: confirm long-press, swipe-to-reply and scrolling are unchanged.

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the \`docs-content\` repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gesture handling for message actions to prevent interference with message list scrolling and enable more reliable double-tap and long-press interactions across iOS versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->