### PR TITLE
Update visibility of info screen buttons based on capabilities

### DIFF
--- a/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/ChatChannelInfoView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/ChatChannelInfoView.swift
@@ -363,7 +363,7 @@ struct ChatChannelInfoViewHeaderViewModifier: ViewModifier {
         }
 
         ToolbarItem(placement: .navigationBarTrailing) {
-            if !viewModel.showSingleMemberDMView {
+            if !viewModel.showSingleMemberDMView && viewModel.channel.canUpdateChannel {
                 editButton
             }
         }

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/ChatChannelInfoViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/ChatChannelInfoViewModel.swift
@@ -370,7 +370,7 @@ import SwiftUI
     open func participantActions(for participant: ParticipantInfo) -> [ParticipantAction] {
         if participant.id == chatClient.currentUserId {
             var actions = [ParticipantAction]()
-            if !showSingleMemberDMView {
+            if !showSingleMemberDMView && shouldShowLeaveConversationButton {
                 actions.append(leaveGroupAction(
                     onDismiss: handleParticipantActionDismiss,
                     onError: handleParticipantActionError


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://github.com/GetStream/stream-chat-swiftui/issues/1467 and https://github.com/GetStream/stream-chat-swiftui/issues/1466.

### 🎯 Goal

Fix visibility of edit button and leave button based on capabilities.

### 📝 Summary

_Provide bullet points with the most important changes in the codebase._

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed channel edit button visibility to respect user permissions in channel information views.
  * Improved leave conversation action availability to only show when appropriate for the conversation type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->