### PR TITLE
Make scroll-to-bottom button reachable from VoiceOver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+### ✅ Added
+- Make the scroll-to-bottom button reachable from VoiceOver without swiping through every message in between [#1449](https://github.com/GetStream/stream-chat-swiftui/pull/1449)
+
 ### 🔄 Changed
 
 # [5.1.1](https://github.com/GetStream/stream-chat-swiftui/releases/tag/5.1.1)

--- a/Sources/StreamChatSwiftUI/ChatMessageList/MessageListView.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/MessageListView.swift
@@ -638,6 +638,9 @@ public struct ScrollToBottomButton<Factory: ViewFactory>: View {
             .modifier(factory.styles.makeScrollToBottomButtonModifier(options: .init()))
             .accessibilityLabel(Text(L10n.Channel.List.ScrollToBottom.title))
             .accessibilityIdentifier("ScrollToBottomButton")
+            // Floats over the message list, so raise the sort priority to make it
+            // reachable from VoiceOver without swiping through every message in between.
+            .accessibilitySortPriority(1)
             .badgeNotification(count: unreadCount)
             .padding(tokens.spacingMd)
         }


### PR DESCRIPTION
### 🔗 Issue Links

- [IOS-1695](https://linear.app/stream/issue/IOS-1695/swiftui-accessibility-message-view-scroll-to-bottom-button-reachable)

### 🎯 Goal

When a user is scrolled up in the message list, the floating scroll-to-bottom button is the fastest way back to recent messages. VoiceOver users could not reach it efficiently: the button was last in the accessibility traversal order, so they had to swipe through every message between their current position and the bottom of the list before focusing it.

### 📝 Summary

- `ScrollToBottomButton` now raises its accessibility sort priority so VoiceOver focuses it ahead of the message list content while it is visible.

### 🛠 Implementation

The scroll-to-bottom button is a sibling of the message `ScrollView` inside the `ZStack` that hosts the chat content. By default both siblings have a sort priority of `0`, so VoiceOver follows the layout order and reaches the floating button only after every message.

Setting `.accessibilitySortPriority(1)` on the button makes it the first focusable element in that container whenever it is rendered (i.e. only when the user is scrolled up and the button actually appears). When the button is hidden, nothing changes for VoiceOver.

This matches the audit recommendation of "exposing the button in the focus order so it's accessible directly without traversing all messages" and keeps the change minimal: a single modifier with no public API or visual changes.

### 🎨 Showcase

No visual changes. Existing `ScrollToBottomButton` snapshot tests pass without updates.

### 🧪 Manual Testing Notes

1. Enable VoiceOver (Settings → Accessibility → VoiceOver, or triple-click the side button).
2. Open a channel with many messages in the demo app.
3. Scroll up so that the scroll-to-bottom button appears at the bottom-right.
4. Swipe right with VoiceOver from the navigation bar.
5. Expected: VoiceOver focuses the "Scroll to bottom" button before any message item.
6. Double-tap to confirm the button works and returns the list to the bottom.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo