### PR TITLE
Improve VoiceOver experience for the Create Poll sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # Upcoming
 
 ### ✅ Added
+- Improve VoiceOver experience for the Create Poll sheet [#1451](https://github.com/GetStream/stream-chat-swiftui/pull/1451)
 - Make the scroll-to-bottom button reachable from VoiceOver without swiping through every message in between [#1449](https://github.com/GetStream/stream-chat-swiftui/pull/1449)
 - Improve VoiceOver experience for composer instant commands and user mentions [#1450](https://github.com/GetStream/stream-chat-swiftui/pull/1450)
 - VoiceOver now announces Giphy message bubbles with the Giphy title instead of just "Giphy" [#1448](https://github.com/GetStream/stream-chat-swiftui/pull/1448)

--- a/Sources/StreamChatSwiftUI/ChatComposer/ComposerAccessibilityAnnouncer.swift
+++ b/Sources/StreamChatSwiftUI/ChatComposer/ComposerAccessibilityAnnouncer.swift
@@ -12,20 +12,41 @@ import UIKit
 /// animations time to settle before the announcement is read out.
 @MainActor
 enum ComposerAccessibilityAnnouncer {
+    /// The kind of VoiceOver notification to post.
+    enum Kind {
+        /// Reads the message without moving VoiceOver focus. Use for ambient
+        /// updates (e.g. "Mentions list opened").
+        case announcement
+        /// Reads the message and lets VoiceOver refocus on the new screen.
+        /// Use when presenting a sheet or pushing a new view.
+        case screenChanged
+    }
+
     static let announcementDelay: TimeInterval = 0.5
 
-    static func announce(_ message: String) {
+    static func announce(_ message: String, kind: Kind = .announcement) {
         guard !message.isEmpty else { return }
         DispatchQueue.main.asyncAfter(deadline: .now() + announcementDelay) {
-            post(message)
+            post(message, kind: kind)
         }
     }
 
-    private static func post(_ message: String) {
+    private static func post(_ message: String, kind: Kind) {
         if #available(iOS 17, *) {
-            AccessibilityNotification.Announcement(message).post()
+            switch kind {
+            case .announcement:
+                AccessibilityNotification.Announcement(message).post()
+            case .screenChanged:
+                AccessibilityNotification.ScreenChanged(message).post()
+            }
         } else {
-            UIAccessibility.post(notification: .announcement, argument: message)
+            let notification: UIAccessibility.Notification = {
+                switch kind {
+                case .announcement: return .announcement
+                case .screenChanged: return .screenChanged
+                }
+            }()
+            UIAccessibility.post(notification: notification, argument: message)
         }
     }
 }

--- a/Sources/StreamChatSwiftUI/ChatComposer/Polls/CreatePollView.swift
+++ b/Sources/StreamChatSwiftUI/ChatComposer/Polls/CreatePollView.swift
@@ -171,14 +171,10 @@ public struct CreatePollView<Factory: ViewFactory>: View {
     /// Posts a VoiceOver screen change announcement naming the sheet so users
     /// orient themselves on open instead of landing on the bare "Close" button.
     private func postScreenChangedAnnouncement() {
-        let title = L10n.Composer.Polls.createPoll
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-            if #available(iOS 17.0, *) {
-                AccessibilityNotification.ScreenChanged(title).post()
-            } else {
-                UIAccessibility.post(notification: .screenChanged, argument: title)
-            }
-        }
+        ComposerAccessibilityAnnouncer.announce(
+            L10n.Composer.Polls.createPoll,
+            kind: .screenChanged
+        )
     }
 
     @ViewBuilder

--- a/Sources/StreamChatSwiftUI/ChatComposer/Polls/CreatePollView.swift
+++ b/Sources/StreamChatSwiftUI/ChatComposer/Polls/CreatePollView.swift
@@ -45,6 +45,7 @@ public struct CreatePollView<Factory: ViewFactory>: View {
                     settingsSection
                     Spacer()
                         .modifier(CreatePollRowModifier(topSpacing: 0, bottomSpacing: 0))
+                        .accessibilityHidden(true)
                 }
                 .environment(\.defaultMinListRowHeight, 1)
                 .listStyle(.plain)
@@ -69,6 +70,7 @@ public struct CreatePollView<Factory: ViewFactory>: View {
                 )
             )
             .navigationBarTitleDisplayMode(.inline)
+            .onAppear(perform: postScreenChangedAnnouncement)
         }
         .actionSheet(isPresented: $viewModel.discardConfirmationShown) {
             ActionSheet(
@@ -120,10 +122,13 @@ public struct CreatePollView<Factory: ViewFactory>: View {
                 bottomSpacing: tokens.spacingXxs
             ))
 
-        ForEach(viewModel.options) { option in
+        let reorderableCount = viewModel.reorderableOptionCount
+        ForEach(Array(viewModel.options.enumerated()), id: \.element.id) { index, option in
             let isLast = viewModel.isLastOption(option)
             CreatePollOptionRow(
                 text: option.text,
+                position: option.text.isEmpty ? nil : index + 1,
+                totalCount: reorderableCount,
                 showsReorderIcon: !option.text.isEmpty,
                 showsDeleteButton: !isLast,
                 showsError: viewModel.showsOptionError(for: option),
@@ -138,6 +143,10 @@ public struct CreatePollView<Factory: ViewFactory>: View {
                     Task { @MainActor in
                         viewModel.removeOption(id: id)
                     }
+                },
+                onAccessibilityMove: { direction in
+                    let id = option.id
+                    return viewModel.moveOption(id: id, direction: direction)
                 }
             )
         }
@@ -156,6 +165,20 @@ public struct CreatePollView<Factory: ViewFactory>: View {
         Color.clear
             .frame(height: tokens.spacingLg)
             .modifier(CreatePollRowModifier(topSpacing: 0, bottomSpacing: 0))
+            .accessibilityHidden(true)
+    }
+
+    /// Posts a VoiceOver screen change announcement naming the sheet so users
+    /// orient themselves on open instead of landing on the bare "Close" button.
+    private func postScreenChangedAnnouncement() {
+        let title = L10n.Composer.Polls.createPoll
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            if #available(iOS 17.0, *) {
+                AccessibilityNotification.ScreenChanged(title).post()
+            } else {
+                UIAccessibility.post(notification: .screenChanged, argument: title)
+            }
+        }
     }
 
     @ViewBuilder
@@ -209,6 +232,7 @@ public struct CreatePollView<Factory: ViewFactory>: View {
                 Toggle("", isOn: $viewModel.multipleAnswers)
                     .labelsHidden()
             }
+            .accessibilityElement(children: .combine)
 
             if viewModel.multipleAnswers, viewModel.maxVotesShown {
                 VStack(alignment: .leading, spacing: tokens.spacingXs) {
@@ -226,6 +250,7 @@ public struct CreatePollView<Factory: ViewFactory>: View {
                             .labelsHidden()
                     }
                     .padding(.vertical, tokens.spacingXxxs)
+                    .accessibilityElement(children: .combine)
 
                     if viewModel.maxVotesEnabled {
                         CreatePollMaxVotesStepper(
@@ -293,6 +318,8 @@ private struct CreatePollToolbarModifier<Factory: ViewFactory>: ViewModifier {
             }
             .modifier(factory.styles.makeToolbarConfirmActionModifier(options: .init()))
             .disabled(!canCreatePoll)
+            .accessibilityLabel(Text(L10n.Composer.Polls.Accessibility.saveButton))
+            .accessibilityRemoveTraits(.isSelected)
         }
     }
 }
@@ -306,20 +333,20 @@ private struct CreatePollOptionRow: View {
     @Injected(\.tokens) private var tokens
 
     let text: String
+    let position: Int?
+    let totalCount: Int
     let showsReorderIcon: Bool
     let showsDeleteButton: Bool
     let showsError: Bool
     let onTextChanged: @Sendable (String) -> Void
     let onDelete: () -> Void
+    let onAccessibilityMove: (AccessibilityAdjustmentDirection) -> Bool
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             HStack(spacing: tokens.spacingXs) {
                 if showsReorderIcon {
-                    Image(uiImage: images.pollOptionDragIcon)
-                        .renderingMode(.template)
-                        .font(.system(size: tokens.iconSizeSm))
-                        .foregroundColor(Color(colors.textTertiary))
+                    reorderHandle
                 }
                 TextField(
                     L10n.Composer.Polls.addOption,
@@ -347,6 +374,24 @@ private struct CreatePollOptionRow: View {
                 .strokeBorder(Color(colors.borderCoreDefault), lineWidth: 1)
         )
         .moveDisabled(!showsDeleteButton)
+    }
+
+    private var reorderHandle: some View {
+        Image(uiImage: images.pollOptionDragIcon)
+            .renderingMode(.template)
+            .font(.system(size: tokens.iconSizeSm))
+            .foregroundColor(Color(colors.textTertiary))
+            .accessibilityElement()
+            .accessibilityLabel(Text(L10n.Composer.Polls.Accessibility.reorderOption))
+            .accessibilityValue(Text(reorderAccessibilityValue))
+            .accessibilityAdjustableAction { direction in
+                _ = onAccessibilityMove(direction)
+            }
+    }
+
+    private var reorderAccessibilityValue: String {
+        guard let position else { return "" }
+        return L10n.Composer.Polls.Accessibility.reorderOptionPosition(position, totalCount)
     }
 
     private var duplicateErrorLabel: some View {
@@ -392,6 +437,7 @@ private struct CreatePollSettingCard<Content: View>: View {
         .padding(tokens.spacingMd)
         .background(Color(colors.backgroundCoreSurfaceCard))
         .clipShape(RoundedRectangle(cornerRadius: tokens.radiusLg))
+        .accessibilityElement(children: .combine)
         .modifier(CreatePollRowModifier(
             topSpacing: tokens.spacingXs,
             bottomSpacing: tokens.spacingXs
@@ -414,26 +460,37 @@ private struct CreatePollMaxVotesStepper: View {
 
     var body: some View {
         HStack(spacing: tokens.spacingXxs) {
-            stepperButton(systemName: "minus", enabled: canDecrement, action: onDecrement)
+            stepperButton(
+                systemName: "minus",
+                enabled: canDecrement,
+                accessibilityLabel: L10n.Composer.Polls.Accessibility.decreaseVoteLimit,
+                action: onDecrement
+            )
 
             Text(text)
                 .font(fonts.body)
                 .foregroundColor(Color(colors.textPrimary))
                 .frame(width: tokens.buttonVisualHeightMd, height: tokens.buttonVisualHeightLg)
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(Text(L10n.Composer.Polls.Accessibility.voteLimit))
+                .accessibilityValue(Text(text))
 
-            stepperButton(systemName: "plus", enabled: canIncrement, action: onIncrement)
+            stepperButton(
+                systemName: "plus",
+                enabled: canIncrement,
+                accessibilityLabel: L10n.Composer.Polls.Accessibility.increaseVoteLimit,
+                action: onIncrement
+            )
         }
     }
 
     private func stepperButton(
         systemName: String,
         enabled: Bool,
+        accessibilityLabel: String,
         action: @escaping () -> Void
     ) -> some View {
-        Button {
-            guard enabled else { return }
-            action()
-        } label: {
+        Button(action: action) {
             Image(systemName: systemName)
                 .font(.system(size: tokens.iconSizeSm))
                 .foregroundColor(Color(enabled ? colors.textPrimary : colors.textTertiary))
@@ -448,7 +505,9 @@ private struct CreatePollMaxVotesStepper: View {
                 .contentShape(Circle())
         }
         .buttonStyle(.borderless)
+        .disabled(!enabled)
         .frame(width: tokens.buttonVisualHeightLg, height: tokens.buttonVisualHeightLg)
+        .accessibilityLabel(Text(accessibilityLabel))
     }
 }
 

--- a/Sources/StreamChatSwiftUI/ChatComposer/Polls/CreatePollViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatComposer/Polls/CreatePollViewModel.swift
@@ -105,6 +105,12 @@ import SwiftUI
         return optionsErrorIndices.contains(index)
     }
 
+    /// The number of reorderable options (excluding the trailing empty
+    /// placeholder), used to build the "Option N of M" accessibility value.
+    var reorderableOptionCount: Int {
+        options.filter { !$0.text.isEmpty }.count
+    }
+
     // MARK: - Option Mutations
 
     func updateOption(id: UUID, value: String) {
@@ -124,6 +130,27 @@ import SwiftUI
 
     func moveOptions(from source: IndexSet, to destination: Int) {
         options.move(fromOffsets: source, toOffset: destination)
+    }
+
+    /// Accessibility-driven reordering: moves the option one position up
+    /// (`.decrement`) or down (`.increment`) in the list. Used as the
+    /// adjustable action backing the reorder handle, so VoiceOver users can
+    /// reorder via the rotor without a drag gesture. No-op past the bounds
+    /// or onto the trailing empty placeholder.
+    func moveOption(id: UUID, direction: AccessibilityAdjustmentDirection) -> Bool {
+        guard let index = options.firstIndex(where: { $0.id == id }) else { return false }
+        switch direction {
+        case .decrement:
+            guard index > 0 else { return false }
+            moveOptions(from: IndexSet(integer: index), to: index - 1)
+            return true
+        case .increment:
+            guard index < options.count - 2 else { return false }
+            moveOptions(from: IndexSet(integer: index), to: index + 2)
+            return true
+        @unknown default:
+            return false
+        }
     }
 
     func replaceAllOptions(_ newTexts: [String]) {

--- a/Sources/StreamChatSwiftUI/Generated/L10n.swift
+++ b/Sources/StreamChatSwiftUI/Generated/L10n.swift
@@ -426,6 +426,22 @@ internal enum L10n {
       internal static var suggestOption: String { L10n.tr("Localizable", "composer.polls.suggest-option") }
       /// Choose between 2–10 options
       internal static var typeNumberMinMaxRange: String { L10n.tr("Localizable", "composer.polls.type-number-min-max-range") }
+      internal enum Accessibility {
+        /// Decrease vote limit
+        internal static var decreaseVoteLimit: String { L10n.tr("Localizable", "composer.polls.accessibility.decrease-vote-limit") }
+        /// Increase vote limit
+        internal static var increaseVoteLimit: String { L10n.tr("Localizable", "composer.polls.accessibility.increase-vote-limit") }
+        /// Reorder option
+        internal static var reorderOption: String { L10n.tr("Localizable", "composer.polls.accessibility.reorder-option") }
+        /// Option %1$lld of %2$lld
+        internal static func reorderOptionPosition(_ p1: Int, _ p2: Int) -> String {
+          return L10n.tr("Localizable", "composer.polls.accessibility.reorder-option-position", p1, p2)
+        }
+        /// Save Poll
+        internal static var saveButton: String { L10n.tr("Localizable", "composer.polls.accessibility.save-button") }
+        /// Vote limit
+        internal static var voteLimit: String { L10n.tr("Localizable", "composer.polls.accessibility.vote-limit") }
+      }
     }
     internal enum Quoted {
       /// Audio

--- a/Sources/StreamChatSwiftUI/Resources/en.lproj/Localizable.strings
+++ b/Sources/StreamChatSwiftUI/Resources/en.lproj/Localizable.strings
@@ -198,6 +198,12 @@
 "composer.polls.hide-who-voted" = "Hide who voted";
 "composer.polls.let-others-add-options" = "Let others add options";
 "composer.polls.allow-others-to-add-comments" = "Allow others to add comments";
+"composer.polls.accessibility.save-button" = "Save Poll";
+"composer.polls.accessibility.reorder-option" = "Reorder option";
+"composer.polls.accessibility.reorder-option-position" = "Option %1$lld of %2$lld";
+"composer.polls.accessibility.decrease-vote-limit" = "Decrease vote limit";
+"composer.polls.accessibility.increase-vote-limit" = "Increase vote limit";
+"composer.polls.accessibility.vote-limit" = "Vote limit";
 "composer.audio-recording.start" = "Start recording audio message";
 "composer.audio-recording.stop" = "Stop recording audio message";
 

--- a/StreamChatSwiftUITests/Tests/ChatChannel/CreatePollViewModel_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/CreatePollViewModel_Tests.swift
@@ -4,6 +4,7 @@
 
 @testable import StreamChat
 @testable import StreamChatSwiftUI
+import SwiftUI
 import XCTest
 
 @MainActor final class CreatePollViewModel_Tests: StreamChatTestCase {
@@ -284,6 +285,72 @@ import XCTest
         XCTAssertEqual(viewModel.options[0].id, originalIds[2])
         XCTAssertEqual(viewModel.options[1].id, originalIds[0])
         XCTAssertEqual(viewModel.options[2].id, originalIds[1])
+    }
+
+    // MARK: - Accessibility-driven reordering
+
+    func test_moveOption_decrement_movesUpOnePosition() {
+        let viewModel = makeViewModel()
+        viewModel.replaceAllOptions(["A", "B", "C", ""])
+        let targetId = viewModel.options[1].id
+
+        XCTAssertTrue(viewModel.moveOption(id: targetId, direction: .decrement))
+
+        XCTAssertEqual(viewModel.optionTexts, ["B", "A", "C", ""])
+    }
+
+    func test_moveOption_increment_movesDownOnePosition() {
+        let viewModel = makeViewModel()
+        viewModel.replaceAllOptions(["A", "B", "C", ""])
+        let targetId = viewModel.options[0].id
+
+        XCTAssertTrue(viewModel.moveOption(id: targetId, direction: .increment))
+
+        XCTAssertEqual(viewModel.optionTexts, ["B", "A", "C", ""])
+    }
+
+    func test_moveOption_decrement_atFirstPosition_doesNothing() {
+        let viewModel = makeViewModel()
+        viewModel.replaceAllOptions(["A", "B", ""])
+        let firstId = viewModel.options[0].id
+
+        XCTAssertFalse(viewModel.moveOption(id: firstId, direction: .decrement))
+
+        XCTAssertEqual(viewModel.optionTexts, ["A", "B", ""])
+    }
+
+    func test_moveOption_increment_atLastReorderablePosition_doesNothing() {
+        // The trailing empty placeholder is not movable, so the last reorderable
+        // option must not be swapped down into it.
+        let viewModel = makeViewModel()
+        viewModel.replaceAllOptions(["A", "B", ""])
+        let lastReorderableId = viewModel.options[1].id
+
+        XCTAssertFalse(viewModel.moveOption(id: lastReorderableId, direction: .increment))
+
+        XCTAssertEqual(viewModel.optionTexts, ["A", "B", ""])
+    }
+
+    func test_moveOption_unknownId_doesNothing() {
+        let viewModel = makeViewModel()
+        viewModel.replaceAllOptions(["A", "B"])
+
+        XCTAssertFalse(viewModel.moveOption(id: UUID(), direction: .increment))
+
+        XCTAssertEqual(viewModel.optionTexts, ["A", "B"])
+    }
+
+    // MARK: - Reorderable Option Count
+
+    func test_reorderableOptionCount_excludesTrailingEmptyPlaceholder() {
+        let viewModel = makeViewModel()
+        viewModel.replaceAllOptions(["A", "B", "C", ""])
+        XCTAssertEqual(viewModel.reorderableOptionCount, 3)
+    }
+
+    func test_reorderableOptionCount_initialEmptyOption_isZero() {
+        let viewModel = makeViewModel()
+        XCTAssertEqual(viewModel.reorderableOptionCount, 0)
     }
 
     // MARK: - Option Mutations: replaceAllOptions


### PR DESCRIPTION
### 🔗 Issue Links

- [IOS-1691](https://linear.app/stream/issue/IOS-1691/swiftui-accessibility-attachment-picker-create-poll-sheet)

### 🎯 Goal

Address the Notion accessibility audit findings for the Create Poll sheet (Component = Attachment Picker / Create Poll). The audit numbers prefixed with `audit-` below refer to the rows in the audit table and are unrelated to GitHub issues.

### 📝 Summary

- `audit-34` — Post a screen change announcement naming the sheet on appear so VoiceOver users land with context.
- `audit-35` — Give the toolbar confirm button a real "Save Poll" label and drop the spurious `.isSelected` trait that the bordered-prominent style adds; the existing `.disabled()` already exposes the disabled trait correctly.
- `audit-36` — Mark the section spacer and the trailing list spacer as accessibility hidden so there is no empty focus stop between "Options" and "Multiple votes".
- `audit-37` — Make the option reorder handle a labelled adjustable element ("Reorder option, Option N of M") with an `accessibilityAdjustableAction` that calls a new view-model helper, so VoiceOver users can reorder via the rotor.
- `audit-38` — Label the Max Votes stepper buttons "Decrease vote limit" / "Increase vote limit", apply `.disabled(!enabled)` so the disabled trait reaches the bounds, and expose the current value via a "Vote limit, N" element.
- `audit-39` — Combine the title + description + switch rows in `CreatePollSettingCard` and the multiple-votes / vote-limit toggle rows into single accessibility elements via `.accessibilityElement(children: .combine)`, matching the focus order of the "Multiple votes" row.

### 🧪 Manual Testing Notes

1. Enable VoiceOver and open the channel composer.
2. Tap the attachment picker → Poll. VoiceOver should announce "Create Poll" on present and focus should land somewhere meaningful rather than on the bare close button.
3. Verify the trailing toolbar button announces as "Save Poll, button" (enabled) or "Save Poll, dimmed, button" (disabled before required fields are filled). It should not say "Selected" or "Dim".
4. Add a couple of options. Focus the drag handle on a non-empty option: VoiceOver should announce "Reorder option, Option N of M, adjustable". Swipe up / down to reorder, and confirm the order reflects in the list.
5. Enable "Multiple votes" and the "Limit votes per person" toggle. The stepper buttons should announce "Decrease vote limit" / "Increase vote limit", be dimmed at 2 (min) and 10 (max), and the static value should announce as "Vote limit, N".
6. Swipe through the Anonymous poll, Suggest an option and Add a comment rows. Each should announce as a single element with "{title}, {description}, switch, on/off" and activate the toggle when double-tapped.
7. Confirm there is no longer an empty focus stop between the Options section and the first settings row.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved VoiceOver accessibility for Create Poll sheet with screen change announcements and option reordering through accessibility controls, including new accessibility labels for poll configuration and voting limits.

* **Documentation**
  * Updated changelog with accessibility enhancements for Create Poll.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-chat-swiftui/pull/1451)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->