### PR TITLE
Improve VoiceOver experience for the attachment picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+### ✅ Added
+- Improve VoiceOver experience for the attachment picker [#1456](https://github.com/GetStream/stream-chat-swiftui/pull/1456)
+
 ### 🔄 Changed
 
 # [5.2.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/5.2.0)

--- a/Sources/StreamChatSwiftUI/ChatComposer/AttachmentPicker/AttachmentCameraPickerView.swift
+++ b/Sources/StreamChatSwiftUI/ChatComposer/AttachmentPicker/AttachmentCameraPickerView.swift
@@ -36,6 +36,7 @@ struct AttachmentCameraPickerView: View {
                 .fullScreenCover(isPresented: $cameraPickerShown) {
                     CameraImagePickerView(cameraImageAdded: cameraImageAdded)
                 }
+                .restoresAccessibilityFocusOnDismiss(of: $cameraPickerShown)
                 .onLoad {
                     openCamera()
                 }
@@ -129,7 +130,7 @@ struct AttachmentImagePickerView: UIViewControllerRepresentable {
     var onAssetPicked: (AddedAsset) -> Void
 
     func makeUIViewController(context: Context) -> UIImagePickerController {
-        let pickerController = UIImagePickerController()
+        let pickerController = StreamCameraImagePickerController()
         pickerController.delegate = context.coordinator
         if UIImagePickerController.isSourceTypeAvailable(sourceType) {
             pickerController.sourceType = sourceType
@@ -156,6 +157,18 @@ struct AttachmentImagePickerView: UIViewControllerRepresentable {
     }
 
     typealias Coordinator = ImagePickerCoordinator
+}
+
+/// `UIImagePickerController` subclass that clears the accessibility label
+/// inherited from the SDK module so VoiceOver stops announcing "StreamChat"
+/// in between Apple's native camera elements (e.g. "Viewfinder, StreamChat,
+/// flash auto focus").
+private final class StreamCameraImagePickerController: UIImagePickerController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        accessibilityLabel = ""
+        view.accessibilityLabel = ""
+    }
 }
 
 final class ImagePickerCoordinator: NSObject, UIImagePickerControllerDelegate, UINavigationControllerDelegate {

--- a/Sources/StreamChatSwiftUI/ChatComposer/AttachmentPicker/AttachmentCommandsPickerView.swift
+++ b/Sources/StreamChatSwiftUI/ChatComposer/AttachmentPicker/AttachmentCommandsPickerView.swift
@@ -30,21 +30,20 @@ public struct AttachmentCommandsPickerView: View {
                 VStack(spacing: 0) {
                     ForEach(instantCommands, id: \.id) { command in
                         if let displayInfo = command.displayInfo {
-                            AttachmentCommandRow(displayInfo: displayInfo)
-                                .contentShape(Rectangle())
-                                .highPriorityGesture(
-                                    TapGesture().onEnded {
-                                        let composerCommand = ComposerCommand(
-                                            id: command.id,
-                                            typingSuggestion: TypingSuggestion.empty,
-                                            displayInfo: displayInfo,
-                                            replacesMessageSent: command.replacesMessageSent
-                                        )
-                                        onCommandSelected(composerCommand)
-                                    }
+                            Button {
+                                let composerCommand = ComposerCommand(
+                                    id: command.id,
+                                    typingSuggestion: TypingSuggestion.empty,
+                                    displayInfo: displayInfo,
+                                    replacesMessageSent: command.replacesMessageSent
                                 )
-                                .accessibilityElement(children: .contain)
-                                .accessibilityIdentifier("AttachmentCommandView_\(command.id)")
+                                onCommandSelected(composerCommand)
+                            } label: {
+                                AttachmentCommandRow(displayInfo: displayInfo)
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityElement(children: .combine)
+                            .accessibilityIdentifier("AttachmentCommandView_\(command.id)")
                         }
                     }
                 }

--- a/Sources/StreamChatSwiftUI/ChatComposer/AttachmentPicker/AttachmentFilePickerView.swift
+++ b/Sources/StreamChatSwiftUI/ChatComposer/AttachmentPicker/AttachmentFilePickerView.swift
@@ -22,6 +22,7 @@ struct AttachmentFilePickerView: View {
                 onFilesPicked(urls)
             })
         }
+        .restoresAccessibilityFocusOnDismiss(of: $filePickerShown)
         .onLoad {
             filePickerShown = true
         }

--- a/Sources/StreamChatSwiftUI/ChatComposer/Polls/CreatePollViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatComposer/Polls/CreatePollViewModel.swift
@@ -213,6 +213,7 @@ import SwiftUI
             switch result {
             case let .success(messageId):
                 log.debug("Created poll in message with id \(messageId)")
+                ComposerAccessibilityAnnouncer.announce(L10n.Composer.Polls.Accessibility.pollAdded)
                 completion()
             case let .failure(error):
                 log.error("Error creating a poll: \(error.localizedDescription)")

--- a/Sources/StreamChatSwiftUI/Generated/L10n.swift
+++ b/Sources/StreamChatSwiftUI/Generated/L10n.swift
@@ -431,6 +431,8 @@ internal enum L10n {
         internal static var decreaseVoteLimit: String { L10n.tr("Localizable", "composer.polls.accessibility.decrease-vote-limit") }
         /// Increase vote limit
         internal static var increaseVoteLimit: String { L10n.tr("Localizable", "composer.polls.accessibility.increase-vote-limit") }
+        /// Poll added to message
+        internal static var pollAdded: String { L10n.tr("Localizable", "composer.polls.accessibility.poll-added") }
         /// Reorder option
         internal static var reorderOption: String { L10n.tr("Localizable", "composer.polls.accessibility.reorder-option") }
         /// Option %1$lld of %2$lld

--- a/Sources/StreamChatSwiftUI/Resources/en.lproj/Localizable.strings
+++ b/Sources/StreamChatSwiftUI/Resources/en.lproj/Localizable.strings
@@ -204,6 +204,7 @@
 "composer.polls.accessibility.decrease-vote-limit" = "Decrease vote limit";
 "composer.polls.accessibility.increase-vote-limit" = "Increase vote limit";
 "composer.polls.accessibility.vote-limit" = "Vote limit";
+"composer.polls.accessibility.poll-added" = "Poll added to message";
 "composer.audio-recording.start" = "Start recording audio message";
 "composer.audio-recording.stop" = "Stop recording audio message";
 

--- a/Sources/StreamChatSwiftUI/Utils/Accessibility/AccessibilityFocusRestoration.swift
+++ b/Sources/StreamChatSwiftUI/Utils/Accessibility/AccessibilityFocusRestoration.swift
@@ -1,0 +1,51 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import SwiftUI
+import UIKit
+
+extension View {
+    /// Returns VoiceOver focus to this view when the presentation binding
+    /// flips from `true` to `false`.
+    ///
+    /// Native modal/sheet dismissal sometimes leaves VoiceOver focus orphaned
+    /// on a stale element (commonly the back button or the channel header)
+    /// instead of returning it to the originating element. This modifier
+    /// keeps a small delay so the dismissal animation can settle before
+    /// VoiceOver moves focus.
+    ///
+    /// Uses `@AccessibilityFocusState` on iOS 15+. On iOS 14 it falls back
+    /// to a `screenChanged` notification so VoiceOver at least re-picks a
+    /// focusable element on the current screen.
+    @ViewBuilder
+    func restoresAccessibilityFocusOnDismiss(of isPresented: Binding<Bool>) -> some View {
+        if #available(iOS 15.0, *) {
+            modifier(RestoresAccessibilityFocusOnDismissModifier(isPresented: isPresented))
+        } else {
+            onChange(of: isPresented.wrappedValue) { isShown in
+                guard !isShown else { return }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    UIAccessibility.post(notification: .screenChanged, argument: nil)
+                }
+            }
+        }
+    }
+}
+
+@available(iOS 15.0, *)
+private struct RestoresAccessibilityFocusOnDismissModifier: ViewModifier {
+    @Binding var isPresented: Bool
+    @AccessibilityFocusState private var isFocused: Bool
+
+    func body(content: Content) -> some View {
+        content
+            .accessibilityFocused($isFocused)
+            .onChange(of: isPresented) { isShown in
+                guard !isShown else { return }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    isFocused = true
+                }
+            }
+    }
+}


### PR DESCRIPTION
### 🔗 Issue Links

- [IOS-1692](https://linear.app/stream/issue/IOS-1692/swiftui-accessibility-attachment-picker-camera-files-commands-tab-and)

### 🎯 Goal

Address the Notion accessibility audit findings for the Attachment Picker (Component = Camera / Files / Commands tab and the cross-cutting modal-dismissal pattern).

### 📝 Summary

- \`audit-32\` — Stop the SDK module label from leaking into Apple's native camera UI. VoiceOver previously announced \"Viewfinder, StreamChat, flash auto focus\"; \`StreamChat\` is now cleared so only Apple's own labels are read.
- \`audit-48\` — Scope each row in the Attachment Picker's Commands tab as a single accessibility element, matching the composer-side instant commands list that already announces correctly as one element per command.
- \`audit-33\` / \`audit-31\` — After dismissing the native file picker, return VoiceOver focus to the originating \"Open Files\" prompt instead of letting it land on a stale element.
- \`audit-31\` — Apply the same focus-restoration pattern to the camera tab so dismissing the camera returns focus to the \"Open Camera\" prompt.
- \`audit-31\` — Post a \"Poll added to message\" VoiceOver announcement when the Create Poll sheet completes successfully, so VoiceOver users know the action was performed.

### 🛠 Implementation

- \`AttachmentCameraPickerView.swift\`
  - Introduced a private \`StreamCameraImagePickerController: UIImagePickerController\` subclass that clears \`accessibilityLabel\` (and \`view.accessibilityLabel\`) in \`viewDidLoad\`. \`AttachmentImagePickerView\` now instantiates this subclass instead of \`UIImagePickerController\` directly.
  - Applied \`restoresAccessibilityFocusOnDismiss(of: \$cameraPickerShown)\` to the \`CameraOpenPromptView\` so focus returns to the \"Open Camera\" button on dismiss.
- \`AttachmentFilePickerView.swift\`
  - Applied \`restoresAccessibilityFocusOnDismiss(of: \$filePickerShown)\` to the \`FileOpenPromptView\`.
- \`AttachmentCommandsPickerView.swift\`
  - Wrapped each row in a \`Button { ... } label: { AttachmentCommandRow(...) }\` with \`.buttonStyle(.plain)\` (to preserve the existing visuals) and \`.accessibilityElement(children: .combine)\` so VoiceOver reads each command as a single \"\\[name\\], \\[syntax\\]\" element. This mirrors \`CommandSuggestionsView\` on the composer side.
- \`Utils/Accessibility/AccessibilityFocusRestoration.swift\` (new)
  - Adds \`View.restoresAccessibilityFocusOnDismiss(of:)\`. On iOS 15+ this uses \`@AccessibilityFocusState\` to move focus back to the originating element after a small delay (so the dismissal animation can settle). On iOS 14 it posts a \`screenChanged\` notification with a \`nil\` argument so VoiceOver at least re-picks a focusable element on the current screen.
- \`CreatePollViewModel.swift\`
  - On successful poll creation, calls \`ComposerAccessibilityAnnouncer.announce(L10n.Composer.Polls.Accessibility.pollAdded)\` before the dismiss completion so VoiceOver users hear \"Poll added to message\".
- \`Localizable.strings\` / \`L10n.swift\`
  - New key \`composer.polls.accessibility.poll-added\` = \"Poll added to message\". \`L10n.swift\` regenerated via SwiftGen.
 
### 🧪 Manual Testing Notes

1. Enable VoiceOver and open the channel attachment picker.
2. Switch to the **Commands** tab. Swipe through the commands list and confirm each row is read as a single element (e.g. \"Giphy, /giphy\\[text\\]\", \"Mute, /mute\\[@username\\]\") rather than three separate stops per row.
3. Switch to the **Files** tab. Tap \"Open Files\" to present the native picker, then dismiss it with Cancel. VoiceOver focus should return to the \"Open Files\" button on the Files tab.
4. Switch to the **Camera** tab. Open the camera and confirm VoiceOver no longer announces \"StreamChat\" between Apple's own labels (\"Viewfinder\", \"flash auto\", \"focus\"). Dismiss the camera and confirm focus returns to the \"Open Camera\" button.
5. From the attachment picker, open the **Create Poll** sheet, fill in a question and at least one option, and tap Save. VoiceOver should announce \"Poll added to message\" once the poll is successfully created.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the \`docs-content\` repo