### PR TITLE
Improve VoiceOver announcements for the channel list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🐞 Fixed
 - Keep the navigation bar and its buttons visible while searching in the add members screen [#1499](https://github.com/GetStream/stream-chat-swiftui/pull/1499)
+- Improve VoiceOver announcements for channel list items [#1504](https://github.com/GetStream/stream-chat-swiftui/pull/1504)
 
 ### ✅ Added
 - Add support for enhanced mention suggestions [#1497](https://github.com/GetStream/stream-chat-swiftui/pull/1497)
@@ -12,6 +13,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### ⚡️ Performance
 - Improve channel avatar loading performance in the channel list [#1501](https://github.com/GetStream/stream-chat-swiftui/pull/1501)
+
+### 🎭 New Localizations
+- `channel.item.accessibility.*` — VoiceOver labels for channel list items (conversation type, member and unread counts, last message, draft and open hint)
 
 # [5.5.1](https://github.com/GetStream/stream-chat-swiftui/releases/tag/5.5.1)
 _June 11, 2026_

--- a/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListItem.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListItem.swift
@@ -104,6 +104,8 @@ public struct ChatChannelListItem<Factory: ViewFactory>: View {
         }
         .foregroundColor(.black)
         .disabled(disabled)
+        .accessibilityLabel(viewModel.accessibilityLabel)
+        .accessibilityHint(Text(L10n.Channel.Item.Accessibility.openHint))
         .id("\(viewModel.channel.id)-base")
     }
 }

--- a/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListItemViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannelList/ChatChannelListItemViewModel.swift
@@ -179,6 +179,78 @@ import SwiftUI
         return utils.messageAttachmentPreviewIconProvider.image(for: previewIcon)
     }
 
+    // MARK: - Accessibility
+
+    /// A combined VoiceOver label that describes the whole channel list item as
+    /// a single element: name, conversation type, member count, unread state and
+    /// a contextual summary of the latest activity (message, draft or deleted).
+    open var accessibilityLabel: String {
+        var sentences: [String] = []
+
+        var header = [channelName]
+        if isDirectMessageChannel {
+            header.append(L10n.Channel.Item.Accessibility.directMessage)
+        } else {
+            header.append(L10n.Channel.Item.Accessibility.groupChat)
+            header.append(memberCountText)
+        }
+        sentences.append(header.joined(separator: ", "))
+
+        if isMuted {
+            sentences.append(L10n.Channel.Item.Accessibility.muted)
+        }
+
+        if hasUnread, unreadCount > 0 {
+            sentences.append(unreadText)
+        }
+
+        sentences.append(contentsOf: previewAccessibilitySentences)
+
+        return sentences.joined(separator: ". ")
+    }
+
+    private var isDirectMessageChannel: Bool {
+        channel.isDirectMessageChannel && channel.memberCount == 2
+    }
+
+    private var memberCountText: String {
+        L10n.Channel.Item.Accessibility.memberCount(channel.memberCount)
+    }
+
+    private var unreadText: String {
+        L10n.Channel.Item.Accessibility.unreadCount(unreadCount)
+    }
+
+    private var previewAccessibilitySentences: [String] {
+        if lastMessageFailedToSend {
+            return [L10n.Channel.Item.messageFailedToSend]
+        }
+        if isDraftMessagesEnabled, let draftText = draftMessageText {
+            var sentences = [L10n.Channel.Item.Accessibility.draft(draftText)]
+            if !timestampText.isEmpty {
+                sentences.append(L10n.Channel.Item.Accessibility.lastMessageTime(timestampText))
+            }
+            return sentences
+        }
+        guard let previewMessage else {
+            return [L10n.Channel.Item.emptyMessages]
+        }
+        if previewMessage.isDeleted {
+            return [L10n.Message.deletedMessagePlaceholder]
+        }
+        let sender = previewMessage.isSentByCurrentUser
+            ? L10n.Channel.Item.Accessibility.you
+            : (previewMessage.author.name ?? previewMessage.author.id)
+        let preview = utils.messagePreviewFormatter.formatContent(for: previewMessage, in: channel)
+        if showReadEvents {
+            let status = readUsers.isEmpty
+                ? L10n.Channel.Item.Accessibility.sent
+                : L10n.Channel.Item.Accessibility.sentAndRead
+            return [L10n.Channel.Item.Accessibility.lastMessageWithStatus(sender, timestampText, status, preview)]
+        }
+        return [L10n.Channel.Item.Accessibility.lastMessage(sender, timestampText, preview)]
+    }
+
     // MARK: - Private
 
     private let providedChannelName: String

--- a/Sources/StreamChatSwiftUI/Generated/L10n.swift
+++ b/Sources/StreamChatSwiftUI/Generated/L10n.swift
@@ -164,6 +164,46 @@ internal enum L10n {
       internal static var voiceMessage: String { L10n.tr("Localizable", "channel.item.voice-message") }
       /// You
       internal static var you: String { L10n.tr("Localizable", "channel.item.you") }
+      internal enum Accessibility {
+        /// direct message
+        internal static var directMessage: String { L10n.tr("Localizable", "channel.item.accessibility.direct-message") }
+        /// Draft message: %@
+        internal static func draft(_ p1: Any) -> String {
+          return L10n.tr("Localizable", "channel.item.accessibility.draft", String(describing: p1))
+        }
+        /// group chat
+        internal static var groupChat: String { L10n.tr("Localizable", "channel.item.accessibility.group-chat") }
+        /// Last message from %1$@ at %2$@: %3$@
+        internal static func lastMessage(_ p1: Any, _ p2: Any, _ p3: Any) -> String {
+          return L10n.tr("Localizable", "channel.item.accessibility.last-message", String(describing: p1), String(describing: p2), String(describing: p3))
+        }
+        /// Last message %@
+        internal static func lastMessageTime(_ p1: Any) -> String {
+          return L10n.tr("Localizable", "channel.item.accessibility.last-message-time", String(describing: p1))
+        }
+        /// Last message from %1$@ at %2$@, %3$@: %4$@
+        internal static func lastMessageWithStatus(_ p1: Any, _ p2: Any, _ p3: Any, _ p4: Any) -> String {
+          return L10n.tr("Localizable", "channel.item.accessibility.last-message-with-status", String(describing: p1), String(describing: p2), String(describing: p3), String(describing: p4))
+        }
+        /// Plural format key: "%#@members@"
+        internal static func memberCount(_ p1: Int) -> String {
+          return L10n.tr("Localizable", "channel.item.accessibility.member-count", p1)
+        }
+        /// Muted
+        internal static var muted: String { L10n.tr("Localizable", "channel.item.accessibility.muted") }
+        /// Opens the conversation
+        internal static var openHint: String { L10n.tr("Localizable", "channel.item.accessibility.open-hint") }
+        /// sent
+        internal static var sent: String { L10n.tr("Localizable", "channel.item.accessibility.sent") }
+        /// sent and read
+        internal static var sentAndRead: String { L10n.tr("Localizable", "channel.item.accessibility.sent-and-read") }
+        /// Plural format key: "%#@unread@"
+        internal static func unreadCount(_ p1: Int) -> String {
+          return L10n.tr("Localizable", "channel.item.accessibility.unread-count", p1)
+        }
+        /// you
+        internal static var you: String { L10n.tr("Localizable", "channel.item.accessibility.you") }
+      }
     }
     internal enum List {
       internal enum ScrollToBottom {

--- a/Sources/StreamChatSwiftUI/Resources/en.lproj/Localizable.strings
+++ b/Sources/StreamChatSwiftUI/Resources/en.lproj/Localizable.strings
@@ -18,6 +18,17 @@
 "channel.item.muted" = "Channel is muted";
 "channel.item.mute" = "Mute";
 "channel.item.unmute" = "Unmute";
+"channel.item.accessibility.direct-message" = "direct message";
+"channel.item.accessibility.group-chat" = "group chat";
+"channel.item.accessibility.muted" = "Muted";
+"channel.item.accessibility.you" = "you";
+"channel.item.accessibility.sent" = "sent";
+"channel.item.accessibility.sent-and-read" = "sent and read";
+"channel.item.accessibility.last-message" = "Last message from %1$@ at %2$@: %3$@";
+"channel.item.accessibility.last-message-with-status" = "Last message from %1$@ at %2$@, %3$@: %4$@";
+"channel.item.accessibility.last-message-time" = "Last message %@";
+"channel.item.accessibility.draft" = "Draft message: %@";
+"channel.item.accessibility.open-hint" = "Opens the conversation";
 "channel.name.direct-message" = "user";
 "channel.name.group" = "group";
 

--- a/Sources/StreamChatSwiftUI/Resources/en.lproj/Localizable.stringsdict
+++ b/Sources/StreamChatSwiftUI/Resources/en.lproj/Localizable.stringsdict
@@ -2,6 +2,38 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>channel.item.accessibility.member-count</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@members@</string>
+		<key>members</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d member</string>
+			<key>other</key>
+			<string>%d members</string>
+		</dict>
+	</dict>
+	<key>channel.item.accessibility.unread-count</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@unread@</string>
+		<key>unread</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d unread message</string>
+			<key>other</key>
+			<string>%d unread messages</string>
+		</dict>
+	</dict>
 	<key>chat-info.members.count</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/StreamChatSwiftUITests/Tests/ChatChannelList/ChatChannelListItemViewModel_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannelList/ChatChannelListItemViewModel_Tests.swift
@@ -353,4 +353,268 @@ import XCTest
 
         XCTAssertTrue(viewModel.preview.content is ChannelItemPreview.FailedToSendContent)
     }
+
+    // MARK: - Accessibility
+
+    func test_accessibilityLabel_dmChannel_headerOmitsMemberCount() {
+        let channel = ChatChannel.mockDMChannel(memberCount: 2, latestMessages: [])
+        let viewModel = ChatChannelListItemViewModel(channel: channel, channelName: "Alice")
+
+        let expected = [
+            "Alice, \(L10n.Channel.Item.Accessibility.directMessage)",
+            L10n.Channel.Item.emptyMessages
+        ].joined(separator: ". ")
+        XCTAssertEqual(viewModel.accessibilityLabel, expected)
+    }
+
+    func test_accessibilityLabel_groupChannel_includesGroupChatAndMemberCount() {
+        let channel = ChatChannel.mockNonDMChannel(memberCount: 5, latestMessages: [])
+        let viewModel = ChatChannelListItemViewModel(channel: channel, channelName: "Team")
+
+        let expected = [
+            "Team, \(L10n.Channel.Item.Accessibility.groupChat), \(L10n.Channel.Item.Accessibility.memberCount(5))",
+            L10n.Channel.Item.emptyMessages
+        ].joined(separator: ". ")
+        XCTAssertEqual(viewModel.accessibilityLabel, expected)
+    }
+
+    func test_accessibilityLabel_groupChannel_usesSingularMemberForSingleMember() {
+        let channel = ChatChannel.mockNonDMChannel(memberCount: 1, latestMessages: [])
+        let viewModel = ChatChannelListItemViewModel(channel: channel, channelName: "Team")
+
+        XCTAssertTrue(
+            viewModel.accessibilityLabel.contains(L10n.Channel.Item.Accessibility.memberCount(1))
+        )
+    }
+
+    func test_accessibilityLabel_whenChannelMuted_includesMutedState() {
+        let channel = ChatChannel.mockNonDMChannel(
+            memberCount: 3,
+            latestMessages: [],
+            muteDetails: .init(createdAt: .unique, updatedAt: .unique, expiresAt: nil)
+        )
+        let viewModel = ChatChannelListItemViewModel(channel: channel, channelName: "Team")
+
+        let expected = [
+            "Team, \(L10n.Channel.Item.Accessibility.groupChat), \(L10n.Channel.Item.Accessibility.memberCount(3))",
+            L10n.Channel.Item.Accessibility.muted,
+            L10n.Channel.Item.emptyMessages
+        ].joined(separator: ". ")
+        XCTAssertEqual(viewModel.accessibilityLabel, expected)
+    }
+
+    func test_accessibilityLabel_whenUnread_includesPluralUnreadCount() {
+        let channel = ChatChannel.mockNonDMChannel(
+            unreadCount: .mock(messages: 4),
+            memberCount: 3,
+            latestMessages: []
+        )
+        let viewModel = ChatChannelListItemViewModel(channel: channel, channelName: "Team")
+
+        XCTAssertTrue(
+            viewModel.accessibilityLabel.contains(L10n.Channel.Item.Accessibility.unreadCount(4))
+        )
+    }
+
+    func test_accessibilityLabel_whenSingleUnread_includesSingularUnreadCount() {
+        let channel = ChatChannel.mockNonDMChannel(
+            unreadCount: .mock(messages: 1),
+            memberCount: 3,
+            latestMessages: []
+        )
+        let viewModel = ChatChannelListItemViewModel(channel: channel, channelName: "Team")
+
+        XCTAssertTrue(
+            viewModel.accessibilityLabel.contains(L10n.Channel.Item.Accessibility.unreadCount(1))
+        )
+    }
+
+    func test_accessibilityLabel_whenNoUnread_omitsUnreadSentence() {
+        let channel = ChatChannel.mockNonDMChannel(
+            unreadCount: .noUnread,
+            memberCount: 3,
+            latestMessages: []
+        )
+        let viewModel = ChatChannelListItemViewModel(channel: channel, channelName: "Team")
+
+        XCTAssertFalse(
+            viewModel.accessibilityLabel.contains(L10n.Channel.Item.Accessibility.unreadCount(0))
+        )
+        XCTAssertFalse(viewModel.accessibilityLabel.contains("unread"))
+    }
+
+    func test_accessibilityLabel_lastMessageFromOtherUser() {
+        let message = ChatMessage.mock(
+            id: .unique,
+            cid: .unique,
+            text: "Hello there",
+            author: .mock(id: "yoda", name: "Yoda"),
+            isSentByCurrentUser: false
+        )
+        let channel = ChatChannel.mockNonDMChannel(
+            lastMessageAt: Date(timeIntervalSince1970: 100_000),
+            memberCount: 3,
+            latestMessages: [message]
+        )
+        let viewModel = ChatChannelListItemViewModel(channel: channel, channelName: "Team")
+
+        let expected = [
+            "Team, \(L10n.Channel.Item.Accessibility.groupChat), \(L10n.Channel.Item.Accessibility.memberCount(3))",
+            L10n.Channel.Item.Accessibility.lastMessage("Yoda", viewModel.timestampText, "Hello there")
+        ].joined(separator: ". ")
+        XCTAssertEqual(viewModel.accessibilityLabel, expected)
+    }
+
+    func test_accessibilityLabel_lastMessageFromCurrentUser_usesYouAndNoStatusWhenReadEventsDisabled() {
+        let message = ChatMessage.mock(
+            id: .unique,
+            cid: .unique,
+            text: "On my way",
+            author: .mock(id: Self.currentUserId, name: "Me"),
+            isSentByCurrentUser: true
+        )
+        let channel = ChatChannel.mockNonDMChannel(
+            lastMessageAt: Date(timeIntervalSince1970: 100_000),
+            config: .mock(readEventsEnabled: false),
+            memberCount: 3,
+            latestMessages: [message]
+        )
+        let viewModel = ChatChannelListItemViewModel(channel: channel, channelName: "Team")
+
+        let expected = [
+            "Team, \(L10n.Channel.Item.Accessibility.groupChat), \(L10n.Channel.Item.Accessibility.memberCount(3))",
+            L10n.Channel.Item.Accessibility.lastMessage(
+                L10n.Channel.Item.Accessibility.you,
+                viewModel.timestampText,
+                "On my way"
+            )
+        ].joined(separator: ". ")
+        XCTAssertEqual(viewModel.accessibilityLabel, expected)
+    }
+
+    func test_accessibilityLabel_whenReadEventsEnabledAndNoReaders_includesSentStatus() {
+        let message = ChatMessage.mock(
+            id: .unique,
+            cid: .unique,
+            text: "Ping",
+            author: .mock(id: Self.currentUserId, name: "Me"),
+            createdAt: Date(timeIntervalSince1970: 100),
+            isSentByCurrentUser: true
+        )
+        let channel = ChatChannel.mockNonDMChannel(
+            lastMessageAt: Date(timeIntervalSince1970: 100_000),
+            config: .mock(readEventsEnabled: true),
+            memberCount: 3,
+            latestMessages: [message]
+        )
+        let viewModel = ChatChannelListItemViewModel(channel: channel, channelName: "Team")
+
+        let expected = [
+            "Team, \(L10n.Channel.Item.Accessibility.groupChat), \(L10n.Channel.Item.Accessibility.memberCount(3))",
+            L10n.Channel.Item.Accessibility.lastMessageWithStatus(
+                L10n.Channel.Item.Accessibility.you,
+                viewModel.timestampText,
+                L10n.Channel.Item.Accessibility.sent,
+                "Ping"
+            )
+        ].joined(separator: ". ")
+        XCTAssertEqual(viewModel.accessibilityLabel, expected)
+    }
+
+    func test_accessibilityLabel_whenReadEventsEnabledAndHasReaders_includesSentAndReadStatus() {
+        let messageDate = Date(timeIntervalSince1970: 100)
+        let message = ChatMessage.mock(
+            id: .unique,
+            cid: .unique,
+            text: "Ping",
+            author: .mock(id: Self.currentUserId, name: "Me"),
+            createdAt: messageDate,
+            isSentByCurrentUser: true
+        )
+        let channel = ChatChannel.mockNonDMChannel(
+            lastMessageAt: Date(timeIntervalSince1970: 100_000),
+            config: .mock(readEventsEnabled: true),
+            memberCount: 3,
+            reads: [
+                .init(
+                    lastReadAt: messageDate.addingTimeInterval(10),
+                    lastReadMessageId: message.id,
+                    unreadMessagesCount: 0,
+                    user: .mock(id: "reader", name: "Reader"),
+                    lastDeliveredAt: nil,
+                    lastDeliveredMessageId: nil
+                )
+            ],
+            latestMessages: [message]
+        )
+        let viewModel = ChatChannelListItemViewModel(channel: channel, channelName: "Team")
+
+        XCTAssertTrue(
+            viewModel.accessibilityLabel.contains(L10n.Channel.Item.Accessibility.sentAndRead)
+        )
+    }
+
+    func test_accessibilityLabel_whenPreviewMessageDeleted_usesDeletedPlaceholder() {
+        let message = ChatMessage.mock(
+            id: .unique,
+            cid: .unique,
+            text: "Secret",
+            author: .mock(id: "yoda", name: "Yoda"),
+            createdAt: Date(timeIntervalSince1970: 0),
+            deletedAt: Date(timeIntervalSince1970: 100),
+            isSentByCurrentUser: false
+        )
+        let channel = ChatChannel.mockNonDMChannel(memberCount: 3, latestMessages: [message])
+        let viewModel = ChatChannelListItemViewModel(channel: channel, channelName: "Team")
+
+        let expected = [
+            "Team, \(L10n.Channel.Item.Accessibility.groupChat), \(L10n.Channel.Item.Accessibility.memberCount(3))",
+            L10n.Message.deletedMessagePlaceholder
+        ].joined(separator: ". ")
+        XCTAssertEqual(viewModel.accessibilityLabel, expected)
+    }
+
+    func test_accessibilityLabel_whenDraftPresent_includesDraftAndLastMessageTime() {
+        let draft = DraftMessage.mock(text: "Draft text")
+        let channel = ChatChannel.mockNonDMChannel(
+            lastMessageAt: Date(timeIntervalSince1970: 100_000),
+            memberCount: 3,
+            latestMessages: [],
+            draftMessage: draft
+        )
+        let viewModel = ChatChannelListItemViewModel(channel: channel, channelName: "Team")
+
+        let expected = [
+            "Team, \(L10n.Channel.Item.Accessibility.groupChat), \(L10n.Channel.Item.Accessibility.memberCount(3))",
+            L10n.Channel.Item.Accessibility.draft("Draft text"),
+            L10n.Channel.Item.Accessibility.lastMessageTime(viewModel.timestampText)
+        ].joined(separator: ". ")
+        XCTAssertEqual(viewModel.accessibilityLabel, expected)
+    }
+
+    func test_accessibilityLabel_whenLastMessageFailedToSend_usesFailedToSendText() {
+        let message = ChatMessage.mock(
+            id: .unique,
+            cid: .unique,
+            text: "Oops",
+            author: .mock(id: Self.currentUserId, name: "Me"),
+            localState: .sendingFailed,
+            isSentByCurrentUser: true
+        )
+        let channel = ChatChannel.mockNonDMChannel(memberCount: 3, latestMessages: [message])
+        let viewModel = ChatChannelListItemViewModel(channel: channel, channelName: "Team")
+
+        let expected = [
+            "Team, \(L10n.Channel.Item.Accessibility.groupChat), \(L10n.Channel.Item.Accessibility.memberCount(3))",
+            L10n.Channel.Item.messageFailedToSend
+        ].joined(separator: ". ")
+        XCTAssertEqual(viewModel.accessibilityLabel, expected)
+    }
+
+    func test_accessibilityLabel_whenEmptyChannel_usesEmptyPlaceholder() {
+        let channel = ChatChannel.mockNonDMChannel(memberCount: 3, latestMessages: [])
+        let viewModel = ChatChannelListItemViewModel(channel: channel, channelName: "Team")
+
+        XCTAssertTrue(viewModel.accessibilityLabel.hasSuffix(L10n.Channel.Item.emptyMessages))
+    }
 }


### PR DESCRIPTION
### 🔗 Issue Links

- [IOS-1782](https://linear.app/stream/issue/IOS-1782/a11y-channel-list-announcement-lacks-context-memberstimereadunread)

### 🎯 Goal

VoiceOver reads a channel list item as a string of disconnected fragments (e.g. "+14, Кпкк, 11:10, You: # t…, button"): the avatar overflow count is announced as a bare number, the timestamp and read state have no context, and there is no indication of conversation type or member count. This makes the channel list hard to understand with a screen reader. The goal is to announce each item as a single, meaningful element.

### 📝 Summary

- Announce each channel list item as one VoiceOver element with a rich, contextual label.
- Identify the conversation type (direct message / group chat) and the total member count for groups (instead of the avatar overflow number).
- Convey unread and muted state.
- Summarize the latest activity: last message with sender, time and read status, or a draft, deleted, failed, or empty-channel state.
- Add an accessibility hint ("Opens the conversation").

### 🛠 Implementation

- Add a composite `accessibilityLabel` to `ChatChannelListItemViewModel` that assembles the header (name, type, member count), state (muted, unread) and a contextual preview sentence.
- Apply `.accessibilityLabel` and `.accessibilityHint` on `ChatChannelListItem`.
- Add new localization keys, with pluralized member and unread counts via `Localizable.stringsdict`.

### 🎨 Showcase

_VoiceOver-only change; no visual difference._

### 🧪 Manual Testing Notes

1. Enable VoiceOver.
2. Open the channel list and swipe through the items.
3. Each item should be a single focus stop announcing name, type, member count (groups), unread/muted state and a summary of the last activity, followed by the "Opens the conversation" hint.
4. Verify direct messages, groups, muted channels, channels with unread messages, drafts, and deleted/failed last messages.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo