### PR TITLE
Stop loading first page when leaving channel mid-page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # Upcoming
 
 ### 🐞 Fixed
+- Fix channel list preview showing "No messages" after a mid-page jump [#1442](https://github.com/GetStream/stream-chat-swiftui/pull/1442)
+- Avoid an extra channel-fetch request when leaving a channel [#1442](https://github.com/GetStream/stream-chat-swiftui/pull/1442)
 - Fix message list vertical scrolling not working on iOS 17 [#1441](https://github.com/GetStream/stream-chat-swiftui/pull/1441)
 - Fix attachment picker re-presenting after navigating back to the channel [#1434](https://github.com/GetStream/stream-chat-swiftui/pull/1434)
 - Fix voice message playback breaking after sending while previewing a recording [#1438](https://github.com/GetStream/stream-chat-swiftui/pull/1438)

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelViewModel.swift
@@ -868,9 +868,6 @@ import SwiftUI
                 utils.channelControllerFactory.clearCurrentController()
                 cleanupAudioPlayer()
                 ImageCache.shared.trim(toCost: utils.messageListConfig.cacheSizeOnChatDismiss)
-                if !channelDataSource.hasLoadedAllNextMessages {
-                    channelDataSource.loadFirstPage { _ in }
-                }
             }
         }
     }


### PR DESCRIPTION
### 🔗 Issue Links

Resolves [IOS-1657](https://linear.app/stream/issue/IOS-1657/swiftui-stop-resetting-to-first-page-in-chatchannelviewmodel)

### 🎯 Goal

The SwiftUI counterpart to the [recently merged LLC fix in `stream-chat-swift`](https://github.com/GetStream/stream-chat-swift/pull/4077) for the mid-page channel preview bug. Now that the LLC resets the channel state to the latest page when the channel controller is deallocated, the SwiftUI workaround in `ChatChannelViewModel.deinit` is no longer needed. Removing it also avoids an extra channel-fetch network request on channel exit.

### 📝 Summary

- Remove the `loadFirstPage` workaround from `ChatChannelViewModel.deinit`.
- Channel list preview now correctly shows the last message after leaving a channel that was opened to a mid-page jump.
- Saves one network request (channel fetch) every time a channel is left.

### 🛠 Implementation

The deinit previously called `channelDataSource.loadFirstPage` whenever the user left a channel that hadn't loaded all the next messages. That was a workaround for the LLC `ChatChannel.latestMessages` being wiped on mid-page pagination. With the LLC fix in place, the controller already resets back to the latest page on deallocation, so the SwiftUI side just removes the workaround.

The rest of the deinit (`messageCachingUtils.clearCache()`, the `messageController == nil` guard, `cleanupAudioPlayer()`, and `ImageCache.shared.trim`) is unchanged.

### 🎨 Showcase

N/A — behavior change is invisible to the user beyond the channel preview now staying correct after a mid-page jump (covered by the LLC fix).

### 🧪 Manual Testing Notes

1. Open a channel, jump to a message that triggers a mid-page load (e.g., via a quoted-message tap or notification).
2. Leave the channel.
3. The channel list preview should still display the latest message (not "No messages" or stale state).
4. Network logs should show no extra `channel` query on channel exit.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed unnecessary message loading logic from channel cleanup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->