### PR TITLE
Avoid marking the channel as read while the latest message is still being sent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Improve VoiceOver experience for composer instant commands and user mentions [#1450](https://github.com/GetStream/stream-chat-swiftui/pull/1450)
 - VoiceOver now announces Giphy message bubbles with the Giphy title instead of just "Giphy" [#1448](https://github.com/GetStream/stream-chat-swiftui/pull/1448)
 
+### 🐞 Fixed
+- Avoid marking the channel as read while the latest message is still being sent
+
 # [5.1.1](https://github.com/GetStream/stream-chat-swiftui/releases/tag/5.1.1)
 _May 11, 2026_
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - VoiceOver now announces Giphy message bubbles with the Giphy title instead of just "Giphy" [#1448](https://github.com/GetStream/stream-chat-swiftui/pull/1448)
 
 ### 🐞 Fixed
-- Avoid marking the channel as read while the latest message is still being sent
+- Avoid marking the channel as read while the latest message is still being sent [#1452](https://github.com/GetStream/stream-chat-swiftui/pull/1452)
 
 # [5.1.1](https://github.com/GetStream/stream-chat-swiftui/releases/tag/5.1.1)
 _May 11, 2026_

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelViewModel.swift
@@ -36,6 +36,7 @@ import SwiftUI
     private var readsString = ""
     private var canMarkRead = false
     private var hasSetInitialCanMarkRead = false
+    private var pendingMarkReadMessageId: MessageId?
     private var currentUserSentNewMessage = false
     
     private lazy var messagesDateFormatter = utils.dateFormatter
@@ -515,6 +516,13 @@ import SwiftUI
             updateScrolledIdToNewestMessage()
             currentUserSentNewMessage = false
         }
+        
+        if let pendingMarkReadMessageId,
+           let pendingMarkReadMessage = messages.first(where: { $0.id == pendingMarkReadMessageId }),
+           !pendingMarkReadMessage.isLocalOnly {
+            self.pendingMarkReadMessageId = nil
+            sendReadEventIfNeeded(for: pendingMarkReadMessage)
+        }
     }
     
     func dataSource(
@@ -643,6 +651,10 @@ import SwiftUI
             return
         }
         if let read = channel.read(for: currentUserId), read.lastReadAt > message.createdAt {
+            return
+        }
+        if message.isLocalOnly {
+            pendingMarkReadMessageId = message.id
             return
         }
         throttler.execute { [weak self] in

--- a/StreamChatSwiftUITests/Tests/ChatChannel/ChatChannelViewModel_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/ChatChannelViewModel_Tests.swift
@@ -975,8 +975,93 @@ import XCTest
         XCTAssert(true)
     }
 
+    // MARK: - Pending markRead Tests
+
+    func test_chatChannelVM_sendReadEventIfNeeded_whenLatestMessageIsLocalOnly_thenMarkReadIsNotCalled() {
+        // Given - the latest message is still in flight (e.g., the user's first message
+        // in an empty channel).
+        let pendingMessage = ChatMessage.mock(localState: .pendingSend)
+        let channelController = makeChannelController(messages: [pendingMessage])
+        channelController.channel_mock = .mockDMChannel(reads: [])
+        channelController.hasLoadedAllNextMessages_mock = true
+        let viewModel = ChatChannelViewModel(channelController: channelController)
+        viewModel.currentUserMarkedMessageUnread = false
+        viewModel.throttler = Throttler_Mock(interval: 0)
+
+        // When
+        viewModel.handleMessageAppear(index: 0, scrollDirection: .down)
+
+        // Then - markRead must not be called while the message is still local-only.
+        XCTAssertEqual(0, channelController.markReadCallCount)
+    }
+
+    func test_chatChannelVM_sendReadEventIfNeeded_whenPendingMessageBecomesSent_thenMarkReadIsCalled() {
+        // Given - empty channel that received a local pendingSend message.
+        let messageId: MessageId = .unique
+        let pendingMessage = ChatMessage.mock(id: messageId, localState: .pendingSend)
+        let channelController = makeChannelController(messages: [pendingMessage])
+        channelController.channel_mock = .mockDMChannel(reads: [])
+        channelController.hasLoadedAllNextMessages_mock = true
+        let viewModel = ChatChannelViewModel(channelController: channelController)
+        viewModel.currentUserMarkedMessageUnread = false
+        viewModel.throttler = Throttler_Mock(interval: 0)
+        viewModel.handleMessageAppear(index: 0, scrollDirection: .down)
+        XCTAssertEqual(0, channelController.markReadCallCount)
+
+        // When - the same message transitions to fully sent (localState becomes nil).
+        let sentMessage = ChatMessage.mock(id: messageId, localState: nil)
+        channelController.messages_mock = [sentMessage]
+        let dataSource = ChatChannelDataSource(controller: channelController)
+        viewModel.dataSource(
+            channelDataSource: dataSource,
+            didUpdateMessages: [sentMessage],
+            changes: [.update(sentMessage, index: IndexPath(row: 0, section: 0))]
+        )
+
+        // Then - markRead fires exactly once for the now-sent latest message.
+        XCTAssertEqual(1, channelController.markReadCallCount)
+    }
+
+    func test_chatChannelVM_sendReadEventIfNeeded_whenNonEmptyChannelReceivesPendingMessage_thenMarkReadIsCalledOnlyAfterSent() {
+        // Given - non-empty channel already at the bottom.
+        let existing = ChatMessage.mock(id: .unique, localState: nil)
+        let channelController = makeChannelController(messages: [existing])
+        channelController.channel_mock = .mockDMChannel(reads: [])
+        channelController.hasLoadedAllNextMessages_mock = true
+        let viewModel = ChatChannelViewModel(channelController: channelController)
+        viewModel.currentUserMarkedMessageUnread = false
+        viewModel.throttler = Throttler_Mock(interval: 0)
+        viewModel.handleMessageAppear(index: 0, scrollDirection: .down)
+        let baseline = channelController.markReadCallCount
+
+        // When - user sends a new message; it appears in `.pendingSend` first.
+        let newId: MessageId = .unique
+        let pendingMessage = ChatMessage.mock(id: newId, localState: .pendingSend)
+        channelController.messages_mock = [pendingMessage, existing]
+        let dataSource = ChatChannelDataSource(controller: channelController)
+        viewModel.dataSource(
+            channelDataSource: dataSource,
+            didUpdateMessages: [pendingMessage, existing],
+            changes: [.insert(pendingMessage, index: IndexPath(row: 0, section: 0))]
+        )
+        viewModel.handleMessageAppear(index: 0, scrollDirection: .down)
+        XCTAssertEqual(baseline, channelController.markReadCallCount)
+
+        // When - the new message transitions to sent.
+        let sentMessage = ChatMessage.mock(id: newId, localState: nil)
+        channelController.messages_mock = [sentMessage, existing]
+        viewModel.dataSource(
+            channelDataSource: dataSource,
+            didUpdateMessages: [sentMessage, existing],
+            changes: [.update(sentMessage, index: IndexPath(row: 0, section: 0))]
+        )
+
+        // Then - markRead fires exactly once for the now-sent latest message.
+        XCTAssertEqual(baseline + 1, channelController.markReadCallCount)
+    }
+
     // MARK: - highlightMessage Tests
-    
+
     func test_highlightMessage_highlightsWhenSkipHighlightMessageIdIsNotSet() {
         // Given
         let message = ChatMessage.mock()


### PR DESCRIPTION
### 🔗 Issue Links

[IOS-1697](https://linear.app/stream/issue/IOS-1697)

### 🎯 Goal

Fix an issue where channel is marked read with message which does not exist on the backend side

### 📝 Summary

- Skip `channelController.markRead()` when the latest message is still local-only (`localState != nil` / `.pendingSend` / `.sending` / `.sendingFailed`).
- Cache only the `MessageId` of the pending message and look up the live version in `dataSource(_:didUpdateMessages:changes:)`; once it is no longer `isLocalOnly`, fire the read event.
- Generalised — applies to both empty and non-empty channels.

### 🛠 Implementation

When the user sends the very first message into an empty channel, `ChatChannelViewModel` was queuing `channelController.markRead()` before that message had been persisted server-side. The read receipt referred to a message the server didn't yet know about — wasted call at best, and a stale `lastReadMessageId` at worst. The same race shows up in non-empty channels whenever the user is at the bottom and just hit send.

Read state should only be sent after the latest message's sending status has settled.

`ChatChannelViewModel` gained one piece of state, `pendingMarkReadMessageId: MessageId?`.

- In `sendReadEventIfNeeded(for:)`, after the existing `currentUserMarkedMessageUnread` and `lastReadAt > createdAt` short-circuits, we check `message.isLocalOnly`. If true, we stash `message.id` and return without throttling `markRead`.
- At the end of `dataSource(_:didUpdateMessages:changes:)`, after the messages array and scroll state are updated, we look up the live message by id (`self.messages.first(where:)`) and only retry `sendReadEventIfNeeded` if that live message is no longer `isLocalOnly`. Caching only the id (not the struct copy) avoids the stale-snapshot trap — `ChatMessage` is a value type with a `let localState`, so a cached snapshot would never reflect the transition to sent.

If the pending message is deleted or replaced before it becomes sent, the lookup simply returns nil and nothing happens; the next legitimate read event seeds the id again.

### 🎨 Showcase

N/A — no user-visible UI change. The fix removes a stale-state API call.

### 🧪 Manual Testing Notes

1. **Empty channel.** Open a brand-new DM that has no messages. Send the first message. Observe `ChannelUpdater.markRead` (e.g. via Charles, log, or breakpoint). Before this PR it fires once almost immediately while the bubble still shows the "sending" indicator. After this PR it only fires after the bubble shows as sent.
2. **Non-empty channel, user sends a new message.** Open a channel with existing messages, scroll to the bottom, send a new message. Confirm `markRead` only fires once the new bubble transitions to sent.
3. **Failed send.** Toggle airplane mode and send a message — it should land in `.sendingFailed`. Confirm `markRead` is **not** invoked for it. Going back online and retrying should eventually fire `markRead` once the message is fully sent.
4. **Incoming message.** Behaviour unchanged: a message that arrives from another user (no `localState`) still triggers `markRead` once the cell appears.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo