### PR TITLE
Restore open access on ChatChannelInfoViewModel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🐞 Fixed
 - Fix RTL layout issues in the channel list swipe actions and channel preview [#1459](https://github.com/GetStream/stream-chat-swiftui/pull/1459)
+- Restore `open` access on `ChatChannelInfoViewModel` so it can be subclassed again [#1460](https://github.com/GetStream/stream-chat-swiftui/pull/1460)
 
 ### 🔄 Changed
 

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/ChatChannelInfoViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/ChatChannelInfoViewModel.swift
@@ -8,7 +8,7 @@ import StreamChat
 import SwiftUI
 
 // View model for the `ChatChannelInfoView`.
-@MainActor public class ChatChannelInfoViewModel: ObservableObject, ChatChannelControllerDelegate {
+@MainActor open class ChatChannelInfoViewModel: ObservableObject, ChatChannelControllerDelegate {
     @Injected(\.chatClient) private var chatClient
     @Injected(\.utils) private var utils
     @Injected(\.images) private var images


### PR DESCRIPTION
### 🔗 Issue Links

- [IOS-1705](https://linear.app/stream/issue/IOS-1705)

### 🎯 Goal

Restore the ability for SDK consumers to subclass `ChatChannelInfoViewModel`. The V5 refactor inadvertently downgraded the class from `open` to `public`, which breaks customers that override channel-info behavior in their own subclass.

### 📝 Summary

- Change `ChatChannelInfoViewModel` from `public class` back to `open class`.

### 🛠 Implementation

Single one-line access-modifier change on the class declaration. The individual `open` members on the type were preserved during the V5 refactor; only the class keyword was downgraded, so restoring it is sufficient.

### 🎨 Showcase

_N/A — access-modifier change, no UI impact._

### 🧪 Manual Testing Notes

In a host app that depends on this SDK, define `class MyVM: ChatChannelInfoViewModel { ... }` in a separate module and confirm the compiler accepts it. Before this fix the compiler emits "Cannot inherit from non-open class 'ChatChannelInfoViewModel' outside of its defining module".

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo