### PR TITLE
Improve VoiceOver support for Polls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🐞 Fixed
 - Keep the navigation bar and its buttons visible while searching in the add members screen [#1499](https://github.com/GetStream/stream-chat-swiftui/pull/1499)
+- Improve VoiceOver support for polls so the header, options, and results announce as coherent elements [#1503](https://github.com/GetStream/stream-chat-swiftui/pull/1503)
 
 ### ✅ Added
 - Add support for enhanced mention suggestions [#1497](https://github.com/GetStream/stream-chat-swiftui/pull/1497)
@@ -12,6 +13,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### ⚡️ Performance
 - Improve channel avatar loading performance in the channel list [#1501](https://github.com/GetStream/stream-chat-swiftui/pull/1501)
+
+### 🎭 New Localizations
+- `message.polls.accessibility.poll-header` — VoiceOver label identifying a poll header
+- `message.polls.accessibility.option` — VoiceOver label for a poll option
+- `message.polls.accessibility.option-position` — VoiceOver suffix describing a poll option's position
+- `message.polls.accessibility.selected` — VoiceOver state for a selected poll option
+- `message.polls.accessibility.not-selected` — VoiceOver state for an unselected poll option
+- `message.polls.accessibility.votes-including-yours` — VoiceOver vote count that includes the current user's vote
+- `message.polls.accessibility.leading-option` — VoiceOver label for the leading option in poll results
+- `message.polls.accessibility.voter` — VoiceOver label for a voter row in poll results
 
 # [5.5.1](https://github.com/GetStream/stream-chat-swiftui/releases/tag/5.5.1)
 _June 11, 2026_

--- a/Sources/StreamChatSwiftUI/ChatMessageList/Polls/PollAllOptionsView.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/Polls/PollAllOptionsView.swift
@@ -69,7 +69,7 @@ struct PollAllOptionsView<Factory: ViewFactory>: View {
 
     private var optionsSection: some View {
         VStack(spacing: tokens.spacingMd) {
-            ForEach(viewModel.poll.options) { option in
+            ForEach(Array(viewModel.poll.options.enumerated()), id: \.element.id) { index, option in
                 PollOptionView(
                     viewModel: viewModel,
                     factory: factory,
@@ -77,7 +77,9 @@ struct PollAllOptionsView<Factory: ViewFactory>: View {
                     optionVotes: viewModel.poll.voteCount(for: option),
                     maxVotes: viewModel.poll.currentMaximumVoteCount,
                     message: viewModel.message,
-                    forceIncomingStyle: true
+                    forceIncomingStyle: true,
+                    optionIndex: index + 1,
+                    optionsCount: viewModel.poll.options.count
                 )
             }
         }

--- a/Sources/StreamChatSwiftUI/ChatMessageList/Polls/PollAttachmentView.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/Polls/PollAttachmentView.swift
@@ -60,14 +60,19 @@ public struct PollAttachmentView<Factory: ViewFactory>: View {
             .accessibilityAddTraits(.isHeader)
 
             VStack(spacing: tokens.spacingMd) {
-                ForEach(options.prefix(PollAttachmentViewModel.numberOfVisibleOptionsShown)) { option in
+                ForEach(
+                    Array(options.prefix(PollAttachmentViewModel.numberOfVisibleOptionsShown).enumerated()),
+                    id: \.element.id
+                ) { index, option in
                     PollOptionView(
                         viewModel: viewModel,
                         factory: factory,
                         option: option,
                         optionVotes: poll.voteCount(for: option),
                         maxVotes: poll.currentMaximumVoteCount,
-                        message: message
+                        message: message,
+                        optionIndex: index + 1,
+                        optionsCount: options.count
                     )
                     .layoutPriority(1) // do not compress long text
                 }
@@ -233,6 +238,10 @@ struct PollOptionView<Factory: ViewFactory>: View {
     /// If true, forces incoming color style for the radio button border and progress track,
     /// regardless of whether the message was sent by the current user.
     var forceIncomingStyle: Bool = false
+    /// The 1-based position of this option, used for the VoiceOver announcement.
+    var optionIndex: Int?
+    /// The total number of options, used for the VoiceOver announcement.
+    var optionsCount: Int?
 
     var body: some View {
         HStack(alignment: .top, spacing: tokens.spacingSm) {
@@ -290,6 +299,34 @@ struct PollOptionView<Factory: ViewFactory>: View {
         .onTapGesture {
             togglePollVote()
         }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityAddTraits(viewModel.poll.isClosed ? [] : .isButton)
+        .accessibilityAction {
+            guard !viewModel.poll.isClosed else { return }
+            togglePollVote()
+        }
+    }
+
+    private var accessibilityLabel: String {
+        let isSelected = viewModel.optionVotedByCurrentUser(option)
+        let stateText = isSelected
+            ? L10n.Message.Polls.Accessibility.selected
+            : L10n.Message.Polls.Accessibility.notSelected
+        let count = viewModel.poll.voteCountsByOption?[option.id] ?? 0
+        let votesText: String
+        if isSelected, count > 1 {
+            votesText = L10n.Message.Polls.Accessibility.votesIncludingYours(count)
+        } else if count == 1 {
+            votesText = L10n.Message.Polls.voteSingular(count)
+        } else {
+            votesText = L10n.Message.Polls.votes(count)
+        }
+        var label = L10n.Message.Polls.Accessibility.option(option.text, stateText, votesText)
+        if let optionIndex, let optionsCount {
+            label += ". " + L10n.Message.Polls.Accessibility.optionPosition(optionIndex, optionsCount)
+        }
+        return label
     }
 
     func togglePollVote() {

--- a/Sources/StreamChatSwiftUI/ChatMessageList/Polls/PollAttachmentView.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/Polls/PollAttachmentView.swift
@@ -206,7 +206,7 @@ public struct PollAttachmentView<Factory: ViewFactory>: View {
     }
 
     private var headerAccessibilityLabel: String {
-        L10n.Message.Polls.Accessibility.pollHeader(poll.name, subtitleText, options.count)
+        PollAccessibility.headerLabel(name: poll.name, subtitle: subtitleText, optionsCount: options.count)
     }
 
     private var subtitleText: String {
@@ -309,24 +309,13 @@ struct PollOptionView<Factory: ViewFactory>: View {
     }
 
     private var accessibilityLabel: String {
-        let isSelected = viewModel.optionVotedByCurrentUser(option)
-        let stateText = isSelected
-            ? L10n.Message.Polls.Accessibility.selected
-            : L10n.Message.Polls.Accessibility.notSelected
-        let count = viewModel.poll.voteCountsByOption?[option.id] ?? 0
-        let votesText: String
-        if isSelected, count > 1 {
-            votesText = L10n.Message.Polls.Accessibility.votesIncludingYours(count)
-        } else if count == 1 {
-            votesText = L10n.Message.Polls.voteSingular(count)
-        } else {
-            votesText = L10n.Message.Polls.votes(count)
-        }
-        var label = L10n.Message.Polls.Accessibility.option(option.text, stateText, votesText)
-        if let optionIndex, let optionsCount {
-            label += ". " + L10n.Message.Polls.Accessibility.optionPosition(optionIndex, optionsCount)
-        }
-        return label
+        PollAccessibility.optionLabel(
+            text: option.text,
+            isSelected: viewModel.optionVotedByCurrentUser(option),
+            voteCount: viewModel.poll.voteCountsByOption?[option.id] ?? 0,
+            optionIndex: optionIndex,
+            optionsCount: optionsCount
+        )
     }
 
     func togglePollVote() {
@@ -374,5 +363,92 @@ struct PollVotesIndicatorView: View {
 
     var ratio: CGFloat {
         CGFloat(optionVotes) / CGFloat(max(maxVotes, 1))
+    }
+}
+
+/// Builders for the VoiceOver accessibility labels used across the poll views.
+///
+/// The label-construction logic lives here, rather than inline in the views, so
+/// that the branching (selection state, vote-count wording, option position,
+/// leading option) can be unit tested directly without rendering a view.
+enum PollAccessibility {
+    /// Combined label for the poll header.
+    ///
+    /// Example: "Poll: Where to eat?. Select one. 4 options".
+    static func headerLabel(name: String, subtitle: String, optionsCount: Int) -> String {
+        L10n.Message.Polls.Accessibility.pollHeader(name, subtitle, optionsCount)
+    }
+
+    /// Combined label for a single poll option in the message bubble.
+    ///
+    /// Examples:
+    /// - "Pizza, not selected, 0 votes. Option 2 of 4"
+    /// - "Pizza, selected, 1 vote. Option 1 of 4"
+    /// - "Pizza, selected, 3 votes including yours. Option 1 of 4"
+    static func optionLabel(
+        text: String,
+        isSelected: Bool,
+        voteCount: Int,
+        optionIndex: Int?,
+        optionsCount: Int?
+    ) -> String {
+        let stateText = isSelected
+            ? L10n.Message.Polls.Accessibility.selected
+            : L10n.Message.Polls.Accessibility.notSelected
+        let votesText: String
+        if isSelected, voteCount > 1 {
+            votesText = L10n.Message.Polls.Accessibility.votesIncludingYours(voteCount)
+        } else if voteCount == 1 {
+            votesText = L10n.Message.Polls.voteSingular(voteCount)
+        } else {
+            votesText = L10n.Message.Polls.votes(voteCount)
+        }
+        var label = L10n.Message.Polls.Accessibility.option(text, stateText, votesText)
+        if let optionIndex, let optionsCount {
+            label += ". " + L10n.Message.Polls.Accessibility.optionPosition(optionIndex, optionsCount)
+        }
+        return label
+    }
+
+    /// Combined label for the poll results question section.
+    ///
+    /// Example: "Question. Where to eat?".
+    static func questionLabel(question: String, name: String) -> String {
+        "\(question). \(name)"
+    }
+
+    /// Combined label for an option heading on the poll results screen.
+    ///
+    /// Examples:
+    /// - "Option 1: Pizza, Leading option, 3 votes"
+    /// - "Option 2: Sushi, 0 votes"
+    static func resultsOptionHeadingLabel(
+        optionIndex: Int?,
+        optionText: String,
+        hasMostVotes: Bool,
+        voteCount: Int
+    ) -> String {
+        var parts: [String] = []
+        if let optionIndex {
+            parts.append("\(L10n.Message.Polls.option(optionIndex)): \(optionText)")
+        } else {
+            parts.append(optionText)
+        }
+        if hasMostVotes {
+            parts.append(L10n.Message.Polls.Accessibility.leadingOption)
+        }
+        parts.append(
+            voteCount == 1
+                ? L10n.Message.Polls.voteSingular(voteCount)
+                : L10n.Message.Polls.votes(voteCount)
+        )
+        return parts.joined(separator: ", ")
+    }
+
+    /// Combined label for a voter row on the poll results screen.
+    ///
+    /// Example: "Luke Skywalker, voted 09/04/26".
+    static func voterLabel(name: String, date: String) -> String {
+        L10n.Message.Polls.Accessibility.voter(name, date)
     }
 }

--- a/Sources/StreamChatSwiftUI/ChatMessageList/Polls/PollAttachmentView.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/Polls/PollAttachmentView.swift
@@ -303,7 +303,6 @@ struct PollOptionView<Factory: ViewFactory>: View {
         .accessibilityLabel(accessibilityLabel)
         .accessibilityAddTraits(viewModel.poll.isClosed ? [] : .isButton)
         .accessibilityAction {
-            guard !viewModel.poll.isClosed else { return }
             togglePollVote()
         }
     }
@@ -319,6 +318,7 @@ struct PollOptionView<Factory: ViewFactory>: View {
     }
 
     func togglePollVote() {
+        guard !viewModel.poll.isClosed else { return }
         if viewModel.optionVotedByCurrentUser(option) {
             viewModel.removePollVote(for: option)
         } else {

--- a/Sources/StreamChatSwiftUI/ChatMessageList/Polls/PollAttachmentView.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/Polls/PollAttachmentView.swift
@@ -55,6 +55,9 @@ public struct PollAttachmentView<Factory: ViewFactory>: View {
                     Spacer()
                 }
             }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(headerAccessibilityLabel)
+            .accessibilityAddTraits(.isHeader)
 
             VStack(spacing: tokens.spacingMd) {
                 ForEach(options.prefix(PollAttachmentViewModel.numberOfVisibleOptionsShown)) { option in
@@ -195,6 +198,10 @@ public struct PollAttachmentView<Factory: ViewFactory>: View {
 
     private var options: [PollOption] {
         poll.options
+    }
+
+    private var headerAccessibilityLabel: String {
+        L10n.Message.Polls.Accessibility.pollHeader(poll.name, subtitleText, options.count)
     }
 
     private var subtitleText: String {

--- a/Sources/StreamChatSwiftUI/ChatMessageList/Polls/PollResultsView.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/Polls/PollResultsView.swift
@@ -69,6 +69,7 @@ struct PollResultsView<Factory: ViewFactory>: View {
         .cornerRadius(tokens.radiusLg)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(PollAccessibility.questionLabel(question: L10n.Message.Polls.question, name: viewModel.poll.name))
+        .accessibilityAddTraits(.isHeader)
     }
 
     private var optionsSection: some View {
@@ -149,6 +150,7 @@ struct PollOptionResultsView<Factory: ViewFactory>: View {
         .padding(.bottom, votes.isEmpty && !allButtonShown ? tokens.spacingMd : 0)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(optionHeadingAccessibilityLabel)
+        .accessibilityAddTraits(.isHeader)
     }
 
     private var optionHeadingAccessibilityLabel: String {

--- a/Sources/StreamChatSwiftUI/ChatMessageList/Polls/PollResultsView.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/Polls/PollResultsView.swift
@@ -67,6 +67,8 @@ struct PollResultsView<Factory: ViewFactory>: View {
         .padding(tokens.spacingMd)
         .background(Color(colors.backgroundCoreSurfaceCard))
         .cornerRadius(tokens.radiusLg)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(L10n.Message.Polls.question). \(viewModel.poll.name)")
     }
 
     private var optionsSection: some View {

--- a/Sources/StreamChatSwiftUI/ChatMessageList/Polls/PollResultsView.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/Polls/PollResultsView.swift
@@ -147,6 +147,22 @@ struct PollOptionResultsView<Factory: ViewFactory>: View {
         .padding(.horizontal, tokens.spacingMd)
         .padding(.top, tokens.spacingMd)
         .padding(.bottom, votes.isEmpty && !allButtonShown ? tokens.spacingMd : 0)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(optionHeadingAccessibilityLabel)
+    }
+
+    private var optionHeadingAccessibilityLabel: String {
+        var parts: [String] = []
+        if let optionIndex {
+            parts.append("\(L10n.Message.Polls.option(optionIndex)): \(option.text)")
+        } else {
+            parts.append(option.text)
+        }
+        if hasMostVotes {
+            parts.append(L10n.Message.Polls.Accessibility.leadingOption)
+        }
+        parts.append(voteCountText)
+        return parts.joined(separator: ", ")
     }
 
     private var votesLabel: some View {
@@ -156,6 +172,7 @@ struct PollOptionResultsView<Factory: ViewFactory>: View {
                     .resizable()
                     .aspectRatio(contentMode: .fit)
                     .frame(width: tokens.iconSizeMd, height: tokens.iconSizeMd)
+                    .accessibilityHidden(true)
             }
             Text(voteCountText)
                 .font(fonts.body)
@@ -194,6 +211,7 @@ struct PollOptionResultsView<Factory: ViewFactory>: View {
                         showsIndicator: false
                     )
                 )
+                .accessibilityHidden(true)
             }
             Text(vote.user?.name ?? (vote.user?.id ?? L10n.Message.Polls.unknownVoteAuthor))
                 .font(fonts.body)
@@ -208,6 +226,14 @@ struct PollOptionResultsView<Factory: ViewFactory>: View {
         .padding(.horizontal, tokens.spacingMd)
         .padding(.vertical, tokens.spacingXs)
         .frame(minHeight: 40)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(voterRowAccessibilityLabel(for: vote))
+    }
+
+    private func voterRowAccessibilityLabel(for vote: PollVote) -> String {
+        let name = vote.user?.name ?? (vote.user?.id ?? L10n.Message.Polls.unknownVoteAuthor)
+        let date = utils.pollsDateFormatter.formatDay(vote.createdAt)
+        return L10n.Message.Polls.Accessibility.voter(name, date)
     }
 
     // MARK: - View All Button

--- a/Sources/StreamChatSwiftUI/ChatMessageList/Polls/PollResultsView.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/Polls/PollResultsView.swift
@@ -68,7 +68,7 @@ struct PollResultsView<Factory: ViewFactory>: View {
         .background(Color(colors.backgroundCoreSurfaceCard))
         .cornerRadius(tokens.radiusLg)
         .accessibilityElement(children: .ignore)
-        .accessibilityLabel("\(L10n.Message.Polls.question). \(viewModel.poll.name)")
+        .accessibilityLabel(PollAccessibility.questionLabel(question: L10n.Message.Polls.question, name: viewModel.poll.name))
     }
 
     private var optionsSection: some View {
@@ -152,17 +152,12 @@ struct PollOptionResultsView<Factory: ViewFactory>: View {
     }
 
     private var optionHeadingAccessibilityLabel: String {
-        var parts: [String] = []
-        if let optionIndex {
-            parts.append("\(L10n.Message.Polls.option(optionIndex)): \(option.text)")
-        } else {
-            parts.append(option.text)
-        }
-        if hasMostVotes {
-            parts.append(L10n.Message.Polls.Accessibility.leadingOption)
-        }
-        parts.append(voteCountText)
-        return parts.joined(separator: ", ")
+        PollAccessibility.resultsOptionHeadingLabel(
+            optionIndex: optionIndex,
+            optionText: option.text,
+            hasMostVotes: hasMostVotes,
+            voteCount: poll.voteCountsByOption?[option.id] ?? 0
+        )
     }
 
     private var votesLabel: some View {
@@ -233,7 +228,7 @@ struct PollOptionResultsView<Factory: ViewFactory>: View {
     private func voterRowAccessibilityLabel(for vote: PollVote) -> String {
         let name = vote.user?.name ?? (vote.user?.id ?? L10n.Message.Polls.unknownVoteAuthor)
         let date = utils.pollsDateFormatter.formatDay(vote.createdAt)
-        return L10n.Message.Polls.Accessibility.voter(name, date)
+        return PollAccessibility.voterLabel(name: name, date: date)
     }
 
     // MARK: - View All Button

--- a/Sources/StreamChatSwiftUI/Generated/L10n.swift
+++ b/Sources/StreamChatSwiftUI/Generated/L10n.swift
@@ -783,6 +783,8 @@ internal enum L10n {
         return L10n.tr("Localizable", "message.polls.votes-total", p1)
       }
       internal enum Accessibility {
+        /// Leading option
+        internal static var leadingOption: String { L10n.tr("Localizable", "message.polls.accessibility.leading-option") }
         /// not selected
         internal static var notSelected: String { L10n.tr("Localizable", "message.polls.accessibility.not-selected") }
         /// %1$@, %2$@, %3$@
@@ -799,6 +801,10 @@ internal enum L10n {
         }
         /// selected
         internal static var selected: String { L10n.tr("Localizable", "message.polls.accessibility.selected") }
+        /// %1$@, voted %2$@
+        internal static func voter(_ p1: Any, _ p2: Any) -> String {
+          return L10n.tr("Localizable", "message.polls.accessibility.voter", String(describing: p1), String(describing: p2))
+        }
         /// %d votes including yours
         internal static func votesIncludingYours(_ p1: Int) -> String {
           return L10n.tr("Localizable", "message.polls.accessibility.votes-including-yours", p1)

--- a/Sources/StreamChatSwiftUI/Generated/L10n.swift
+++ b/Sources/StreamChatSwiftUI/Generated/L10n.swift
@@ -782,6 +782,12 @@ internal enum L10n {
       internal static func votesTotal(_ p1: Int) -> String {
         return L10n.tr("Localizable", "message.polls.votes-total", p1)
       }
+      internal enum Accessibility {
+        /// Poll: %1$@. %2$@. %3$d options
+        internal static func pollHeader(_ p1: Any, _ p2: Any, _ p3: Int) -> String {
+          return L10n.tr("Localizable", "message.polls.accessibility.poll-header", String(describing: p1), String(describing: p2), p3)
+        }
+      }
       internal enum Button {
         /// Add a Comment
         internal static var addComment: String { L10n.tr("Localizable", "message.polls.button.addComment") }

--- a/Sources/StreamChatSwiftUI/Generated/L10n.swift
+++ b/Sources/StreamChatSwiftUI/Generated/L10n.swift
@@ -783,9 +783,25 @@ internal enum L10n {
         return L10n.tr("Localizable", "message.polls.votes-total", p1)
       }
       internal enum Accessibility {
+        /// not selected
+        internal static var notSelected: String { L10n.tr("Localizable", "message.polls.accessibility.not-selected") }
+        /// %1$@, %2$@, %3$@
+        internal static func option(_ p1: Any, _ p2: Any, _ p3: Any) -> String {
+          return L10n.tr("Localizable", "message.polls.accessibility.option", String(describing: p1), String(describing: p2), String(describing: p3))
+        }
+        /// Option %1$d of %2$d
+        internal static func optionPosition(_ p1: Int, _ p2: Int) -> String {
+          return L10n.tr("Localizable", "message.polls.accessibility.option-position", p1, p2)
+        }
         /// Poll: %1$@. %2$@. %3$d options
         internal static func pollHeader(_ p1: Any, _ p2: Any, _ p3: Int) -> String {
           return L10n.tr("Localizable", "message.polls.accessibility.poll-header", String(describing: p1), String(describing: p2), p3)
+        }
+        /// selected
+        internal static var selected: String { L10n.tr("Localizable", "message.polls.accessibility.selected") }
+        /// %d votes including yours
+        internal static func votesIncludingYours(_ p1: Int) -> String {
+          return L10n.tr("Localizable", "message.polls.accessibility.votes-including-yours", p1)
         }
       }
       internal enum Button {

--- a/Sources/StreamChatSwiftUI/Resources/en.lproj/Localizable.strings
+++ b/Sources/StreamChatSwiftUI/Resources/en.lproj/Localizable.strings
@@ -80,6 +80,11 @@
 "message.reactions.tap-to-remove" = "Tap to remove";
 
 "message.polls.accessibility.poll-header" = "Poll: %1$@. %2$@. %3$d options";
+"message.polls.accessibility.option" = "%1$@, %2$@, %3$@";
+"message.polls.accessibility.option-position" = "Option %1$d of %2$d";
+"message.polls.accessibility.selected" = "selected";
+"message.polls.accessibility.not-selected" = "not selected";
+"message.polls.accessibility.votes-including-yours" = "%d votes including yours";
 "message.polls.button.addComment" = "Add a Comment";
 "message.polls.button.updateComment" = "Update Your Comment";
 "message.polls.button.endVote" = "End Poll";

--- a/Sources/StreamChatSwiftUI/Resources/en.lproj/Localizable.strings
+++ b/Sources/StreamChatSwiftUI/Resources/en.lproj/Localizable.strings
@@ -79,6 +79,7 @@
 "message.reactions.more" = "More reactions";
 "message.reactions.tap-to-remove" = "Tap to remove";
 
+"message.polls.accessibility.poll-header" = "Poll: %1$@. %2$@. %3$d options";
 "message.polls.button.addComment" = "Add a Comment";
 "message.polls.button.updateComment" = "Update Your Comment";
 "message.polls.button.endVote" = "End Poll";

--- a/Sources/StreamChatSwiftUI/Resources/en.lproj/Localizable.strings
+++ b/Sources/StreamChatSwiftUI/Resources/en.lproj/Localizable.strings
@@ -85,6 +85,8 @@
 "message.polls.accessibility.selected" = "selected";
 "message.polls.accessibility.not-selected" = "not selected";
 "message.polls.accessibility.votes-including-yours" = "%d votes including yours";
+"message.polls.accessibility.leading-option" = "Leading option";
+"message.polls.accessibility.voter" = "%1$@, voted %2$@";
 "message.polls.button.addComment" = "Add a Comment";
 "message.polls.button.updateComment" = "Update Your Comment";
 "message.polls.button.endVote" = "End Poll";

--- a/StreamChatSwiftUI.xcodeproj/project.pbxproj
+++ b/StreamChatSwiftUI.xcodeproj/project.pbxproj
@@ -214,6 +214,7 @@
 				Tests/ChatChannel/MessageView_Tests.swift,
 				Tests/ChatChannel/MessageViewMultiRowReactions_Tests.swift,
 				Tests/ChatChannel/MoreReactionsView_Tests.swift,
+				Tests/ChatChannel/PollAccessibility_Tests.swift,
 				Tests/ChatChannel/PollAllOptionsView_Tests.swift,
 				Tests/ChatChannel/PollAttachmentView_Tests.swift,
 				Tests/ChatChannel/PollAttachmentViewModel_Tests.swift,
@@ -1524,20 +1525,20 @@
 				minimumVersion = 9.0.0;
 			};
 		};
-		E3A1C01A282BAC66002D1E26 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/getsentry/sentry-cocoa.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 8.30.0;
-			};
-		};
 		84E7F9E02EFAF9BF00BA56A3 /* XCRemoteSwiftPackageReference "stream-chat-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/GetStream/stream-chat-swift.git";
 			requirement = {
 				branch = develop;
 				kind = branch;
+			};
+		};
+		E3A1C01A282BAC66002D1E26 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/getsentry/sentry-cocoa.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 8.30.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/StreamChatSwiftUITests/Tests/ChatChannel/PollAccessibility_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/PollAccessibility_Tests.swift
@@ -1,0 +1,177 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamChat
+@testable import StreamChatSwiftUI
+import XCTest
+
+@MainActor final class PollAccessibility_Tests: StreamChatTestCase {
+    // MARK: - Header
+
+    func test_headerLabel_combinesNameSubtitleAndOptionCount() {
+        let label = PollAccessibility.headerLabel(
+            name: "Where to eat?",
+            subtitle: "Select one",
+            optionsCount: 4
+        )
+
+        XCTAssertEqual(
+            label,
+            L10n.Message.Polls.Accessibility.pollHeader("Where to eat?", "Select one", 4)
+        )
+    }
+
+    // MARK: - Option
+
+    func test_optionLabel_notSelected_zeroVotes_includesPosition() {
+        let label = PollAccessibility.optionLabel(
+            text: "Pizza",
+            isSelected: false,
+            voteCount: 0,
+            optionIndex: 2,
+            optionsCount: 4
+        )
+
+        let expected = L10n.Message.Polls.Accessibility.option(
+            "Pizza",
+            L10n.Message.Polls.Accessibility.notSelected,
+            L10n.Message.Polls.votes(0)
+        ) + ". " + L10n.Message.Polls.Accessibility.optionPosition(2, 4)
+        XCTAssertEqual(label, expected)
+    }
+
+    func test_optionLabel_selected_singleVote_usesSingularWording() {
+        let label = PollAccessibility.optionLabel(
+            text: "Pizza",
+            isSelected: true,
+            voteCount: 1,
+            optionIndex: 1,
+            optionsCount: 4
+        )
+
+        let expected = L10n.Message.Polls.Accessibility.option(
+            "Pizza",
+            L10n.Message.Polls.Accessibility.selected,
+            L10n.Message.Polls.voteSingular(1)
+        ) + ". " + L10n.Message.Polls.Accessibility.optionPosition(1, 4)
+        XCTAssertEqual(label, expected)
+    }
+
+    func test_optionLabel_selected_multipleVotes_usesIncludingYoursWording() {
+        let label = PollAccessibility.optionLabel(
+            text: "Pizza",
+            isSelected: true,
+            voteCount: 3,
+            optionIndex: 1,
+            optionsCount: 4
+        )
+
+        let expected = L10n.Message.Polls.Accessibility.option(
+            "Pizza",
+            L10n.Message.Polls.Accessibility.selected,
+            L10n.Message.Polls.Accessibility.votesIncludingYours(3)
+        ) + ". " + L10n.Message.Polls.Accessibility.optionPosition(1, 4)
+        XCTAssertEqual(label, expected)
+    }
+
+    func test_optionLabel_notSelected_multipleVotes_usesPluralWording() {
+        let label = PollAccessibility.optionLabel(
+            text: "Pizza",
+            isSelected: false,
+            voteCount: 3,
+            optionIndex: 1,
+            optionsCount: 4
+        )
+
+        let expected = L10n.Message.Polls.Accessibility.option(
+            "Pizza",
+            L10n.Message.Polls.Accessibility.notSelected,
+            L10n.Message.Polls.votes(3)
+        ) + ". " + L10n.Message.Polls.Accessibility.optionPosition(1, 4)
+        XCTAssertEqual(label, expected)
+    }
+
+    func test_optionLabel_withoutPosition_omitsPositionSuffix() {
+        let label = PollAccessibility.optionLabel(
+            text: "Pizza",
+            isSelected: false,
+            voteCount: 0,
+            optionIndex: nil,
+            optionsCount: nil
+        )
+
+        let expected = L10n.Message.Polls.Accessibility.option(
+            "Pizza",
+            L10n.Message.Polls.Accessibility.notSelected,
+            L10n.Message.Polls.votes(0)
+        )
+        XCTAssertEqual(label, expected)
+        XCTAssertFalse(label.contains(L10n.Message.Polls.Accessibility.optionPosition(1, 1)))
+    }
+
+    // MARK: - Question
+
+    func test_questionLabel_combinesQuestionAndName() {
+        let label = PollAccessibility.questionLabel(
+            question: L10n.Message.Polls.question,
+            name: "Where to eat?"
+        )
+
+        XCTAssertEqual(label, "\(L10n.Message.Polls.question). Where to eat?")
+    }
+
+    // MARK: - Results Option Heading
+
+    func test_resultsOptionHeadingLabel_withIndexLeadingAndMultipleVotes() {
+        let label = PollAccessibility.resultsOptionHeadingLabel(
+            optionIndex: 1,
+            optionText: "Pizza",
+            hasMostVotes: true,
+            voteCount: 3
+        )
+
+        let expected = [
+            "\(L10n.Message.Polls.option(1)): Pizza",
+            L10n.Message.Polls.Accessibility.leadingOption,
+            L10n.Message.Polls.votes(3)
+        ].joined(separator: ", ")
+        XCTAssertEqual(label, expected)
+    }
+
+    func test_resultsOptionHeadingLabel_withIndexNotLeadingSingleVote_usesSingularWording() {
+        let label = PollAccessibility.resultsOptionHeadingLabel(
+            optionIndex: 2,
+            optionText: "Sushi",
+            hasMostVotes: false,
+            voteCount: 1
+        )
+
+        let expected = [
+            "\(L10n.Message.Polls.option(2)): Sushi",
+            L10n.Message.Polls.voteSingular(1)
+        ].joined(separator: ", ")
+        XCTAssertEqual(label, expected)
+        XCTAssertFalse(label.contains(L10n.Message.Polls.Accessibility.leadingOption))
+    }
+
+    func test_resultsOptionHeadingLabel_withoutIndex_omitsOptionPrefix() {
+        let label = PollAccessibility.resultsOptionHeadingLabel(
+            optionIndex: nil,
+            optionText: "Sushi",
+            hasMostVotes: false,
+            voteCount: 0
+        )
+
+        let expected = ["Sushi", L10n.Message.Polls.votes(0)].joined(separator: ", ")
+        XCTAssertEqual(label, expected)
+    }
+
+    // MARK: - Voter
+
+    func test_voterLabel_combinesNameAndDate() {
+        let label = PollAccessibility.voterLabel(name: "Luke Skywalker", date: "09/04/26")
+
+        XCTAssertEqual(label, L10n.Message.Polls.Accessibility.voter("Luke Skywalker", "09/04/26"))
+    }
+}

--- a/StreamChatSwiftUITests/Tests/ChatChannel/ReactionsOverlayView_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/ReactionsOverlayView_Tests.swift
@@ -142,7 +142,18 @@ import XCTest
         }
 
         // Then
-        assertSnapshot(matching: view, as: .image(perceptualPrecision: precision))
+        // Pin the snapshot to the default screen size so layout does not try to
+        // measure the unconstrained tall message via sizeThatFits, which can hang on CI.
+        assertSnapshot(
+            matching: view,
+            as: .image(
+                perceptualPrecision: precision,
+                layout: .fixed(
+                    width: defaultScreenSize.width,
+                    height: defaultScreenSize.height
+                )
+            )
+        )
     }
 
     func test_reactionAnimatableView_snapshot() {


### PR DESCRIPTION
### 🔗 Issue Links

- [IOS-1778](https://linear.app/stream/issue/IOS-1778/a11y-poll-header-not-identified-as-a-poll-just-text)
- [IOS-1779](https://linear.app/stream/issue/IOS-1779/a11y-poll-options-split-into-many-focus-stops-radiotextavatarcount)
- [IOS-1790](https://linear.app/stream/issue/IOS-1790/a11y-poll-results-decorative-trophyavatar-announced-as-separate-stops)

### 🎯 Goal

Navigating a poll with VoiceOver was confusing: the poll header read as plain text with no indication it was a poll, every option was fragmented into several focus stops (radio, text, avatar, count), and the results screen exposed decorative trophy/avatar images as separate stops. This PR makes polls announce as coherent, meaningful elements.

### 📝 Summary

- Announce the poll header as a single element identified as a poll, including the selection rule and option count.
- Combine each poll option into one focus stop that conveys its text, selection state, vote count, and position.
- Hide decorative trophy and voter-avatar images from VoiceOver and combine the results option headings and voter rows into single elements.
- Read the poll results question section as one element ("Question. <name>").

### 🛠 Implementation

- Poll header, options, results headings, and voter rows now use `accessibilityElement(children: .ignore)` with composed labels, and add the appropriate traits (`.isHeader`, `.isButton`).
- Poll options receive their position (`Option X of Y`) by passing the index and count down from the option lists.
- The label-building logic is centralised in a `PollAccessibility` helper so the branching (selection state, singular/plural/"including yours" vote wording, leading option, option position) can be unit tested directly.
- New localization keys were added for the poll accessibility announcements.

### 🧪 Manual Testing Notes

- Enable VoiceOver and open a channel with a poll message.
- Swipe through the poll: the header should announce as a poll with the rule and option count, and each option should be a single stop with its state, vote count, and position.
- Open Poll Results: the question, each option heading (including the leading option), and each voter row should each be a single, clean announcement with no separate "image" stops.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VoiceOver behavior for poll screens so headers, options, results, and voter rows are announced more clearly.
  * Added better accessibility support for poll options, including selection state, position, and vote count wording.
  * Fixed a layout issue that could freeze the app when viewing very long messages in the reactions overlay.

* **New Features**
  * Added new localized accessibility text for poll-related VoiceOver announcements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->