### PR TITLE
Add VoiceOver label for Giphy message bubble

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+### ✅ Added
+- VoiceOver now announces Giphy message bubbles with the Giphy title (e.g. "Giphy, happy cat") instead of just "Giphy" [#1448](https://github.com/GetStream/stream-chat-swiftui/pull/1448)
+
 ### 🔄 Changed
 
 # [5.1.1](https://github.com/GetStream/stream-chat-swiftui/releases/tag/5.1.1)

--- a/Sources/StreamChatSwiftUI/ChatMessageList/GiphyAttachmentView.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/GiphyAttachmentView.swift
@@ -61,6 +61,9 @@ public struct GiphyAttachmentView<Factory: ViewFactory>: View {
                     )
                 )
             )
+            .accessibilityElement(children: .ignore)
+            .accessibilityAddTraits(.isImage)
+            .accessibilityLabel(giphyAccessibilityLabel)
 
             if visibleOnlyToCurrentUser {
                 HStack {
@@ -104,6 +107,14 @@ public struct GiphyAttachmentView<Factory: ViewFactory>: View {
 
     private var giphyActions: [AttachmentAction] {
         message.giphyAttachments[0].actions
+    }
+
+    var giphyAccessibilityLabel: String {
+        let title = message.giphyAttachments[0].title?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let title, !title.isEmpty {
+            return L10n.Message.GiphyAttachment.accessibilityLabelWithTitle(title)
+        }
+        return L10n.Message.GiphyAttachment.accessibilityLabel
     }
 
     private func execute(action: AttachmentAction) {

--- a/Sources/StreamChatSwiftUI/Generated/L10n.swift
+++ b/Sources/StreamChatSwiftUI/Generated/L10n.swift
@@ -634,6 +634,12 @@ internal enum L10n {
       internal static var photos: String { L10n.tr("Localizable", "message.gallery.photos") }
     }
     internal enum GiphyAttachment {
+      /// Giphy
+      internal static var accessibilityLabel: String { L10n.tr("Localizable", "message.giphy-attachment.accessibility-label") }
+      /// Giphy, %@
+      internal static func accessibilityLabelWithTitle(_ p1: Any) -> String {
+        return L10n.tr("Localizable", "message.giphy-attachment.accessibility-label-with-title", String(describing: p1))
+      }
       /// GIPHY
       internal static var title: String { L10n.tr("Localizable", "message.giphy-attachment.title") }
     }

--- a/Sources/StreamChatSwiftUI/Resources/en.lproj/Localizable.strings
+++ b/Sources/StreamChatSwiftUI/Resources/en.lproj/Localizable.strings
@@ -232,6 +232,8 @@
 
 "message.file-attachment.error-preview" = "Error occured while previewing the file.";
 "message.giphy-attachment.title" = "GIPHY";
+"message.giphy-attachment.accessibility-label" = "Giphy";
+"message.giphy-attachment.accessibility-label-with-title" = "Giphy, %@";
 
 "message.search.title" = "Search";
 "message.search.cancel" = "Cancel";

--- a/StreamChatSwiftUI.xcodeproj/project.pbxproj
+++ b/StreamChatSwiftUI.xcodeproj/project.pbxproj
@@ -189,6 +189,7 @@
 				Tests/ChatChannel/CreatePollViewModel_Tests.swift,
 				Tests/ChatChannel/EditedMessageView_Tests.swift,
 				Tests/ChatChannel/FileAttachmentView_Tests.swift,
+				Tests/ChatChannel/GiphyAttachmentView_Tests.swift,
 				Tests/ChatChannel/LazyLoadingImage_Tests.swift,
 				Tests/ChatChannel/MediaAttachmentGalleryOrdering_Tests.swift,
 				Tests/ChatChannel/MediaViewer_Tests.swift,

--- a/StreamChatSwiftUITests/Tests/ChatChannel/GiphyAttachmentView_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/GiphyAttachmentView_Tests.swift
@@ -1,0 +1,78 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+@testable import StreamChatSwiftUI
+import StreamSwiftTestHelpers
+import SwiftUI
+import XCTest
+
+@MainActor final class GiphyAttachmentView_Tests: StreamChatTestCase {
+    // MARK: - Accessibility Label
+
+    func test_giphyAccessibilityLabel_whenTitleIsPresent_includesTitle() {
+        let view = makeView(giphyTitle: "happy cat")
+
+        XCTAssertEqual(view.giphyAccessibilityLabel, "Giphy, happy cat")
+    }
+
+    func test_giphyAccessibilityLabel_whenTitleIsNil_isJustGiphy() {
+        let view = makeView(giphyTitle: nil)
+
+        XCTAssertEqual(view.giphyAccessibilityLabel, "Giphy")
+    }
+
+    func test_giphyAccessibilityLabel_whenTitleIsEmpty_isJustGiphy() {
+        let view = makeView(giphyTitle: "")
+
+        XCTAssertEqual(view.giphyAccessibilityLabel, "Giphy")
+    }
+
+    func test_giphyAccessibilityLabel_whenTitleIsWhitespaceOnly_isJustGiphy() {
+        let view = makeView(giphyTitle: "   \n\t  ")
+
+        XCTAssertEqual(view.giphyAccessibilityLabel, "Giphy")
+    }
+
+    func test_giphyAccessibilityLabel_whenTitleHasSurroundingWhitespace_isTrimmed() {
+        let view = makeView(giphyTitle: "  happy cat  ")
+
+        XCTAssertEqual(view.giphyAccessibilityLabel, "Giphy, happy cat")
+    }
+
+    // MARK: - Helpers
+
+    private func makeView(
+        giphyTitle: String?
+    ) -> GiphyAttachmentView<DefaultViewFactory> {
+        let attachment = ChatMessageGiphyAttachment(
+            id: .unique,
+            type: .giphy,
+            payload: GiphyAttachmentPayload(
+                title: giphyTitle,
+                previewURL: ChatChannelTestHelpers.testURL,
+                actions: []
+            ),
+            downloadingState: nil,
+            uploadingState: nil
+        )
+        .asAnyAttachment
+
+        let message = ChatMessage.mock(
+            id: .unique,
+            cid: .unique,
+            text: "",
+            author: .mock(id: .unique),
+            attachments: [attachment]
+        )
+
+        return GiphyAttachmentView(
+            factory: DefaultViewFactory.shared,
+            message: message,
+            width: 300,
+            isFirst: true,
+            scrolledId: .constant(nil)
+        )
+    }
+}

--- a/StreamChatSwiftUITestsAppTests/Pages/MessageListPage.swift
+++ b/StreamChatSwiftUITestsAppTests/Pages/MessageListPage.swift
@@ -193,10 +193,6 @@ class MessageListPage {
         static func giphyImage(in messageCell: XCUIElement) -> XCUIElement {
             messageCell.images["GiphyAttachmentView"].firstMatch
         }
-
-        static func giphyLabel(in messageCell: XCUIElement) -> XCUIElement {
-            messageCell.staticTexts["GiphyAttachmentView"]
-        }
         
         static func actionButtons() -> XCUIElementQuery {
             app.buttons.matching(NSPredicate(format: "identifier LIKE 'GiphyAttachmentView'"))

--- a/StreamChatSwiftUITestsAppTests/Robots/UserRobot+Asserts.swift
+++ b/StreamChatSwiftUITestsAppTests/Robots/UserRobot+Asserts.swift
@@ -3,6 +3,7 @@
 //
 
 import Foundation
+@testable import StreamChatSwiftUI
 import XCTest
 
 let channelAttributes = ChannelListPage.Attributes.self
@@ -954,8 +955,14 @@ extension UserRobot {
         line: UInt = #line
     ) -> Self {
         let cell = messageCell(withIndex: messageCellIndex, file: file, line: line).wait()
-        XCTAssertTrue(attributes.giphyLabel(in: cell).wait().exists, "Giphy label does not exist")
-        XCTAssertTrue(attributes.giphyImage(in: cell).exists, "Giphy image does not exist")
+        let image = attributes.giphyImage(in: cell).wait()
+        XCTAssertTrue(image.exists, "Giphy image does not exist", file: file, line: line)
+        XCTAssertTrue(
+            image.label.hasPrefix(L10n.Message.GiphyAttachment.accessibilityLabel),
+            "Giphy image is missing the expected VoiceOver label, got: \(image.label)",
+            file: file,
+            line: line
+        )
         return self
     }
 
@@ -966,7 +973,12 @@ extension UserRobot {
         line: UInt = #line
     ) -> Self {
         let cell = messageCell(withIndex: messageCellIndex, file: file, line: line)
-        XCTAssertFalse(attributes.giphyLabel(in: cell).waitForDisappearance().exists, "Giphy label exists")
+        XCTAssertFalse(
+            attributes.giphyImage(in: cell).waitForDisappearance().exists,
+            "Giphy image exists",
+            file: file,
+            line: line
+        )
         XCTAssertEqual(0, attributes.giphyButtons(in: cell).count)
         return self
     }

--- a/StreamChatSwiftUITestsAppTests/Robots/UserRobot+Asserts.swift
+++ b/StreamChatSwiftUITestsAppTests/Robots/UserRobot+Asserts.swift
@@ -3,7 +3,6 @@
 //
 
 import Foundation
-@testable import StreamChatSwiftUI
 import XCTest
 
 let channelAttributes = ChannelListPage.Attributes.self
@@ -958,7 +957,7 @@ extension UserRobot {
         let image = attributes.giphyImage(in: cell).wait()
         XCTAssertTrue(image.exists, "Giphy image does not exist", file: file, line: line)
         XCTAssertTrue(
-            image.label.hasPrefix(L10n.Message.GiphyAttachment.accessibilityLabel),
+            image.label.hasPrefix("Giphy"),
             "Giphy image is missing the expected VoiceOver label, got: \(image.label)",
             file: file,
             line: line


### PR DESCRIPTION
### 🔗 Issue Links

- [IOS-1694](https://linear.app/stream/issue/IOS-1694/swiftui-accessibility-giphy-message-bubble-voiceover-label)

### 🎯 Goal

VoiceOver focuses the "GIPHY" badge overlaid on a Giphy message bubble and announces only "Giphy", giving the user no information about the content of the GIF. The Giphy message should be exposed as a single accessibility element with a label that includes the title (the user's search query, e.g. "happy cat") so VoiceOver users get the same content cue as sighted users.

### 📝 Summary

- Expose the Giphy message bubble (image + badge overlay) as a single VoiceOver element with the `.isImage` trait and a meaningful label.
- Label format: `"Giphy, {title}"` when the attachment has a non-empty title, fallback `"Giphy"` when the title is missing/empty/whitespace-only.
- Add two new localization keys: `message.giphy-attachment.accessibility-label` and `message.giphy-attachment.accessibility-label-with-title`.
- Add unit tests covering the title-present, nil, empty, whitespace-only, and surrounding-whitespace cases.

### 🛠 Implementation

In `GiphyAttachmentView`, the inner `LazyGiphyView` with its `GiphyBadgeView` overlay now uses:

```swift
.accessibilityElement(children: .ignore)
.accessibilityAddTraits(.isImage)
.accessibilityLabel(giphyAccessibilityLabel)
```

`.accessibilityElement(children: .ignore)` collapses the GIF and the badge text into a single VoiceOver stop, replacing the previous behavior where focus landed only on the "GIPHY" badge label. The badge icon already had `.accessibilityHidden(true)`; both badge children are now subsumed by the ignored container so they no longer split focus.

The label is sourced from `GiphyAttachmentPayload.title`, which the server populates with the user's search query. The fallback uses a separate localization key so consumers can localize the empty-title case independently.

The pending-Giphy action buttons (Send/Shuffle/Cancel) sit outside the labeled container and remain individually reachable.

### 🧪 Manual Testing Notes

- Enable VoiceOver and send a Giphy via `/giphy <query>`. Focus the Giphy message bubble and verify it announces as a single element with "Giphy, {search query}".
- Confirm focus no longer lands separately on the "GIPHY" badge label.
- Send a Giphy with an empty/missing title (edge case) and verify it announces just "Giphy".
- Repeat on a pending Giphy: confirm the bubble announces "Giphy, {title}" and that the Send/Shuffle/Cancel buttons are still individually reachable via swipe.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [x] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * VoiceOver now announces Giphy message bubbles with their titles (when available) instead of a generic label, improving screen reader context.

* **Accessibility**
  * Giphy images expose a proper accessibility label and image trait to assistive technologies.

* **Tests**
  * Added UI tests covering multiple Giphy title scenarios and updated assertions to verify accessibility labels.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-chat-swiftui/pull/1448)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->