### PR TITLE
Fix attachment and quoted-message taps not working on iOS 17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix channel list preview showing "No messages" after a mid-page jump [#1442](https://github.com/GetStream/stream-chat-swiftui/pull/1442)
 - Avoid an extra channel-fetch request when leaving a channel [#1442](https://github.com/GetStream/stream-chat-swiftui/pull/1442)
 - Fix message list vertical scrolling not working on iOS 17 [#1441](https://github.com/GetStream/stream-chat-swiftui/pull/1441)
+- Fix tapping image attachments, quoted messages, and link previews not working on iOS 17 [#1443](https://github.com/GetStream/stream-chat-swiftui/pull/1443)
 - Fix attachment picker re-presenting after navigating back to the channel [#1434](https://github.com/GetStream/stream-chat-swiftui/pull/1434)
 - Fix voice message playback breaking after sending while previewing a recording [#1438](https://github.com/GetStream/stream-chat-swiftui/pull/1438)
 - Fix Send button briefly flashing before the mic when confirming an edit [#1438](https://github.com/GetStream/stream-chat-swiftui/pull/1438)

--- a/Sources/StreamChatSwiftUI/ChatMessageList/MessageContainerView.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/MessageContainerView.swift
@@ -147,10 +147,6 @@ struct MessageContainerView<Factory: ViewFactory>: View {
             messageViewModel.failureIndicatorShown ? SendFailureIndicator() : nil
         )
         .frame(maxWidth: contentWidth, alignment: messageViewModel.isRightAligned ? .trailing : .leading)
-        .highPriorityGesture(
-            TapGesture().onEnded { /* Swallow taps on the bubble so attachments don't open and the overlay doesn't dismiss. */ },
-            including: shownAsPreview ? .all : .none
-        )
     }
 
     @ViewBuilder


### PR DESCRIPTION
### 🔗 Issue Links

https://linear.app/stream/issue/IOS-1678/swiftuiv5ios-17-jumping-to-messages-does-not-work

### 🎯 Goal

On iOS 17, taps on image attachments, quoted messages, and link previews inside the message bubble are completely unresponsive. The bubble appears to "eat" all touches, even though long-press, double-tap, and swipe-to-reply still work fine.

### 📝 Summary

- Drops the `.highPriorityGesture(TapGesture(), including: shownAsPreview ? .all : .none)` modifier from `MessageContainerView`'s bubble content.
- Restores tap interactivity on attachments and quoted messages on iOS 17.
- No visible behavior change on iOS 18+.

### 🛠 Implementation

The bubble had a tap-swallowing `.highPriorityGesture(...)` whose only purpose was to absorb taps while the message is rendered inside the reactions overlay (`shownAsPreview == true`), so attachments wouldn't open and the overlay wouldn't dismiss. In normal display the gesture was meant to be inert via `including: .none`.

On iOS 18+ that worked. On iOS 17 SwiftUI still arbitrates touches through the recognizer regardless of `including: .none`, which starves descendant tap recognizers of touches and makes attachments / quoted messages feel completely dead.

The swallow gesture is no longer required at all: the inner content is already prevented from reacting to touches in preview mode via `.allowsHitTesting(!shownAsPreview)` on `MessageView`. Removing the modifier across all iOS versions fixes the iOS 17 regression with zero behavior change on iOS 18+.

### 🧪 Manual Testing Notes

On an iOS 17 simulator (e.g. iPhone 14 / iOS 17.2):

1. Open any channel with an image attachment, a quoted-reply message, or a link-preview message.
2. Tap the attachment → gallery opens. Tap the quoted reference → list scrolls to the quoted message. Tap the link preview → link opens.
3. Long-press a bubble → reactions overlay appears, then tap on the previewed bubble in the overlay → overlay does not dismiss and attachments inside the preview do not open.
4. Verify vertical scrolling, swipe-to-reply, and long-press still behave the same as before.

Repeat on iOS 18+ to confirm there is no regression.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tap gesture handling on preview messages that was previously blocked
  * Added a visual failure indicator that displays when a message fails to send

<!-- end of auto-generated comment: release notes by coderabbit.ai -->