### PR TITLE
Collapse composer picker only when multiple items are available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+### 🐞 Fixed
+- Fix the composer attachment picker collapsing the paperclip icon into an arrow while typing when only a single picker item is available [#1496](https://github.com/GetStream/stream-chat-swiftui/pull/1496)
+
 ### 🔄 Changed
 
 # [4.101.1](https://github.com/GetStream/stream-chat-swiftui/releases/tag/4.101.1)

--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/AttachmentPickerTypeView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/AttachmentPickerTypeView.swift
@@ -51,7 +51,7 @@ public struct AttachmentPickerTypeView: View {
         HStack(spacing: 16) {
             switch pickerTypeState {
             case let .expanded(attachmentPickerType):
-                if composerViewModel.channelController.channel?.canUploadFile == true && composerViewModel.isSendMessageEnabled {
+                if composerViewModel.fileUploadsAvailable && composerViewModel.isSendMessageEnabled {
                     PickerTypeButton(
                         pickerTypeState: $pickerTypeState,
                         pickerType: .media,

--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerViewModel.swift
@@ -53,8 +53,10 @@ open class MessageComposerViewModel: ObservableObject {
                 checkTypingSuggestions()
                 if pickerTypeState != .collapsed {
                     if composerCommand == nil && (abs(text.count - oldValue.count) < 10) {
-                        withAnimation {
-                            pickerTypeState = .collapsed
+                        if availablePickerItemsCount > 1 {
+                            withAnimation {
+                                pickerTypeState = .collapsed
+                            }
                         }
                     } else {
                         pickerTypeState = .collapsed
@@ -449,6 +451,26 @@ open class MessageComposerViewModel: ObservableObject {
         channelController.channel?.canSendMessage ?? true
     }
 
+    var fileUploadsAvailable: Bool {
+        channelController.channel?.canUploadFile == true
+    }
+
+    var configuredCommandsAvailable: Bool {
+        channelController.channel?.config.commands.count ?? 0 > 0
+    }
+
+    var availablePickerItemsCount: Int {
+        guard isSendMessageEnabled else { return 0 }
+        var count = 0
+        if fileUploadsAvailable {
+            count += 1
+        }
+        if configuredCommandsAvailable {
+            count += 1
+        }
+        return count
+    }
+
     public var sendButtonEnabled: Bool {
         if let composerCommand = composerCommand,
            let handler = commandsHandler.commandHandler(for: composerCommand) {
@@ -480,7 +502,6 @@ open class MessageComposerViewModel: ObservableObject {
             return true
         }
         let commandAvailable = composerCommand != nil
-        let configuredCommandsAvailable = channelController.channel?.config.commands.count ?? 0 > 0
         return commandAvailable && configuredCommandsAvailable
     }
     

--- a/StreamChatSwiftUITests/Tests/ChatChannel/MessageComposerViewModel_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/MessageComposerViewModel_Tests.swift
@@ -758,6 +758,82 @@ class MessageComposerViewModel_Tests: StreamChatTestCase {
         XCTAssertTrue(viewModel.showCommandsOverlay)
     }
 
+    // MARK: - availablePickerItemsCount
+
+    func test_availablePickerItemsCount_whenUploadAndCommandsAvailable_returnsTwo() {
+        // Given
+        let viewModel = makeComposerViewModel(
+            config: ChannelConfig(commands: [.init()]),
+            ownCapabilities: [.sendMessage, .uploadFile]
+        )
+
+        // When
+        let count = viewModel.availablePickerItemsCount
+
+        // Then
+        XCTAssertEqual(count, 2)
+    }
+
+    func test_availablePickerItemsCount_whenOnlyUploadAvailable_returnsOne() {
+        // Given
+        let viewModel = makeComposerViewModel(
+            config: ChannelConfig(commands: []),
+            ownCapabilities: [.sendMessage, .uploadFile]
+        )
+
+        // When
+        let count = viewModel.availablePickerItemsCount
+
+        // Then
+        XCTAssertEqual(count, 1)
+    }
+
+    func test_availablePickerItemsCount_whenSendMessageDisabled_returnsZero() {
+        // Given
+        let viewModel = makeComposerViewModel(
+            config: ChannelConfig(commands: [.init()]),
+            ownCapabilities: [.uploadFile]
+        )
+
+        // When
+        let count = viewModel.availablePickerItemsCount
+
+        // Then
+        XCTAssertEqual(count, 0)
+    }
+
+    // MARK: - pickerTypeState on text change
+
+    func test_pickerTypeState_whenTypingWithSingleItem_staysExpanded() {
+        // Given
+        let viewModel = makeComposerViewModel(
+            config: ChannelConfig(commands: []),
+            ownCapabilities: [.sendMessage, .uploadFile]
+        )
+        viewModel.pickerTypeState = .expanded(.none)
+
+        // When
+        viewModel.text = "test"
+
+        // Then
+        XCTAssertEqual(viewModel.pickerTypeState, .expanded(.none))
+    }
+
+    func test_pickerTypeState_whenTypingWithMultipleItems_collapses() {
+        // Given
+        let viewModel = makeComposerViewModel(
+            config: ChannelConfig(commands: [.init()]),
+            ownCapabilities: [.sendMessage, .uploadFile]
+        )
+        viewModel.pickerTypeState = .expanded(.none)
+
+        // When
+        viewModel.text = "test"
+
+        // Then
+        XCTAssertEqual(viewModel.pickerTypeState, .collapsed)
+    }
+
     func test_addedAsset_extraData() {
         // Given
         let image = UIImage(systemName: "person")!
@@ -1417,6 +1493,21 @@ class MessageComposerViewModel_Tests: StreamChatTestCase {
 
     private func makeComposerViewModel() -> MessageComposerViewModel {
         MessageComposerTestUtils.makeComposerViewModel(chatClient: chatClient)
+    }
+
+    private func makeComposerViewModel(
+        config: ChannelConfig,
+        ownCapabilities: Set<ChannelCapability>
+    ) -> MessageComposerViewModel {
+        let channelController = makeChannelController()
+        channelController.channel_mock = .mockDMChannel(
+            config: config,
+            ownCapabilities: ownCapabilities
+        )
+        return MessageComposerViewModel(
+            channelController: channelController,
+            messageController: nil
+        )
     }
     
     private func makeChannelController(


### PR DESCRIPTION
### 🔗 Issue Links

Resolves: [IOS-1767](https://linear.app/stream/issue/IOS-1767)

### 🎯 Goal

Do not collapse composer leading items when there is just one item (e.g. commands are disabled)

### 📝 Summary

- Collapse the composer's attachment picker on text entry **only when more than one picker item is available** (media + instant commands). A single-button picker now stays expanded while typing.
- Add `availablePickerItemsCount`, `fileUploadsAvailable`, and `configuredCommandsAvailable` on `MessageComposerViewModel`; reuse the latter two in the picker view and `showCommandsOverlay`.

### 🛠 Implementation

- The collapse-on-type lived in `MessageComposerViewModel.text`'s `didSet` and fired on every keystroke. It's now gated on `availablePickerItemsCount > 1`. The `else` branch (active slash-command or large paste) is unchanged.
- `availablePickerItemsCount` mirrors the button-visibility conditions in `AttachmentPickerTypeView`'s `.expanded` case: media via `canUploadFile`, commands via `config.commands.count`, both gated by `isSendMessageEnabled`.
- Extracted `fileUploadsAvailable` / `configuredCommandsAvailable` to remove duplication; the picker view's media button and `showCommandsOverlay` now route through them (same source, no behavior change).
- Note: `develop` does not need this fix — the composer was rewritten there and no longer collapses the picker on typing.

### 🧪 Manual Testing Notes

- **Single item** (uploads enabled, no commands configured, or vice-versa): start typing — the paperclip stays put, no swap to the arrow.
- **Multiple items** (uploads enabled *and* commands configured): start typing — the picker collapses to the arrow as before; tapping re-expands to both buttons.
- Selecting a slash command or pasting a large block still collapses (unchanged `else` branch).

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
