### PR TITLE
Fix deadlock when building message actions in reactions overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Keep the navigation bar and its buttons visible while searching in the add members screen [#1499](https://github.com/GetStream/stream-chat-swiftui/pull/1499)
 - Improve VoiceOver support for polls so the header, options, and results announce as coherent elements [#1503](https://github.com/GetStream/stream-chat-swiftui/pull/1503)
 - Improve VoiceOver announcements for channel list items [#1504](https://github.com/GetStream/stream-chat-swiftui/pull/1504)
-- Avoid a layout loop in the reactions overlay that could freeze the UI for very long messages [#1506](https://github.com/GetStream/stream-chat-swiftui/pull/1506)
+- Avoid a deadlock when building message actions in the reactions overlay that could freeze the UI for very long messages [#1506](https://github.com/GetStream/stream-chat-swiftui/pull/1506)
 
 ### ✅ Added
 - Add support for enhanced mention suggestions [#1497](https://github.com/GetStream/stream-chat-swiftui/pull/1497)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Keep the navigation bar and its buttons visible while searching in the add members screen [#1499](https://github.com/GetStream/stream-chat-swiftui/pull/1499)
 - Improve VoiceOver support for polls so the header, options, and results announce as coherent elements [#1503](https://github.com/GetStream/stream-chat-swiftui/pull/1503)
 - Improve VoiceOver announcements for channel list items [#1504](https://github.com/GetStream/stream-chat-swiftui/pull/1504)
+- Avoid a layout loop in the reactions overlay that could freeze the UI for very long messages [#1506](https://github.com/GetStream/stream-chat-swiftui/pull/1506)
 
 ### ✅ Added
 - Add support for enhanced mention suggestions [#1497](https://github.com/GetStream/stream-chat-swiftui/pull/1497)

--- a/Sources/StreamChatSwiftUI/ChatChannelList/DefaultChannelActions.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannelList/DefaultChannelActions.swift
@@ -35,7 +35,7 @@ extension ChannelAction {
         }
 
         if let otherMember = channel.lastActiveMembers.first(where: { $0.id != chatClient.currentUserId }) {
-            let blockedIds = chatClient.currentUserController().dataStore.currentUser()?.blockedUserIds ?? []
+            let blockedIds = chatClient.currentUserController().currentUser?.blockedUserIds ?? []
             actions.append(
                 blockedIds.contains(otherMember.id)
                     ? unblockUserAction(for: otherMember, chatClient: chatClient, onDismiss: onDismiss, onError: onError)

--- a/Sources/StreamChatSwiftUI/ChatMessageList/Reactions/MessageActions/DefaultMessageActions.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/Reactions/MessageActions/DefaultMessageActions.swift
@@ -200,8 +200,7 @@ public extension MessageAction {
             }
             
             if InjectedValues[\.utils].messageListConfig.userBlockingEnabled {
-                let userController = chatClient.currentUserController()
-                let blockedUserIds = userController.dataStore.currentUser()?.blockedUserIds ?? []
+                let blockedUserIds = chatClient.currentUserController().currentUser?.blockedUserIds ?? []
                 if blockedUserIds.contains(message.author.id) {
                     let unblockAction = unblockUserAction(
                         for: message,

--- a/Sources/StreamChatSwiftUI/ChatMessageList/Reactions/ReactionsOverlayView.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/Reactions/ReactionsOverlayView.swift
@@ -32,7 +32,6 @@ public struct ReactionsOverlayView<Factory: ViewFactory>: View {
     @State private var screenHeight = UIScreen.main.bounds.size.height
     @State private var orientationChanged = false
     @State private var moreReactionsShown = false
-    @State private var naturalContentHeight: CGFloat = 0
     @State private var measuredTotalContentHeight: CGFloat = 0
 
     private let factory: Factory
@@ -119,7 +118,7 @@ public struct ReactionsOverlayView<Factory: ViewFactory>: View {
                     messageActionsView(reader: reader)
                 }
                 .frame(width: overlayContentWidth, alignment: isRightAligned ? .trailing : .leading)
-                .frame(height: measuredTotalContentHeight > 0 ? measuredTotalContentHeight : nil)
+                .frame(height: measuredTotalContentHeight > 0 ? min(measuredTotalContentHeight, allowedTotalContentHeight) : nil)
                 .background(
                     GeometryReader { proxy in
                         Color.clear.preference(
@@ -134,25 +133,17 @@ public struct ReactionsOverlayView<Factory: ViewFactory>: View {
         .onPreferenceChange(HeightPreferenceKey.self) { value in
             if let value, value != screenHeight {
                 screenHeight = value
-                updateContentHeights()
             }
         }
         .onPreferenceChange(OverlayContentHeightKey.self) { value in
-            guard value > 0 else { return }
-            // Keep the tallest observed height. Enabling the scroll view shrinks the
-            // measured height to the clamped value; using that lower measurement to
-            // decide `usesScrollView` toggles scroll off again and re-expands the
-            // content, which never converges on iOS 26.2.
-            let updatedNatural = max(naturalContentHeight, value)
-            guard updatedNatural != naturalContentHeight else { return }
-            naturalContentHeight = updatedNatural
-            updateContentHeights()
+            if value > 0 {
+                measuredTotalContentHeight = value
+            }
         }
         .onChange(of: measuredTotalContentHeight) { _ in
             messageViewModel.usesScrollView = usesScrollView
         }
         .onChange(of: screenHeight) { _ in
-            updateContentHeights()
             messageViewModel.usesScrollView = usesScrollView
         }
         .edgesIgnoringSafeArea(.all)
@@ -174,8 +165,6 @@ public struct ReactionsOverlayView<Factory: ViewFactory>: View {
         .onRotate { _ in
             if isIPad {
                 orientationChanged = true
-                naturalContentHeight = 0
-                measuredTotalContentHeight = 0
             }
         }
         .sheet(isPresented: $moreReactionsShown) {
@@ -339,14 +328,9 @@ public struct ReactionsOverlayView<Factory: ViewFactory>: View {
 
     // MARK: - Origin Y
 
-    private func updateContentHeights() {
-        guard naturalContentHeight > 0 else { return }
-        measuredTotalContentHeight = min(naturalContentHeight, allowedTotalContentHeight)
-    }
-
     private var usesScrollView: Bool {
-        guard naturalContentHeight > 0 else { return false }
-        return naturalContentHeight >= allowedTotalContentHeight
+        guard measuredTotalContentHeight > 0 else { return false }
+        return measuredTotalContentHeight >= allowedTotalContentHeight
     }
     
     private var allowedTotalContentHeight: CGFloat { screenHeight - topContentSpacing - bottomContentSpacing }

--- a/Sources/StreamChatSwiftUI/ChatMessageList/Reactions/ReactionsOverlayView.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/Reactions/ReactionsOverlayView.swift
@@ -335,7 +335,7 @@ public struct ReactionsOverlayView<Factory: ViewFactory>: View {
 
     // MARK: - Origin Y
 
-    /// Minimum height delta (in points) required to react to a measured height
+    /// Minimum height delta required to react to a measured height
     /// change. Prevents a sub-point layout feedback loop around the scroll-view
     /// threshold from re-triggering layout indefinitely.
     private static var heightChangeTolerance: CGFloat { 1 }

--- a/Sources/StreamChatSwiftUI/ChatMessageList/Reactions/ReactionsOverlayView.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/Reactions/ReactionsOverlayView.swift
@@ -131,12 +131,19 @@ public struct ReactionsOverlayView<Factory: ViewFactory>: View {
             }
         }
         .onPreferenceChange(HeightPreferenceKey.self) { value in
-            if let value, value != screenHeight {
+            if let value, abs(value - screenHeight) > Self.heightChangeTolerance {
                 screenHeight = value
             }
         }
         .onPreferenceChange(OverlayContentHeightKey.self) { value in
-            if value > 0 {
+            // The content height is measured after it is clamped by
+            // `allowedTotalContentHeight`, and it also flips `usesScrollView` at
+            // that same boundary. A message whose content sits right on the
+            // boundary can therefore oscillate by sub-point amounts each layout
+            // pass and never converge (observed as a hang on iOS 26.2). Ignoring
+            // sub-point changes breaks the loop without affecting the layout,
+            // which only needs point accuracy for the scroll-view threshold.
+            if value > 0, abs(value - measuredTotalContentHeight) > Self.heightChangeTolerance {
                 measuredTotalContentHeight = value
             }
         }
@@ -327,6 +334,11 @@ public struct ReactionsOverlayView<Factory: ViewFactory>: View {
     }
 
     // MARK: - Origin Y
+
+    /// Minimum height delta (in points) required to react to a measured height
+    /// change. Prevents a sub-point layout feedback loop around the scroll-view
+    /// threshold from re-triggering layout indefinitely.
+    private static var heightChangeTolerance: CGFloat { 1 }
 
     private var usesScrollView: Bool {
         guard measuredTotalContentHeight > 0 else { return false }

--- a/Sources/StreamChatSwiftUI/ChatMessageList/Reactions/ReactionsOverlayView.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/Reactions/ReactionsOverlayView.swift
@@ -32,6 +32,7 @@ public struct ReactionsOverlayView<Factory: ViewFactory>: View {
     @State private var screenHeight = UIScreen.main.bounds.size.height
     @State private var orientationChanged = false
     @State private var moreReactionsShown = false
+    @State private var naturalContentHeight: CGFloat = 0
     @State private var measuredTotalContentHeight: CGFloat = 0
 
     private let factory: Factory
@@ -118,7 +119,7 @@ public struct ReactionsOverlayView<Factory: ViewFactory>: View {
                     messageActionsView(reader: reader)
                 }
                 .frame(width: overlayContentWidth, alignment: isRightAligned ? .trailing : .leading)
-                .frame(height: measuredTotalContentHeight > 0 ? min(measuredTotalContentHeight, allowedTotalContentHeight) : nil)
+                .frame(height: measuredTotalContentHeight > 0 ? measuredTotalContentHeight : nil)
                 .background(
                     GeometryReader { proxy in
                         Color.clear.preference(
@@ -131,26 +132,27 @@ public struct ReactionsOverlayView<Factory: ViewFactory>: View {
             }
         }
         .onPreferenceChange(HeightPreferenceKey.self) { value in
-            if let value, abs(value - screenHeight) > Self.heightChangeTolerance {
+            if let value, value != screenHeight {
                 screenHeight = value
+                updateContentHeights()
             }
         }
         .onPreferenceChange(OverlayContentHeightKey.self) { value in
-            // The content height is measured after it is clamped by
-            // `allowedTotalContentHeight`, and it also flips `usesScrollView` at
-            // that same boundary. A message whose content sits right on the
-            // boundary can therefore oscillate by sub-point amounts each layout
-            // pass and never converge (observed as a hang on iOS 26.2). Ignoring
-            // sub-point changes breaks the loop without affecting the layout,
-            // which only needs point accuracy for the scroll-view threshold.
-            if value > 0, abs(value - measuredTotalContentHeight) > Self.heightChangeTolerance {
-                measuredTotalContentHeight = value
-            }
+            guard value > 0 else { return }
+            // Keep the tallest observed height. Enabling the scroll view shrinks the
+            // measured height to the clamped value; using that lower measurement to
+            // decide `usesScrollView` toggles scroll off again and re-expands the
+            // content, which never converges on iOS 26.2.
+            let updatedNatural = max(naturalContentHeight, value)
+            guard updatedNatural != naturalContentHeight else { return }
+            naturalContentHeight = updatedNatural
+            updateContentHeights()
         }
         .onChange(of: measuredTotalContentHeight) { _ in
             messageViewModel.usesScrollView = usesScrollView
         }
         .onChange(of: screenHeight) { _ in
+            updateContentHeights()
             messageViewModel.usesScrollView = usesScrollView
         }
         .edgesIgnoringSafeArea(.all)
@@ -172,6 +174,8 @@ public struct ReactionsOverlayView<Factory: ViewFactory>: View {
         .onRotate { _ in
             if isIPad {
                 orientationChanged = true
+                naturalContentHeight = 0
+                measuredTotalContentHeight = 0
             }
         }
         .sheet(isPresented: $moreReactionsShown) {
@@ -335,14 +339,14 @@ public struct ReactionsOverlayView<Factory: ViewFactory>: View {
 
     // MARK: - Origin Y
 
-    /// Minimum height delta required to react to a measured height
-    /// change. Prevents a sub-point layout feedback loop around the scroll-view
-    /// threshold from re-triggering layout indefinitely.
-    private static var heightChangeTolerance: CGFloat { 1 }
+    private func updateContentHeights() {
+        guard naturalContentHeight > 0 else { return }
+        measuredTotalContentHeight = min(naturalContentHeight, allowedTotalContentHeight)
+    }
 
     private var usesScrollView: Bool {
-        guard measuredTotalContentHeight > 0 else { return false }
-        return measuredTotalContentHeight >= allowedTotalContentHeight
+        guard naturalContentHeight > 0 else { return false }
+        return naturalContentHeight >= allowedTotalContentHeight
     }
     
     private var allowedTotalContentHeight: CGFloat { screenHeight - topContentSpacing - bottomContentSpacing }


### PR DESCRIPTION
## Summary
- Fix a Core Data deadlock that freezes the reactions overlay (and hangs `test_reactionsOverlay_veryLongMessage` on CI) when resolving block/unblock message actions
- Use the in-memory `currentUserController().currentUser` property instead of `dataStore.currentUser()`, which performs a synchronous `readAndWait` during SwiftUI layout

## Test plan
- [x] `test_reactionsOverlay_veryLongMessage` passes locally
- [ ] Smoke Checks pass on iOS 26.2 CI (previously hung at `ReactionsOverlayView_Tests`)

### 🔗 Issue Links

_Unblocks CI hangs observed while working on PR #1503._

### 🎯 Goal

Fix a deadlock when the reactions overlay builds its message actions menu for messages from other users, which caused CI to hang indefinitely on iOS 26.2.

### 📝 Summary

- Replace `dataStore.currentUser()` with `currentUserController().currentUser` in `DefaultMessageActions` when checking blocked users
- Apply the same fix in `DefaultChannelActions` (same latent pattern)

### 🛠 Implementation

Building default message actions for incoming messages calls into the user-blocking branch, which previously used:

```swift
userController.dataStore.currentUser()?.blockedUserIds
```

`DataStore.currentUser()` calls `DatabaseContainer.readAndWait`, a synchronous Core Data read. When this runs during SwiftUI layout (e.g. while snapshotting `ReactionsOverlayView`), it deadlocks on the `NSManagedObjectContext` serial queue.

The mute/unmute check in the same method already uses the safe in-memory accessor:

```swift
chatClient.currentUserController().currentUser
```

This PR aligns the block/unblock check with that pattern.

### 🧪 Manual Testing Notes

Open the reactions/actions overlay on a message from another user and verify block/unblock actions appear correctly when user blocking is enabled.

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo