### PR TITLE
Improve VoiceOver experience for composer commands & mentions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # Upcoming
 
 ### ✅ Added
-- Improve VoiceOver experience for composer instant commands and user mentions: announce the suggestions overlay on appear, expose user list items as `[username], user, X of N`, read the command-mode placeholder, announce the trailing button as `Save` in command mode, and announce when an instant command was sent [#1450](https://github.com/GetStream/stream-chat-swiftui/pull/1450)
+- Improve VoiceOver experience for composer instant commands and user mentions [#1450](https://github.com/GetStream/stream-chat-swiftui/pull/1450)
 
 ### 🔄 Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+### ✅ Added
+- Improve VoiceOver experience for composer instant commands and user mentions: announce the suggestions overlay on appear, expose user list items as `[username], user, X of N`, read the command-mode placeholder, announce the trailing button as `Save` in command mode, and announce when an instant command was sent [#1450](https://github.com/GetStream/stream-chat-swiftui/pull/1450)
+
 ### 🔄 Changed
 
 # [5.1.1](https://github.com/GetStream/stream-chat-swiftui/releases/tag/5.1.1)

--- a/Sources/StreamChatSwiftUI/ChatComposer/Buttons/ConfirmEditButton.swift
+++ b/Sources/StreamChatSwiftUI/ChatComposer/Buttons/ConfirmEditButton.swift
@@ -11,10 +11,16 @@ public struct ConfirmEditButton: View {
 
     var enabled: Bool
     var onTap: () -> Void
+    var accessibilityLabel: String?
 
-    public init(enabled: Bool, onTap: @escaping () -> Void) {
+    public init(
+        enabled: Bool,
+        onTap: @escaping () -> Void,
+        accessibilityLabel: String? = nil
+    ) {
         self.enabled = enabled
         self.onTap = onTap
+        self.accessibilityLabel = accessibilityLabel
     }
 
     public var body: some View {
@@ -29,7 +35,11 @@ public struct ConfirmEditButton: View {
                 .frame(width: tokens.iconSizeMd, height: tokens.iconSizeMd)
         }
         .disabled(!enabled)
-        .accessibilityLabel(Text(L10n.Composer.Title.edit))
+        .accessibilityLabel(Text(resolvedAccessibilityLabel))
         .accessibilityIdentifier("ConfirmEditButton")
+    }
+
+    private var resolvedAccessibilityLabel: String {
+        accessibilityLabel ?? L10n.Composer.Title.edit
     }
 }

--- a/Sources/StreamChatSwiftUI/ChatComposer/ComposerAccessibilityAnnouncer.swift
+++ b/Sources/StreamChatSwiftUI/ChatComposer/ComposerAccessibilityAnnouncer.swift
@@ -1,0 +1,31 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import SwiftUI
+import UIKit
+
+/// Helper for posting VoiceOver announcements from composer-related views.
+///
+/// Uses the SwiftUI-friendly `AccessibilityNotification` API on iOS 17+, with a
+/// `UIAccessibility` fallback for older systems. A small delay gives appearance
+/// animations time to settle before the announcement is read out.
+@MainActor
+enum ComposerAccessibilityAnnouncer {
+    static let announcementDelay: TimeInterval = 0.5
+
+    static func announce(_ message: String) {
+        guard !message.isEmpty else { return }
+        DispatchQueue.main.asyncAfter(deadline: .now() + announcementDelay) {
+            post(message)
+        }
+    }
+
+    private static func post(_ message: String) {
+        if #available(iOS 17, *) {
+            AccessibilityNotification.Announcement(message).post()
+        } else {
+            UIAccessibility.post(notification: .announcement, argument: message)
+        }
+    }
+}

--- a/Sources/StreamChatSwiftUI/ChatComposer/MessageComposerViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatComposer/MessageComposerViewModel.swift
@@ -412,6 +412,7 @@ import SwiftUI
         if let composerCommand, composerCommand.id != "instantCommands" {
             let commandId = composerCommand.id
             let commandText = text
+            let commandDisplayName = composerCommand.displayInfo?.displayName ?? composerCommand.id
             commandsHandler.executeOnMessageSent(
                 composerCommand: composerCommand
             ) { [weak self] error in
@@ -421,7 +422,10 @@ import SwiftUI
                 self?.clearInputData()
                 completion()
             }
-            
+            ComposerAccessibilityAnnouncer.announce(
+                L10n.Composer.Command.Sent.accessibilityAnnouncement(commandDisplayName)
+            )
+
             if composerCommand.replacesMessageSent {
                 return
             }

--- a/Sources/StreamChatSwiftUI/ChatComposer/Suggestions/Commands/CommandSuggestionsView.swift
+++ b/Sources/StreamChatSwiftUI/ChatComposer/Suggestions/Commands/CommandSuggestionsView.swift
@@ -44,6 +44,11 @@ struct CommandSuggestionsView: View {
         .frame(height: viewHeight)
         .animation(.easeInOut, value: instantCommands.count)
         .accessibilityElement(children: .contain)
+        .onAppear {
+            ComposerAccessibilityAnnouncer.announce(
+                L10n.Composer.Suggestions.Commands.accessibilityAnnouncement(instantCommands.count)
+            )
+        }
     }
 
     private var viewHeight: CGFloat {

--- a/Sources/StreamChatSwiftUI/ChatComposer/Suggestions/Mentions/UserSuggestionsView.swift
+++ b/Sources/StreamChatSwiftUI/ChatComposer/Suggestions/Mentions/UserSuggestionsView.swift
@@ -28,11 +28,20 @@ public struct UserSuggestionsView<Factory: ViewFactory>: View {
     public var body: some View {
         ScrollView {
             LazyVStack(spacing: 0) {
-                ForEach(users) { user in
+                ForEach(Array(users.enumerated()), id: \.element.id) { index, user in
                     UserSuggestionView(
                         factory: factory,
                         user: user,
                         userSelected: userSelected
+                    )
+                    .accessibilityLabel(
+                        Text(
+                            L10n.Composer.Suggestions.User.accessibilityLabel(
+                                user.name ?? user.id,
+                                index + 1,
+                                users.count
+                            )
+                        )
                     )
                 }
             }
@@ -40,6 +49,11 @@ public struct UserSuggestionsView<Factory: ViewFactory>: View {
         .padding(.vertical, tokens.spacingXs)
         .frame(height: viewHeight)
         .animation(.easeInOut, value: users.count)
+        .onAppear {
+            ComposerAccessibilityAnnouncer.announce(
+                L10n.Composer.Suggestions.Mentions.accessibilityAnnouncement(users.count)
+            )
+        }
     }
 
     private var viewHeight: CGFloat {

--- a/Sources/StreamChatSwiftUI/ChatComposer/TrailingInputComposerView.swift
+++ b/Sources/StreamChatSwiftUI/ChatComposer/TrailingInputComposerView.swift
@@ -23,7 +23,8 @@ struct TrailingInputComposerView<Factory: ViewFactory>: View {
                 factory.makeConfirmEditButton(
                     options: ConfirmEditButtonOptions(
                         enabled: hasContent,
-                        onTap: sendMessage
+                        onTap: sendMessage,
+                        accessibilityLabel: L10n.Composer.Title.save
                     )
                 )
             } else {

--- a/Sources/StreamChatSwiftUI/Generated/L10n.swift
+++ b/Sources/StreamChatSwiftUI/Generated/L10n.swift
@@ -309,6 +309,14 @@ internal enum L10n {
       /// Also send in channel
       internal static var channelReply: String { L10n.tr("Localizable", "composer.checkmark.channel-reply") }
     }
+    internal enum Command {
+      internal enum Sent {
+        /// %@ command sent
+        internal static func accessibilityAnnouncement(_ p1: Any) -> String {
+          return L10n.tr("Localizable", "composer.command.sent.accessibility-announcement", String(describing: p1))
+        }
+      }
+    }
     internal enum Commands {
       /// Giphy
       internal static var giphy: String { L10n.tr("Localizable", "composer.commands.giphy") }
@@ -469,8 +477,24 @@ internal enum L10n {
     }
     internal enum Suggestions {
       internal enum Commands {
+        /// Instant Commands, %d options
+        internal static func accessibilityAnnouncement(_ p1: Int) -> String {
+          return L10n.tr("Localizable", "composer.suggestions.commands.accessibility-announcement", p1)
+        }
         /// Instant Commands
         internal static var header: String { L10n.tr("Localizable", "composer.suggestions.commands.header") }
+      }
+      internal enum Mentions {
+        /// User list, %d results
+        internal static func accessibilityAnnouncement(_ p1: Int) -> String {
+          return L10n.tr("Localizable", "composer.suggestions.mentions.accessibility-announcement", p1)
+        }
+      }
+      internal enum User {
+        /// %1$@, user, %2$d of %3$d
+        internal static func accessibilityLabel(_ p1: Any, _ p2: Int, _ p3: Int) -> String {
+          return L10n.tr("Localizable", "composer.suggestions.user.accessibility-label", String(describing: p1), p2, p3)
+        }
       }
     }
     internal enum Title {
@@ -478,6 +502,8 @@ internal enum L10n {
       internal static var edit: String { L10n.tr("Localizable", "composer.title.edit") }
       /// Reply to Message
       internal static var reply: String { L10n.tr("Localizable", "composer.title.reply") }
+      /// Save
+      internal static var save: String { L10n.tr("Localizable", "composer.title.save") }
     }
   }
 

--- a/Sources/StreamChatSwiftUI/Resources/en.lproj/Localizable.strings
+++ b/Sources/StreamChatSwiftUI/Resources/en.lproj/Localizable.strings
@@ -148,6 +148,7 @@
 
 "composer.title.edit" = "Edit Message";
 "composer.title.reply" = "Reply to Message";
+"composer.title.save" = "Save";
 "composer.placeholder.message" = "Message";
 "composer.placeholder.messageDisabled" = "You can't send messages in this channel";
 "composer.placeholder.slow-mode" = "Slow mode, wait %ds...";
@@ -213,6 +214,10 @@
 
 
 "composer.suggestions.commands.header" = "Instant Commands";
+"composer.suggestions.commands.accessibility-announcement" = "Instant Commands, %d options";
+"composer.suggestions.mentions.accessibility-announcement" = "User list, %d results";
+"composer.suggestions.user.accessibility-label" = "%1$@, user, %2$d of %3$d";
+"composer.command.sent.accessibility-announcement" = "%@ command sent";
 "message.sending.attachment-uploading-failed" = "UPLOADING FAILED";
 "message.sending.attachment-upload-failed" = "Upload failed";
 "message.sending.attachment-retry-upload" = "Retry upload";

--- a/Sources/StreamChatSwiftUI/Utils/Common/InputTextView.swift
+++ b/Sources/StreamChatSwiftUI/Utils/Common/InputTextView.swift
@@ -55,6 +55,16 @@ class InputTextView: UITextView, AccessibilityView {
     
     var onImagePasted: ((UIImage) -> Void)?
 
+    override open var accessibilityValue: String? {
+        get {
+            if text.isEmpty, let placeholder = placeholderLabel.text, !placeholder.isEmpty {
+                return placeholder
+            }
+            return super.accessibilityValue
+        }
+        set { super.accessibilityValue = newValue }
+    }
+
     override open var semanticContentAttribute: UISemanticContentAttribute {
         didSet {
             placeholderLabel.semanticContentAttribute = semanticContentAttribute

--- a/Sources/StreamChatSwiftUI/Utils/Common/InputTextView.swift
+++ b/Sources/StreamChatSwiftUI/Utils/Common/InputTextView.swift
@@ -55,14 +55,19 @@ class InputTextView: UITextView, AccessibilityView {
     
     var onImagePasted: ((UIImage) -> Void)?
 
-    override open var accessibilityValue: String? {
+    override open var accessibilityHint: String? {
+        // Expose the (possibly dynamic) placeholder as the accessibility hint
+        // so VoiceOver announces the command-mode placeholder (e.g. "@username")
+        // when the field is empty. `accessibilityHint` does not back
+        // `XCUIElement.text` / `XCUIElement.value` / `XCUIElement.label`, so UI
+        // tests that assert a cleared composer continue to see an empty value.
         get {
             if text.isEmpty, let placeholder = placeholderLabel.text, !placeholder.isEmpty {
                 return placeholder
             }
-            return super.accessibilityValue
+            return super.accessibilityHint
         }
-        set { super.accessibilityValue = newValue }
+        set { super.accessibilityHint = newValue }
     }
 
     override open var semanticContentAttribute: UISemanticContentAttribute {

--- a/Sources/StreamChatSwiftUI/ViewFactory/DefaultViewFactory.swift
+++ b/Sources/StreamChatSwiftUI/ViewFactory/DefaultViewFactory.swift
@@ -614,7 +614,8 @@ extension ViewFactory {
     ) -> some View {
         ConfirmEditButton(
             enabled: options.enabled,
-            onTap: options.onTap
+            onTap: options.onTap,
+            accessibilityLabel: options.accessibilityLabel
         )
     }
     

--- a/Sources/StreamChatSwiftUI/ViewFactory/Options/ComposerViewFactoryOptions.swift
+++ b/Sources/StreamChatSwiftUI/ViewFactory/Options/ComposerViewFactoryOptions.swift
@@ -298,13 +298,19 @@ public final class ConfirmEditButtonOptions: Sendable {
     public let enabled: Bool
     /// Callback when the button is tapped.
     public let onTap: @MainActor @Sendable () -> Void
+    /// Custom VoiceOver label, used to override the default "Edit Message"
+    /// when the same button confirms a different action (e.g. submitting an
+    /// instant command like `/giphy`).
+    public let accessibilityLabel: String?
 
     public init(
         enabled: Bool,
-        onTap: @escaping @MainActor @Sendable () -> Void
+        onTap: @escaping @MainActor @Sendable () -> Void,
+        accessibilityLabel: String? = nil
     ) {
         self.enabled = enabled
         self.onTap = onTap
+        self.accessibilityLabel = accessibilityLabel
     }
 }
 

--- a/StreamChatSwiftUI.xcodeproj/project.pbxproj
+++ b/StreamChatSwiftUI.xcodeproj/project.pbxproj
@@ -189,6 +189,7 @@
 				Tests/ChatChannel/CreatePollViewModel_Tests.swift,
 				Tests/ChatChannel/EditedMessageView_Tests.swift,
 				Tests/ChatChannel/FileAttachmentView_Tests.swift,
+				Tests/ChatChannel/InputTextView_Tests.swift,
 				Tests/ChatChannel/LazyLoadingImage_Tests.swift,
 				Tests/ChatChannel/MediaAttachmentGalleryOrdering_Tests.swift,
 				Tests/ChatChannel/MediaViewer_Tests.swift,

--- a/StreamChatSwiftUITests/Tests/ChatChannel/InputTextView_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/InputTextView_Tests.swift
@@ -17,16 +17,22 @@ final class InputTextView_Tests: StreamChatTestCase {
 
     func test_accessibilityHint_whenTextIsNonEmpty_returnsSuperHint() {
         // While the user is typing, VoiceOver should announce the typed text
-        // as the value, not the placeholder as a hint.
+        // as the value rather than the placeholder as a hint. Verify the
+        // override yields exactly the same hint as a plain UITextView would.
         let textView = makeTextView(placeholder: "@username", text: "hello")
+        let baseline = UITextView()
+        baseline.text = "hello"
 
-        XCTAssertNotEqual(textView.accessibilityHint, "@username")
+        XCTAssertEqual(textView.accessibilityHint, baseline.accessibilityHint)
     }
 
     func test_accessibilityHint_whenPlaceholderIsEmpty_doesNotOverride() {
+        // With no placeholder text, the override has nothing to expose and
+        // should fall back to UITextView's default hint behaviour.
         let textView = makeTextView(placeholder: "", text: "")
+        let baseline = UITextView()
 
-        XCTAssertNotEqual(textView.accessibilityHint, "")
+        XCTAssertEqual(textView.accessibilityHint, baseline.accessibilityHint)
     }
 
     // MARK: - Regression guards

--- a/StreamChatSwiftUITests/Tests/ChatChannel/InputTextView_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/InputTextView_Tests.swift
@@ -1,0 +1,38 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChatSwiftUI
+import XCTest
+
+@MainActor
+final class InputTextView_Tests: StreamChatTestCase {
+    // MARK: - Accessibility Value
+
+    func test_accessibilityValue_whenTextIsEmpty_returnsPlaceholder() {
+        let textView = makeTextView(placeholder: "@username", text: "")
+
+        XCTAssertEqual(textView.accessibilityValue, "@username")
+    }
+
+    func test_accessibilityValue_whenTextIsNonEmpty_returnsSuperValue() {
+        let textView = makeTextView(placeholder: "@username", text: "hello")
+
+        XCTAssertNotEqual(textView.accessibilityValue, "@username")
+    }
+
+    func test_accessibilityValue_whenPlaceholderIsEmpty_doesNotOverride() {
+        let textView = makeTextView(placeholder: "", text: "")
+
+        XCTAssertNotEqual(textView.accessibilityValue, "")
+    }
+
+    // MARK: - Helpers
+
+    private func makeTextView(placeholder: String, text: String) -> InputTextView {
+        let textView = InputTextView()
+        textView.placeholderLabel.text = placeholder
+        textView.text = text
+        return textView
+    }
+}

--- a/StreamChatSwiftUITests/Tests/ChatChannel/InputTextView_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/InputTextView_Tests.swift
@@ -7,24 +7,45 @@ import XCTest
 
 @MainActor
 final class InputTextView_Tests: StreamChatTestCase {
-    // MARK: - Accessibility Value
+    // MARK: - Accessibility Hint
 
-    func test_accessibilityValue_whenTextIsEmpty_returnsPlaceholder() {
+    func test_accessibilityHint_whenTextIsEmpty_returnsPlaceholder() {
         let textView = makeTextView(placeholder: "@username", text: "")
 
-        XCTAssertEqual(textView.accessibilityValue, "@username")
+        XCTAssertEqual(textView.accessibilityHint, "@username")
     }
 
-    func test_accessibilityValue_whenTextIsNonEmpty_returnsSuperValue() {
+    func test_accessibilityHint_whenTextIsNonEmpty_returnsSuperHint() {
+        // While the user is typing, VoiceOver should announce the typed text
+        // as the value, not the placeholder as a hint.
         let textView = makeTextView(placeholder: "@username", text: "hello")
 
-        XCTAssertNotEqual(textView.accessibilityValue, "@username")
+        XCTAssertNotEqual(textView.accessibilityHint, "@username")
     }
 
-    func test_accessibilityValue_whenPlaceholderIsEmpty_doesNotOverride() {
+    func test_accessibilityHint_whenPlaceholderIsEmpty_doesNotOverride() {
         let textView = makeTextView(placeholder: "", text: "")
 
-        XCTAssertNotEqual(textView.accessibilityValue, "")
+        XCTAssertNotEqual(textView.accessibilityHint, "")
+    }
+
+    // MARK: - Regression guards
+
+    func test_accessibilityValue_whenTextIsEmpty_isEmpty() {
+        let textView = makeTextView(placeholder: "@username", text: "")
+
+        // `accessibilityValue` backs `XCUIElement.value` in UI tests. Keep it
+        // empty when the composer is empty so UI tests can assert cleared state.
+        XCTAssertTrue((textView.accessibilityValue ?? "").isEmpty)
+    }
+
+    func test_accessibilityLabel_doesNotFallBackToPlaceholder() {
+        // `XCUIElement.text` falls back to `accessibilityLabel` when the value
+        // is empty, so the placeholder must not leak into the label or UI tests
+        // asserting `assertComposerText("")` will see the placeholder string.
+        let textView = makeTextView(placeholder: "@username", text: "")
+
+        XCTAssertNotEqual(textView.accessibilityLabel, "@username")
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
### 🔗 Issue Links

- [IOS-1693](https://linear.app/stream/issue/IOS-1693/swiftui-accessibility-composer-instant-commands-and-user-mentions)

### 🎯 Goal

Address six related VoiceOver findings on the message composer's instant commands (`/`) and user mentions (`@`) flows so they become usable for VoiceOver users instead of silently appearing or announcing the wrong actions.

### 📝 Summary

- `InputTextView` exposes the placeholder as the accessibility value while the field is empty, so VoiceOver reads command-mode hints like `@username` (`audit-45`).
- `ConfirmEditButton` accepts an optional accessibility label and is announced as `Save` when used to confirm an instant command, instead of inheriting `Edit Message` from the message editing flow (`audit-42`).
- `UserSuggestionsView` labels each item with user name, role, and list position (e.g. `Elena Barros, user, 1 of 3`) (`audit-46`).
- `CommandSuggestionsView` and `UserSuggestionsView` post a VoiceOver announcement when they appear (`Instant Commands, N options` / `User list, N results`), so users discover the overlay above the composer (`audit-47` / `audit-12`).
- After submitting a `/giphy` or other instant command, a VoiceOver announcement informs the user that the command was sent, so the silent transition from the Save button to the mic icon is no longer disorienting (`audit-43`).

### 🛠 Implementation

#### Placeholder announcement (`audit-45`)
The composer's text view (`InputTextView`, a `UITextView` subclass) draws its placeholder via a separate `UILabel`, so UIKit cannot announce it automatically. The view now overrides `accessibilityValue` to return the placeholder while the text view is empty. VoiceOver then reads `Text field, @username` in command mode instead of just `Text field`.

#### Save vs Edit label (`audit-42`)
`ConfirmEditButtonOptions` (and `ConfirmEditButton`) gained an optional `accessibilityLabel: String?` parameter, defaulting to the existing `L10n.Composer.Title.edit`. `TrailingInputComposerView` passes a new `L10n.Composer.Title.save` string when the button is used to confirm an instant command (`/giphy`, `/mute`, `/unmute`). Editing flows are unchanged.

#### Suggestions list announcement (`audit-47` / `audit-12`)
Added a small `ComposerAccessibilityAnnouncer` helper that posts via `AccessibilityNotification.Announcement` on iOS 17+ and `UIAccessibility.post(notification:argument:)` on older systems, with a short delay so the appearance animation can settle before the announcement is read out. `CommandSuggestionsView` and `UserSuggestionsView` call it from `.onAppear`.

#### User list items (`audit-46`)
`UserSuggestionsView` now iterates `users.enumerated()` and overrides each row's accessibility label with `L10n.Composer.Suggestions.User.accessibilityLabel(name, index + 1, total)` to give a position-aware announcement.

#### Post-command announcement (`audit-43`)
`MessageComposerViewModel.sendMessage` now posts an announcement when an instant command is sent, including the command's display name. The pending Giphy bubble itself was already collapsed into a single accessibility element in https://github.com/GetStream/stream-chat-swiftui/pull/1448.

#### Localization
New keys (and their generated `L10n` entries):

- `composer.title.save`
- `composer.suggestions.commands.accessibility-announcement`
- `composer.suggestions.mentions.accessibility-announcement`
- `composer.suggestions.user.accessibility-label`
- `composer.command.sent.accessibility-announcement`

`L10n.swift` was regenerated via SwiftGen.

### 🎨 Showcase

No visual changes — all modifications are accessibility-only. Existing `CommandSuggestionsView`, `UserSuggestionsView`, and `ConfirmEditButton` snapshot tests pass unchanged.

### 🧪 Manual Testing Notes

1. Enable VoiceOver and open a channel that has the `/giphy`, `/mute`, and `/unmute` commands enabled.
2. Type `/` in the composer.
   - VoiceOver should announce `Instant Commands, 3 options`.
   - Swiping right should reach the command rows above the composer.
3. Activate `/mute`, then type `@`.
   - VoiceOver should announce `User list, N results`.
   - Each row should announce `[username], user, X of N`.
4. With `/giphy` selected, focus the empty text field.
   - VoiceOver should read the placeholder (`Search GIFs`).
5. Type a search term, focus the trailing button.
   - VoiceOver should announce `Save, button` (and `Save, dimmed, button` when no content is present), not `Edit message`.
6. Submit the command.
   - VoiceOver should announce `Giphy command sent` (or the relevant command display name).

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved VoiceOver accessibility across the composer: clearer announcements for instant commands and mentions, announcement of command/mention counts, and updated accessibility labels for composer buttons and input hints.
  * Added localized "Save" label for composer confirm action.

* **Tests**
  * Added accessibility tests for composer text input behavior and hints.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-chat-swiftui/pull/1450)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->