### PR TITLE
Add option to configure max length for question and option text in polls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### ✅ Added
+- Add `PollsConfig.maxQuestionLength` and `PollsConfig.maxOptionLength` to limit the character count of poll questions and options [#1500](https://github.com/GetStream/stream-chat-swiftui/pull/1500)
 
 # [5.5.1](https://github.com/GetStream/stream-chat-swiftui/releases/tag/5.5.1)
 _June 11, 2026_

--- a/Sources/StreamChatSwiftUI/ChatComposer/Polls/CreatePollViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatComposer/Polls/CreatePollViewModel.swift
@@ -14,9 +14,12 @@ import SwiftUI
 
     @Published var question = "" {
         didSet {
+            guard let maxQuestionLength else { return }
             let clamped = clamped(question, to: maxQuestionLength)
             if clamped != question {
-                question = clamped
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1, execute: { [weak self] in
+                    self?.question = clamped
+                })
             }
         }
     }
@@ -133,6 +136,11 @@ import SwiftUI
         guard let index = options.firstIndex(where: { $0.id == id }) else { return }
         let value = clamped(value, to: maxOptionLength)
         options[index].text = value
+        if maxOptionLength != nil {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+                self?.options[index].text = value
+            }
+        }
         if index == options.count - 1,
            !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             withAnimation {

--- a/Sources/StreamChatSwiftUI/ChatComposer/Polls/CreatePollViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatComposer/Polls/CreatePollViewModel.swift
@@ -12,7 +12,15 @@ import SwiftUI
 
     // MARK: - Published State
 
-    @Published var question = ""
+    @Published var question = "" {
+        didSet {
+            let clamped = clamped(question, to: maxQuestionLength)
+            if clamped != question {
+                question = clamped
+            }
+        }
+    }
+
     @Published private(set) var options: [PollOptionEntry] = [PollOptionEntry()]
     @Published private(set) var optionsErrorIndices = Set<Int>()
 
@@ -34,12 +42,20 @@ import SwiftUI
 
     private var cancellables = [AnyCancellable]()
 
+    /// The maximum number of characters accepted in the question text field, or `nil` for no limit.
+    private let maxQuestionLength: Int?
+    /// The maximum number of characters accepted in each option text field, or `nil` for no limit.
+    private let maxOptionLength: Int?
+
     // MARK: - Init
 
     init(chatController: ChatChannelController, messageController: ChatMessageController?) {
         let pollsConfig = InjectedValues[\.utils].pollsConfig
         self.chatController = chatController
         self.messageController = messageController
+
+        maxQuestionLength = pollsConfig.maxQuestionLength
+        maxOptionLength = pollsConfig.maxOptionLength
 
         multipleAnswers = pollsConfig.multipleAnswers.defaultValue
         maxVotesEnabled = pollsConfig.maxVotesPerPerson.defaultValue
@@ -115,6 +131,7 @@ import SwiftUI
 
     func updateOption(id: UUID, value: String) {
         guard let index = options.firstIndex(where: { $0.id == id }) else { return }
+        let value = clamped(value, to: maxOptionLength)
         options[index].text = value
         if index == options.count - 1,
            !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
@@ -225,6 +242,13 @@ import SwiftUI
     // MARK: - Private
 
     private let maxVotesRange = 2...10
+
+    /// Truncates `text` to at most `limit` characters. Returns `text` unchanged
+    /// when `limit` is `nil` (no limit configured) or the text is already within it.
+    private func clamped(_ text: String, to limit: Int?) -> String {
+        guard let limit, text.count > limit else { return text }
+        return String(text.prefix(limit))
+    }
 }
 
 struct PollOptionEntry: Identifiable, Equatable, Sendable {

--- a/Sources/StreamChatSwiftUI/ChatMessageList/Polls/PollsConfig.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/Polls/PollsConfig.swift
@@ -16,7 +16,17 @@ public final class PollsConfig {
     public var addComments: PollsEntryConfig
     /// Configuration for setting the maximum number of votes per person.
     public var maxVotesPerPerson: PollsEntryConfig
-    
+    /// The maximum number of characters allowed in the poll question.
+    ///
+    /// When set, the question text field in the poll creation view stops accepting
+    /// further input once the limit is reached. Defaults to `nil`, meaning no limit.
+    public var maxQuestionLength: Int?
+    /// The maximum number of characters allowed in each poll option.
+    ///
+    /// When set, an option's text field in the poll creation view stops accepting
+    /// further input once the limit is reached. Defaults to `nil`, meaning no limit.
+    public var maxOptionLength: Int?
+
     /// Initializes a new `PollsConfig` with the given configurations.
     ///
     /// - Parameters:
@@ -25,18 +35,24 @@ public final class PollsConfig {
     ///   - suggestAnOption: Configuration for allowing users to suggest options. Defaults to `.default`.
     ///   - addComments: Configuration for adding comments. Defaults to `.default`.
     ///   - maxVotesPerPerson: Configuration for setting the maximum number of votes per person. Defaults to `.default`.
+    ///   - maxQuestionLength: The maximum number of characters allowed in the poll question. Defaults to `nil` (no limit).
+    ///   - maxOptionLength: The maximum number of characters allowed in each poll option. Defaults to `nil` (no limit).
     public init(
         multipleAnswers: PollsEntryConfig = .default,
         anonymousPoll: PollsEntryConfig = .default,
         suggestAnOption: PollsEntryConfig = .default,
         addComments: PollsEntryConfig = .default,
-        maxVotesPerPerson: PollsEntryConfig = .default
+        maxVotesPerPerson: PollsEntryConfig = .default,
+        maxQuestionLength: Int? = nil,
+        maxOptionLength: Int? = nil
     ) {
         self.multipleAnswers = multipleAnswers
         self.anonymousPoll = anonymousPoll
         self.suggestAnOption = suggestAnOption
         self.addComments = addComments
         self.maxVotesPerPerson = maxVotesPerPerson
+        self.maxQuestionLength = maxQuestionLength
+        self.maxOptionLength = maxOptionLength
     }
 }
 

--- a/StreamChatSwiftUITests/Tests/ChatChannel/CreatePollViewModel_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/CreatePollViewModel_Tests.swift
@@ -172,6 +172,61 @@ import XCTest
         XCTAssertFalse(viewModel.maxVotesEnabled)
     }
 
+    // MARK: - Text Length Limits
+
+    func test_question_noLimitByDefault_acceptsLongText() {
+        let viewModel = makeViewModel()
+        let longText = String(repeating: "A", count: 500)
+        viewModel.question = longText
+        XCTAssertEqual(viewModel.question, longText)
+    }
+
+    func test_question_truncatedToMaxQuestionLength() {
+        let viewModel = makeViewModel(pollsConfig: .init(maxQuestionLength: 5))
+        viewModel.question = "Hello, World"
+        XCTAssertEqual(viewModel.question, "Hello")
+    }
+
+    func test_question_withinMaxQuestionLength_unchanged() {
+        let viewModel = makeViewModel(pollsConfig: .init(maxQuestionLength: 5))
+        viewModel.question = "Hi"
+        XCTAssertEqual(viewModel.question, "Hi")
+    }
+
+    func test_question_truncationCountsCharactersNotBytes() {
+        let viewModel = makeViewModel(pollsConfig: .init(maxQuestionLength: 3))
+        viewModel.question = "😀😀😀😀😀"
+        XCTAssertEqual(viewModel.question, "😀😀😀")
+    }
+
+    func test_updateOption_noLimitByDefault_acceptsLongText() {
+        let viewModel = makeViewModel()
+        let longText = String(repeating: "A", count: 500)
+        let id = viewModel.options.last!.id
+        viewModel.updateOption(id: id, value: longText)
+        XCTAssertEqual(viewModel.options[0].text, longText)
+    }
+
+    func test_updateOption_truncatedToMaxOptionLength() {
+        let viewModel = makeViewModel(pollsConfig: .init(maxOptionLength: 4))
+        let id = viewModel.options.last!.id
+        viewModel.updateOption(id: id, value: "Option")
+        XCTAssertEqual(viewModel.options[0].text, "Opti")
+    }
+
+    func test_updateOption_withinMaxOptionLength_unchanged() {
+        let viewModel = makeViewModel(pollsConfig: .init(maxOptionLength: 4))
+        let id = viewModel.options.last!.id
+        viewModel.updateOption(id: id, value: "Opt")
+        XCTAssertEqual(viewModel.options[0].text, "Opt")
+    }
+
+    func test_maxQuestionAndOptionLength_defaultToNil() {
+        let config = PollsConfig()
+        XCTAssertNil(config.maxQuestionLength)
+        XCTAssertNil(config.maxOptionLength)
+    }
+
     // MARK: - Initial State
 
     func test_initialState_hasOneEmptyOption() {

--- a/StreamChatSwiftUITests/Tests/ChatChannel/CreatePollViewModel_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/CreatePollViewModel_Tests.swift
@@ -183,8 +183,15 @@ import XCTest
 
     func test_question_truncatedToMaxQuestionLength() {
         let viewModel = makeViewModel(pollsConfig: .init(maxQuestionLength: 5))
+        let testExpectation = XCTestExpectation(description: "Question should be truncated")
+
         viewModel.question = "Hello, World"
-        XCTAssertEqual(viewModel.question, "Hello")
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            XCTAssertEqual(viewModel.question, "Hello")
+            testExpectation.fulfill()
+        }
+        wait(for: [testExpectation], timeout: defaultTimeout)
     }
 
     func test_question_withinMaxQuestionLength_unchanged() {
@@ -195,8 +202,15 @@ import XCTest
 
     func test_question_truncationCountsCharactersNotBytes() {
         let viewModel = makeViewModel(pollsConfig: .init(maxQuestionLength: 3))
+        let testExpectation = XCTestExpectation(description: "Question should be truncated by characters")
+
         viewModel.question = "😀😀😀😀😀"
-        XCTAssertEqual(viewModel.question, "😀😀😀")
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            XCTAssertEqual(viewModel.question, "😀😀😀")
+            testExpectation.fulfill()
+        }
+        wait(for: [testExpectation], timeout: defaultTimeout)
     }
 
     func test_updateOption_noLimitByDefault_acceptsLongText() {


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1698/swiftuistrava-configure-max-length-for-question-and-option-text.

### 🎯 Goal

_Describe why we are making this change._

### 📝 Summary

_Provide bullet points with the most important changes in the codebase._

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable character limits for poll questions and options to enforce maximum text lengths during poll creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->