### PR TITLE
Improve VoiceOver experience for attachment picker trigger, tabs, and photos gallery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # Upcoming
 
 ### ✅ Added
-- Improve VoiceOver experience for the attachment picker trigger button, tab bar, and photos gallery [#1457](https://github.com/GetStream/stream-chat-swiftui/pull/1457)
-- Improve VoiceOver experience for the attachment picker [#1456](https://github.com/GetStream/stream-chat-swiftui/pull/1456)
+- Improve VoiceOver experience for the attachment picker [#1456](https://github.com/GetStream/stream-chat-swiftui/pull/1456) [#1457](https://github.com/GetStream/stream-chat-swiftui/pull/1457)
 
 ### 🔄 Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # Upcoming
 
 ### ✅ Added
+- Improve VoiceOver experience for the attachment picker trigger button, tab bar, and photos gallery [#1457](https://github.com/GetStream/stream-chat-swiftui/pull/1457)
 - Improve VoiceOver experience for the attachment picker [#1456](https://github.com/GetStream/stream-chat-swiftui/pull/1456)
 
 ### 🔄 Changed

--- a/Sources/StreamChatSwiftUI/ChatComposer/AttachmentPicker/AttachmentMediaPicker/AttachmentMediaPickerItemView.swift
+++ b/Sources/StreamChatSwiftUI/ChatComposer/AttachmentPicker/AttachmentMediaPicker/AttachmentMediaPickerItemView.swift
@@ -68,25 +68,7 @@ public struct AttachmentMediaPickerItemView: View {
                             .allowsHitTesting(true)
                             .onTapGesture {
                                 withAnimation {
-                                    let resolvedURL = asset.mediaType == .image ? assetJpgURL() : assetURL
-                                    if let url = resolvedURL {
-                                        let width = Double(asset.pixelWidth)
-                                        let height = Double(asset.pixelHeight)
-                                        let durationSeconds: TimeInterval? = asset.mediaType == .video ? asset.duration : nil
-                                        onImageTap(
-                                            AddedAsset(
-                                                image: image,
-                                                id: asset.localIdentifier,
-                                                url: url,
-                                                type: assetType,
-                                                extraData: asset.mediaType == .video ? ["duration": .number(asset.duration)] : [:],
-                                                originalWidth: width > 0 ? width : nil,
-                                                originalHeight: height > 0 ? height : nil,
-                                                duration: durationSeconds
-                                            )
-                                        )
-                                    }
-                                    idOverlay = UUID()
+                                    handleAssetTap(image: image, currentlySelected: selected)
                                 }
                             }
                     }
@@ -127,8 +109,17 @@ public struct AttachmentMediaPickerItemView: View {
                 }
             }
             .allowsHitTesting(false)
+            .accessibilityHidden(true)
             .id(idOverlay)
         )
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityAddTraits(.isButton)
+        .accessibilityAddTraits(selected ? .isSelected : [])
+        .accessibilityAction {
+            guard let image = assetLoader.loadedImages[asset.localIdentifier] else { return }
+            handleAssetTap(image: image, currentlySelected: selected)
+        }
         .onAppear {
             loading = false
             
@@ -171,6 +162,61 @@ public struct AttachmentMediaPickerItemView: View {
 
     private var assetDurationText: String {
         utils.mediaBadgeDurationFormatter.longFormat(asset.duration)
+    }
+
+    private var accessibilityLabel: String {
+        switch asset.mediaType {
+        case .video:
+            let duration = Self.accessibilityDurationFormatter.string(from: asset.duration) ?? assetDurationText
+            return L10n.Composer.MediaPicker.Accessibility.video(duration)
+        default:
+            return L10n.Composer.MediaPicker.Accessibility.photo
+        }
+    }
+
+    private static let accessibilityDurationFormatter: DateComponentsFormatter = {
+        let formatter = DateComponentsFormatter()
+        formatter.unitsStyle = .full
+        formatter.allowedUnits = [.hour, .minute, .second]
+        formatter.zeroFormattingBehavior = .dropLeading
+        return formatter
+    }()
+
+    private func handleAssetTap(image: UIImage, currentlySelected: Bool) {
+        let resolvedURL = asset.mediaType == .image ? assetJpgURL() : assetURL
+        guard let url = resolvedURL else { return }
+        let width = Double(asset.pixelWidth)
+        let height = Double(asset.pixelHeight)
+        let durationSeconds: TimeInterval? = asset.mediaType == .video ? asset.duration : nil
+        onImageTap(
+            AddedAsset(
+                image: image,
+                id: asset.localIdentifier,
+                url: url,
+                type: assetType,
+                extraData: asset.mediaType == .video ? ["duration": .number(asset.duration)] : [:],
+                originalWidth: width > 0 ? width : nil,
+                originalHeight: height > 0 ? height : nil,
+                duration: durationSeconds
+            )
+        )
+        idOverlay = UUID()
+        announceSelectionChange(willBeSelected: !currentlySelected)
+    }
+
+    private func announceSelectionChange(willBeSelected: Bool) {
+        let message: String
+        switch (asset.mediaType, willBeSelected) {
+        case (.video, true):
+            message = L10n.Composer.MediaPicker.Accessibility.videoAdded
+        case (.video, false):
+            message = L10n.Composer.MediaPicker.Accessibility.videoRemoved
+        case (_, true):
+            message = L10n.Composer.MediaPicker.Accessibility.photoAdded
+        case (_, false):
+            message = L10n.Composer.MediaPicker.Accessibility.photoRemoved
+        }
+        ComposerAccessibilityAnnouncer.announce(message)
     }
 
     /// The original photo is usually in HEIC format.

--- a/Sources/StreamChatSwiftUI/ChatComposer/AttachmentPicker/AttachmentMediaPicker/AttachmentMediaPickerView.swift
+++ b/Sources/StreamChatSwiftUI/ChatComposer/AttachmentPicker/AttachmentMediaPicker/AttachmentMediaPickerView.swift
@@ -75,6 +75,11 @@ public struct AttachmentMediaPickerView: View {
             }
             .animation(nil)
         }
+        .onChange(of: collection.count) { _ in
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                UIAccessibility.post(notification: .screenChanged, argument: nil)
+            }
+        }
     }
 
     private var accessDeniedContent: some View {

--- a/Sources/StreamChatSwiftUI/ChatComposer/AttachmentPicker/AttachmentTypePickerView.swift
+++ b/Sources/StreamChatSwiftUI/ChatComposer/AttachmentPicker/AttachmentTypePickerView.swift
@@ -115,5 +115,6 @@ public struct AttachmentTypePickerButton: View {
                 .customizable()
                 .frame(width: 18, height: 18)
         }
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
 }

--- a/Sources/StreamChatSwiftUI/ChatComposer/Buttons/ComposerAttachmentPickerButton.swift
+++ b/Sources/StreamChatSwiftUI/ChatComposer/Buttons/ComposerAttachmentPickerButton.swift
@@ -37,10 +37,12 @@ public struct ComposerAttachmentPickerButton<Factory: ViewFactory>: View, Keyboa
                 .frame(width: tokens.iconSizeMd, height: tokens.iconSizeMd)
                 .foregroundColor(Color(colors.buttonSecondaryText))
                 .rotationEffect(.degrees(isExpanded ? 45 : 0))
+                .padding(tokens.buttonPaddingYLg)
+                .contentShape(Rectangle())
         }
-        .padding(tokens.buttonPaddingYLg)
         .foregroundColor(Color(colors.buttonSecondaryText))
         .modifier(factory.styles.makeComposerButtonViewModifier(options: .init()))
+        .accessibilityLabel(isExpanded ? L10n.Composer.Attachment.Accessibility.close : L10n.Composer.Attachment.Accessibility.open)
         .onChange(of: pickerTypeState) { _ in
             triggerHapticFeedback(style: .soft)
         }

--- a/Sources/StreamChatSwiftUI/Generated/L10n.swift
+++ b/Sources/StreamChatSwiftUI/Generated/L10n.swift
@@ -289,6 +289,14 @@ internal enum L10n {
   }
 
   internal enum Composer {
+    internal enum Attachment {
+      internal enum Accessibility {
+        /// Close attachments
+        internal static var close: String { L10n.tr("Localizable", "composer.attachment.accessibility.close") }
+        /// Add attachment
+        internal static var `open`: String { L10n.tr("Localizable", "composer.attachment.accessibility.open") }
+      }
+    }
     internal enum AudioRecording {
       /// Start recording audio message
       internal static var start: String { L10n.tr("Localizable", "composer.audio-recording.start") }
@@ -364,6 +372,24 @@ internal enum L10n {
       internal static var accessSettings: String { L10n.tr("Localizable", "composer.images.access-settings") }
       /// You have not granted access to the photo library.
       internal static var noAccessLibrary: String { L10n.tr("Localizable", "composer.images.no-access-library") }
+    }
+    internal enum MediaPicker {
+      internal enum Accessibility {
+        /// Photo
+        internal static var photo: String { L10n.tr("Localizable", "composer.media-picker.accessibility.photo") }
+        /// Photo added to message
+        internal static var photoAdded: String { L10n.tr("Localizable", "composer.media-picker.accessibility.photo-added") }
+        /// Photo removed from message
+        internal static var photoRemoved: String { L10n.tr("Localizable", "composer.media-picker.accessibility.photo-removed") }
+        /// Video, %@
+        internal static func video(_ p1: Any) -> String {
+          return L10n.tr("Localizable", "composer.media-picker.accessibility.video", String(describing: p1))
+        }
+        /// Video added to message
+        internal static var videoAdded: String { L10n.tr("Localizable", "composer.media-picker.accessibility.video-added") }
+        /// Video removed from message
+        internal static var videoRemoved: String { L10n.tr("Localizable", "composer.media-picker.accessibility.video-removed") }
+      }
     }
     internal enum Picker {
       /// Cancel

--- a/Sources/StreamChatSwiftUI/Resources/en.lproj/Localizable.strings
+++ b/Sources/StreamChatSwiftUI/Resources/en.lproj/Localizable.strings
@@ -205,6 +205,14 @@
 "composer.polls.accessibility.increase-vote-limit" = "Increase vote limit";
 "composer.polls.accessibility.vote-limit" = "Vote limit";
 "composer.polls.accessibility.poll-added" = "Poll added to message";
+"composer.attachment.accessibility.open" = "Add attachment";
+"composer.attachment.accessibility.close" = "Close attachments";
+"composer.media-picker.accessibility.photo" = "Photo";
+"composer.media-picker.accessibility.video" = "Video, %@";
+"composer.media-picker.accessibility.photo-added" = "Photo added to message";
+"composer.media-picker.accessibility.photo-removed" = "Photo removed from message";
+"composer.media-picker.accessibility.video-added" = "Video added to message";
+"composer.media-picker.accessibility.video-removed" = "Video removed from message";
 "composer.audio-recording.start" = "Start recording audio message";
 "composer.audio-recording.stop" = "Stop recording audio message";
 


### PR DESCRIPTION
### 🔗 Issue Links

- [IOS-1690](https://linear.app/stream/issue/IOS-1690/swiftui-accessibility-attachment-picker-trigger-button-tabs-and-photos)

### 🎯 Goal

Continue the SwiftUI v5 accessibility audit work by fixing 10 VoiceOver issues across the attachment picker trigger button, tab bar, and photos gallery.

### 📝 Summary

**Trigger button**
- The trigger button now exposes a dynamic, action-based accessibility label that switches between "Add attachment" (closed) and "Close attachments" (open), instead of the generic "Add" inferred from the icon asset.
- Padding has been moved inside the `Button` label and the content shape has been made explicit so the whole button surface (icon + surrounding padding) is one accessibility focus scope and tap target.

**Tab bar**
- The active attachment type tab now carries the `.isSelected` accessibility trait, so VoiceOver announces "Photos, selected" / "Files, selected" instead of just the tab label.

**Photos gallery**
- Each thumbnail is now a single accessibility element with the correct order and a meaningful label: "Photo" for images and a localized `"Video, 6 seconds"` style label for videos (built with `DateComponentsFormatter` so the duration is spelled out properly instead of being read out character by character from the visual badge).
- Selection is expressed via the `.isSelected` trait on the cell itself rather than via the visual checkmark badge, so VoiceOver announces the state change instead of "Selected, image, tick".
- The dimming overlay, selection badge and duration badge are hidden from VoiceOver in this context so the cell can speak for itself, and an explicit `.accessibilityAction` is provided so VoiceOver users can activate the cell as a single element.
- A separate status announcement ("Photo / Video added to message" / "Photo / Video removed from message") is posted via the shared `ComposerAccessibilityAnnouncer` when the user toggles selection.

**Photos permission dialog**
- When the underlying photo library asset count changes (typically after the native "Add more / Keep current selection" dialog dismisses), a `screenChanged` notification is posted so VoiceOver focus returns to the gallery instead of drifting to an unrelated element behind the picker.

### 🛠 Implementation

- `ComposerAttachmentPickerButton`: padding moved inside the `Button` label, `contentShape(Rectangle())` added on the label, and a dynamic `accessibilityLabel` driven by `isExpanded`.
- `AttachmentTypePickerView`: each `AttachmentTypePickerButton` now adds `.isSelected` to its accessibility traits when active.
- `AttachmentMediaPickerItemView`: refactored to expose a single accessibility element with a computed `accessibilityLabel`, `.isButton` + conditional `.isSelected` traits, and an `.accessibilityAction` that delegates to a shared `handleAssetTap(image:currentlySelected:)`. The status announcement is posted right after `onImageTap` so the wording reflects whether the asset was just added or removed. The visual overlays are marked `.accessibilityHidden(true)` so they no longer become VoiceOver focus stops.
- `AttachmentMediaPickerView`: `onChange(of: collection.count)` posts `.screenChanged` (with a small delay to let SwiftUI settle) so VoiceOver lands back on the gallery after the limited-library dialog.
- New localization keys under `composer.attachment.accessibility.*` and `composer.media-picker.accessibility.*`, regenerated via SwiftGen.

### 🧪 Manual Testing Notes

1. Open a channel with VoiceOver enabled.
2. Focus the trigger button next to the composer: it should announce "Add attachment, button" while closed and "Close attachments, button" while open, and the focus rectangle should wrap the whole tap area, not just the icon.
3. Open the attachment picker and swipe through the tabs (Photos / Camera / Files / Polls / Commands): the active tab should announce "Photos, selected" (or equivalent) and tapping a tab should immediately update the announced selection state.
4. In the Photos tab, swipe through thumbnails: each should announce "Photo" or "Video, N seconds" as a single focus stop with the focus rectangle matching the cell bounds. Double-tap to select: VoiceOver should say "Selected" followed by "Photo added to message" / "Video added to message". Double-tap again to deselect and confirm the removal announcement.
5. With limited photo library access, trigger the native "Add more / Keep current selection" dialog from the system prompt and confirm that VoiceOver focus returns to the gallery once the dialog dismisses.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo