### PR TITLE
Support actions menu and reactions in voice over

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # Upcoming
 
 ### 🔄 Changed
+- Improve VoiceOver support for the message reactions and actions overlay [#1491](https://github.com/GetStream/stream-chat-swiftui/pull/1491)
 
 # [5.5.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/5.5.0)
 _June 03, 2026_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🔄 Changed
 - Improve VoiceOver support for the message reactions and actions overlay [#1491](https://github.com/GetStream/stream-chat-swiftui/pull/1491)
+### 🎭 New Localizations
+- `message.reactions.more` — VoiceOver label for the "more reactions" button in the reactions overlay
 
 # [5.5.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/5.5.0)
 _June 03, 2026_

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelView.swift
@@ -153,6 +153,11 @@ public struct ChatChannelView<Factory: ViewFactory>: View, KeyboardReadable {
                     }
                     .opacity(0) // Fixes showing accessibility button shape
                 }
+                // While the reactions overlay is shown it acts as a modal: hide the
+                // chat content behind it so VoiceOver only exposes the overlay's
+                // reactions and message actions. Applied before `.overlay` so the
+                // overlay itself stays accessible.
+                .accessibilityHidden(viewModel.reactionsShown)
                 .overlay(
                     viewModel.currentSnapshot != nil && messageDisplayInfo != nil && viewModel.reactionsShown ?
                         factory.makeReactionsOverlayView(
@@ -182,6 +187,7 @@ public struct ChatChannelView<Factory: ViewFactory>: View, KeyboardReadable {
                         composerView
                             .padding(.bottom, floatingComposerBottomPadding)
                             .opacity(viewModel.reactionsShown ? 0 : 1)
+                            .accessibilityHidden(viewModel.reactionsShown)
                     }
                 ))
             } else {

--- a/Sources/StreamChatSwiftUI/ChatMessageList/MessageItemView.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/MessageItemView.swift
@@ -192,7 +192,8 @@ public struct MessageItemView<Factory: ViewFactory>: View {
 // MARK: - Message Actions Gesture
 
 /// Attaches the double-tap and long-press gestures that open the message actions
-/// overlay on a `MessageItemView`.
+/// overlay on a `MessageItemView`, plus a default accessibility action so the
+/// overlay can be opened with a single VoiceOver double tap.
 ///
 /// When the message is rendered as a preview inside the reactions overlay
 /// (`shownAsPreview == true`), both gestures are intentionally skipped. Keeping
@@ -216,7 +217,15 @@ struct MessageActionsGestureModifier: ViewModifier {
         if shownAsPreview {
             content
         } else {
-            let withTap = content.onTapGesture(count: 2) {
+            // VoiceOver delivers its activation gesture (the "double tap") as a
+            // single synthesized tap, which matches neither the count-2 tap nor the
+            // long press below, so neither fires for VoiceOver users. Expose the
+            // actions overlay as the element's default accessibility action so a
+            // single VoiceOver double tap opens it reliably.
+            let base = content.accessibilityAction {
+                onActionsTriggered()
+            }
+            let withTap = base.onTapGesture(count: 2) {
                 if isDoubleTapEnabled {
                     onActionsTriggered()
                 }

--- a/Sources/StreamChatSwiftUI/ChatMessageList/Reactions/MessageActions/MessageActionsView.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/Reactions/MessageActions/MessageActionsView.swift
@@ -38,6 +38,8 @@ public struct MessageActionsView: View {
                                 bundle: bundle
                             )
                         }
+                        .accessibilityLabel(action.title)
+                        .accessibilityAddTraits(.isButton)
                     } else {
                         Button {
                             if action.confirmationPopup != nil {
@@ -54,6 +56,8 @@ public struct MessageActionsView: View {
                                 bundle: bundle
                             )
                         }
+                        .accessibilityLabel(action.title)
+                        .accessibilityAddTraits(.isButton)
                     }
 
                     Divider()

--- a/Sources/StreamChatSwiftUI/ChatMessageList/Reactions/MessageActions/MessageActionsView.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/Reactions/MessageActions/MessageActionsView.swift
@@ -39,7 +39,6 @@ public struct MessageActionsView: View {
                             )
                         }
                         .accessibilityLabel(action.title)
-                        .accessibilityAddTraits(.isButton)
                     } else {
                         Button {
                             if action.confirmationPopup != nil {
@@ -57,7 +56,6 @@ public struct MessageActionsView: View {
                             )
                         }
                         .accessibilityLabel(action.title)
-                        .accessibilityAddTraits(.isButton)
                     }
 
                     Divider()

--- a/Sources/StreamChatSwiftUI/ChatMessageList/Reactions/ReactionsOverlayContainer.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/Reactions/ReactionsOverlayContainer.swift
@@ -154,9 +154,6 @@ public struct ReactionAnimatableView: View {
                     .resizable()
                     .scaledToFit()
                     .frame(width: useLargeIcons ? 25 : 20, height: useLargeIcons ? 27 : 20)
-                    .accessibilityLabel(reactionAccessibilityLabel)
-                    .accessibilityAddTraits(isUserReaction ? [.isButton, .isSelected] : .isButton)
-                    .accessibilityHint(isUserReaction ? L10n.Message.Reactions.tapToRemove : "")
             }
             .frame(width: ButtonSize.large, height: ButtonSize.large)
             .background(reactionSelectedBackgroundColor(for: reaction)?.clipShape(Circle()))
@@ -176,7 +173,12 @@ public struct ReactionAnimatableView: View {
                     animationStates[index] = 1
                 }
             }
-            .accessibilityElement(children: .contain)
+            // VoiceOver announces the whole button as one element: the emoji name,
+            // a selected state and a "tap to remove" hint when the current user has
+            // already added this reaction. The button trait is already implied.
+            .accessibilityLabel(reactionAccessibilityLabel)
+            .accessibilityAddTraits(isUserReaction ? .isSelected : [])
+            .accessibilityHint(isUserReaction ? L10n.Message.Reactions.tapToRemove : "")
             .accessibilityIdentifier("reaction-\(reaction.rawValue)")
         }
     }

--- a/Sources/StreamChatSwiftUI/ChatMessageList/Reactions/ReactionsOverlayContainer.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/Reactions/ReactionsOverlayContainer.swift
@@ -109,6 +109,8 @@ public struct ReactionsAnimatableView: View {
                 Circle().strokeBorder(Color(colors.buttonSecondaryBorder), lineWidth: 1)
             )
             .padding(tokens.spacingXs)
+            .accessibilityLabel(L10n.Message.Reactions.more)
+            .accessibilityIdentifier("moreReactions")
         }
         .padding(.leading, tokens.spacingXxs)
         .reactionsBubble(for: message, background: colors.backgroundCoreElevation2)
@@ -152,6 +154,9 @@ public struct ReactionAnimatableView: View {
                     .resizable()
                     .scaledToFit()
                     .frame(width: useLargeIcons ? 25 : 20, height: useLargeIcons ? 27 : 20)
+                    .accessibilityLabel(reactionAccessibilityLabel)
+                    .accessibilityAddTraits(isUserReaction ? [.isButton, .isSelected] : .isButton)
+                    .accessibilityHint(isUserReaction ? L10n.Message.Reactions.tapToRemove : "")
             }
             .frame(width: ButtonSize.large, height: ButtonSize.large)
             .background(reactionSelectedBackgroundColor(for: reaction)?.clipShape(Circle()))
@@ -190,6 +195,24 @@ public struct ReactionAnimatableView: View {
 
     private var userReactionIDs: Set<MessageReactionType> {
         Set(message.currentUserReactions.map(\.type))
+    }
+
+    /// Whether the current user has already added this reaction.
+    private var isUserReaction: Bool {
+        userReactionIDs.contains(reaction)
+    }
+
+    /// A spoken label for the reaction, preferring the emoji (VoiceOver reads its
+    /// name, e.g. "thumbs up") and falling back to the raw reaction type.
+    private var reactionAccessibilityLabel: String {
+        if let emoji = images.availableMessagesReactionEmojis[reaction] {
+            return emoji
+        }
+        if let dictionary = images.availableEmojis.first(where: { $0["key"] == reaction.rawValue }),
+           let emoji = dictionary["value"] {
+            return emoji
+        }
+        return reaction.rawValue
     }
 }
 

--- a/Sources/StreamChatSwiftUI/ChatMessageList/Reactions/ReactionsOverlayView.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/Reactions/ReactionsOverlayView.swift
@@ -150,9 +150,18 @@ public struct ReactionsOverlayView<Factory: ViewFactory>: View {
         .background(orientationChanged ? nil : Color(colors.backgroundCoreElevation1))
         .onAppear {
             popIn = true
+            // Once the chat behind the overlay is hidden, tell VoiceOver the screen
+            // changed so it moves focus into the overlay (the reactions picker)
+            // instead of staying on a now-hidden message.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                UIAccessibility.post(notification: .screenChanged, argument: nil)
+            }
         }
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("ReactionsOverlayView")
+        .accessibilityAction(.escape) {
+            dismissReactionsOverlay { /* No additional handling. */ }
+        }
         .onRotate { _ in
             if isIPad {
                 orientationChanged = true
@@ -192,6 +201,9 @@ public struct ReactionsOverlayView<Factory: ViewFactory>: View {
                     .edgesIgnoringSafeArea(.all)
             }
         }
+        // The blurred snapshot and scrim are purely decorative; keep them out of
+        // the accessibility tree so VoiceOver focuses the overlay's content.
+        .accessibilityHidden(true)
         .transition(.opacity)
         .onTapGesture {
             dismissReactionsOverlay { /* No additional handling. */ }
@@ -275,6 +287,9 @@ public struct ReactionsOverlayView<Factory: ViewFactory>: View {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
             onBackgroundTap()
             completion()
+            // The chat is visible again now that the overlay is gone; let VoiceOver
+            // re-scan so focus returns to the message list instead of being orphaned.
+            UIAccessibility.post(notification: .screenChanged, argument: nil)
         }
     }
 

--- a/Sources/StreamChatSwiftUI/Generated/L10n.swift
+++ b/Sources/StreamChatSwiftUI/Generated/L10n.swift
@@ -810,6 +810,8 @@ internal enum L10n {
     internal enum Reactions {
       /// You
       internal static var currentUser: String { L10n.tr("Localizable", "message.reactions.currentUser") }
+      /// More reactions
+      internal static var more: String { L10n.tr("Localizable", "message.reactions.more") }
       /// Tap to remove
       internal static var tapToRemove: String { L10n.tr("Localizable", "message.reactions.tap-to-remove") }
     }

--- a/Sources/StreamChatSwiftUI/Resources/en.lproj/Localizable.strings
+++ b/Sources/StreamChatSwiftUI/Resources/en.lproj/Localizable.strings
@@ -76,6 +76,7 @@
 "message.cell.edited" = "Edited";
 "message.cell.sent-at" = "Sent at %@";
 "message.reactions.currentUser" = "You";
+"message.reactions.more" = "More reactions";
 "message.reactions.tap-to-remove" = "Tap to remove";
 
 "message.polls.button.addComment" = "Add a Comment";

--- a/StreamChatSwiftUITestsAppTests/Pages/MessageListPage.swift
+++ b/StreamChatSwiftUITestsAppTests/Pages/MessageListPage.swift
@@ -11,11 +11,17 @@ import XCTest
 
 class MessageListPage {
     static var cells: XCUIElementQuery {
-        app.otherElements.matching(identifier: "MessageItemView")
+        app.descendants(matching: .any).matching(
+            NSPredicate(format:
+                "(elementType == %d or elementType == %d) and identifier LIKE 'MessageItemView'",
+                XCUIElement.ElementType.button.rawValue,
+                XCUIElement.ElementType.other.rawValue
+            )
+        )
     }
 
     static func messageView(for cell: XCUIElement) -> XCUIElement {
-        cell.otherElements.matching(identifier: "MessageView").firstMatch
+        cell.buttons.matching(identifier: "MessageView").firstMatch
     }
 
     static var messages: XCUIElementQuery {
@@ -119,7 +125,11 @@ class MessageListPage {
         }
 
         static func threadReplyCountButton(in messageCell: XCUIElement) -> XCUIElement {
-            app.buttons.matching(NSPredicate(format: "identifier LIKE 'UserAvatar' or identifier LIKE 'UserAvatarPlaceholder'")).firstMatch
+            app.buttons.matching(
+                NSPredicate(format:
+                    "(identifier LIKE 'UserAvatar' or identifier LIKE 'UserAvatarPlaceholder') and label CONTAINS 'Thread Repl'"
+                )
+            ).firstMatch
         }
 
         static func reactions(in messageCell: XCUIElement) -> XCUIElementQuery {
@@ -131,7 +141,7 @@ class MessageListPage {
         }
 
         static func time(in messageCell: XCUIElement) -> XCUIElement {
-            messageCell.staticTexts["MessageDateView"]
+            messageCell.buttons["MessageDateView"]
         }
 
         static func author(messageCell: XCUIElement) -> XCUIElement {

--- a/StreamChatSwiftUITestsAppTests/Pages/MessageListPage.swift
+++ b/StreamChatSwiftUITestsAppTests/Pages/MessageListPage.swift
@@ -12,7 +12,8 @@ import XCTest
 class MessageListPage {
     static var cells: XCUIElementQuery {
         app.descendants(matching: .any).matching(
-            NSPredicate(format:
+            NSPredicate(
+                format:
                 "(elementType == %d or elementType == %d) and identifier LIKE 'MessageItemView'",
                 XCUIElement.ElementType.button.rawValue,
                 XCUIElement.ElementType.other.rawValue

--- a/StreamChatSwiftUITestsAppTests/Pages/MessageListPage.swift
+++ b/StreamChatSwiftUITestsAppTests/Pages/MessageListPage.swift
@@ -102,16 +102,16 @@ class MessageListPage {
 
     enum Reactions {
         static var reactionsMessageView: XCUIElement { app.otherElements["ReactionsMessageView"] }
-        static var love: XCUIElement { app.otherElements["reaction-love"] }
-        static var lol: XCUIElement { app.otherElements["reaction-haha"] }
-        static var like: XCUIElement { app.otherElements["reaction-like"] }
-        static var sad: XCUIElement { app.otherElements["reaction-sad"] }
-        static var wow: XCUIElement { app.otherElements["reaction-wow"] }
+        static var love: XCUIElement { app.buttons["reaction-love"].firstMatch }
+        static var lol: XCUIElement { app.buttons["reaction-haha"].firstMatch }
+        static var like: XCUIElement { app.buttons["reaction-like"].firstMatch }
+        static var sad: XCUIElement { app.buttons["reaction-sad"].firstMatch }
+        static var wow: XCUIElement { app.buttons["reaction-wow"].firstMatch }
     }
 
     enum Attributes {
         static func messageBubble(in messageCell: XCUIElement) -> XCUIElement {
-            messageCell.otherElements["MessageView"]
+            messageCell.buttons["MessageView"]
         }
         
         static func reactionButton(in messageCell: XCUIElement) -> XCUIElement {


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1748/voice-over-message-actions-and-reactions.

### 🎯 Goal

Improve usage of the reactions overlay view (message actions and reactions picker) in Voice over.

### 📝 Summary

- Enabled the double tap overlay in voice over. 
- Improved the selection of elements of the reactions overlay view.

### 🛠 Implementation

  Reactions picker — Each reaction in the overlay now has a spoken label (the emoji name, e.g. "thumbs up"), is announced as a button, exposes its selected state when the
  current user has already reacted, and reads "Tap to remove" as a hint in that case. The previously-unlabeled "+" button now reads "More reactions".

  Message actions — Each action (reply, edit, delete, etc.) is given an explicit accessibility label from its title and is announced as a button, so VoiceOver reads every
  action clearly and presents it as selectable.

  Overlay as a modal — When the reactions overlay is shown, the chat content and floating composer behind it are hidden from VoiceOver, so it no longer reads the messages
  underneath; the decorative blurred snapshot is also hidden. VoiceOver focus is moved into the overlay (onto the reactions picker) when it appears, returns to the chat
  when it's dismissed, and the overlay can be closed with the two-finger "escape" gesture.

  Opening the overlay — Added a default accessibility action on each message so a single VoiceOver double-tap reliably opens the reactions/actions overlay, fixing the
  issue where it required repeated taps (VoiceOver's activation didn't match the existing count-2 tap / long-press gestures).

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

Go into voice over, double tap to show the reactions picker and test the actions.

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility Improvements**
  * Enhanced VoiceOver support for reactions and message actions overlays: focus management when overlays open/close, escape action to dismiss, background content hidden while overlays are active, and explicit accessibility actions for reliably opening actions.
  * Added descriptive accessibility labels, dynamic labels, traits and hints for reaction and action buttons.

* **Localization**
  * Added a localization key/label for the "More reactions" button.

* **Tests**
  * Updated UI tests to query message views and reaction controls as interactive buttons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->