### PR TITLE
Send Files/iCloud picker images and videos as their proper type (v4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🐞 Fixed
 - Fix the composer attachment picker collapsing the paperclip icon into an arrow while typing when only a single picker item is available [#1496](https://github.com/GetStream/stream-chat-swiftui/pull/1496)
-- Send images and videos picked from the Files/iCloud picker as their proper type so they render inline instead of as downloadable files
+- Send images and videos picked from the Files/iCloud picker as their proper type so they render inline instead of as downloadable files [#1516](https://github.com/GetStream/stream-chat-swiftui/pull/1516)
 
 ### 🔄 Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🐞 Fixed
 - Fix the composer attachment picker collapsing the paperclip icon into an arrow while typing when only a single picker item is available [#1496](https://github.com/GetStream/stream-chat-swiftui/pull/1496)
+- Send images and videos picked from the Files/iCloud picker as their proper type so they render inline instead of as downloadable files
 
 ### 🔄 Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🐞 Fixed
 - Fix the composer attachment picker collapsing the paperclip icon into an arrow while typing when only a single picker item is available [#1496](https://github.com/GetStream/stream-chat-swiftui/pull/1496)
-- Send images and videos picked from the Files/iCloud picker as their proper type so they render inline instead of as downloadable files [#1516](https://github.com/GetStream/stream-chat-swiftui/pull/1516)
+- Send images and videos picked from the Files/iCloud picker as their proper type so they render inline instead of as downloadable files [#1516](https://github.com/GetStream/stream-chat-swiftui/pull/1516) [#1527](https://github.com/GetStream/stream-chat-swiftui/pull/1527)
 
 ### 🔄 Changed
 

--- a/DemoAppSwiftUI/AppleMessageComposerView.swift
+++ b/DemoAppSwiftUI/AppleMessageComposerView.swift
@@ -103,7 +103,7 @@ struct AppleMessageComposerView<Factory: ViewFactory>: View, KeyboardReadable {
                 attachmentPickerState: $viewModel.pickerState,
                 filePickerShown: $viewModel.filePickerShown,
                 cameraPickerShown: $viewModel.cameraPickerShown,
-                addedFileURLs: $viewModel.addedFileURLs,
+                addedFileURLs: viewModel.pickedFileURLsBinding,
                 onPickerStateChange: viewModel.change(pickerState:),
                 photoLibraryAssets: viewModel.imageAssets,
                 onAssetTap: viewModel.imageTapped(_:),

--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/AddedFileAttachmentsView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/AddedFileAttachmentsView.swift
@@ -44,13 +44,9 @@ public struct AddedFileAttachmentsView: View {
 
 extension URL {
     var sizeString: String {
-        let didStartAccessing = startAccessingSecurityScopedResource()
-        defer {
-            if didStartAccessing {
-                stopAccessingSecurityScopedResource()
-            }
-        }
+        _ = startAccessingSecurityScopedResource()
         if let file = try? AttachmentFile(url: self) {
+            stopAccessingSecurityScopedResource()
             return file.sizeString
         }
 

--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/AddedFileAttachmentsView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/AddedFileAttachmentsView.swift
@@ -44,9 +44,13 @@ public struct AddedFileAttachmentsView: View {
 
 extension URL {
     var sizeString: String {
-        _ = startAccessingSecurityScopedResource()
+        let didStartAccessing = startAccessingSecurityScopedResource()
+        defer {
+            if didStartAccessing {
+                stopAccessingSecurityScopedResource()
+            }
+        }
         if let file = try? AttachmentFile(url: self) {
-            stopAccessingSecurityScopedResource()
             return file.sizeString
         }
 

--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerView.swift
@@ -149,7 +149,7 @@ public struct MessageComposerView<Factory: ViewFactory>: View, KeyboardReadable 
                 attachmentPickerState: $viewModel.pickerState,
                 filePickerShown: $viewModel.filePickerShown,
                 cameraPickerShown: $viewModel.cameraPickerShown,
-                addedFileURLs: $viewModel.addedFileURLs,
+                addedFileURLs: viewModel.pickedFileURLsBinding,
                 onPickerStateChange: viewModel.change(pickerState:),
                 photoLibraryAssets: viewModel.imageAssets,
                 onAssetTap: viewModel.imageTapped(_:),

--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerViewModel.swift
@@ -642,12 +642,7 @@ open class MessageComposerViewModel: ObservableObject {
     /// `MessageAttachmentsConverter` still resolves the correct attachment type from the file
     /// extension when sending it.
     private static func mediaAsset(fromPickedFileURL url: URL) -> AddedAsset? {
-        let didStartAccessing = url.startAccessingSecurityScopedResource()
-        defer {
-            if didStartAccessing {
-                url.stopAccessingSecurityScopedResource()
-            }
-        }
+        _ = url.startAccessingSecurityScopedResource()
 
         switch AttachmentType(fileExtension: url.pathExtension) {
         case .image:
@@ -991,14 +986,9 @@ open class MessageComposerViewModel: ObservableObject {
     
     private func checkAttachmentSize(with url: URL?) -> Bool {
         guard let url = url else { return true }
-
-        let didStartAccessing = url.startAccessingSecurityScopedResource()
-        defer {
-            if didStartAccessing {
-                url.stopAccessingSecurityScopedResource()
-            }
-        }
-
+        
+        _ = url.startAccessingSecurityScopedResource()
+        
         do {
             let fileSize = try AttachmentFile(url: url).size
             let canAdd = fileSize < chatClient.maxAttachmentSize(for: url)
@@ -1080,12 +1070,7 @@ class MessageAttachmentsConverter {
 
         var attachments = try mediaAssets.map { try $0.toAttachmentPayload() }
         attachments += try fileAssets.map { file in
-            let didStartAccessing = file.url.startAccessingSecurityScopedResource()
-            defer {
-                if didStartAccessing {
-                    file.url.stopAccessingSecurityScopedResource()
-                }
-            }
+            _ = file.url.startAccessingSecurityScopedResource()
             if let filePayload = file.payload {
                 return AnyAttachmentPayload(payload: filePayload)
             }
@@ -1101,12 +1086,7 @@ class MessageAttachmentsConverter {
             return try AnyAttachmentPayload(localFileURL: file.url, attachmentType: attachmentType)
         }
         attachments += try voiceAssets.map { recording in
-            let didStartAccessing = recording.url.startAccessingSecurityScopedResource()
-            defer {
-                if didStartAccessing {
-                    recording.url.stopAccessingSecurityScopedResource()
-                }
-            }
+            _ = recording.url.startAccessingSecurityScopedResource()
             var localMetadata = AnyAttachmentLocalMetadata()
             localMetadata.duration = recording.duration
             localMetadata.waveformData = recording.waveform

--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerViewModel.swift
@@ -642,7 +642,12 @@ open class MessageComposerViewModel: ObservableObject {
     /// `MessageAttachmentsConverter` still resolves the correct attachment type from the file
     /// extension when sending it.
     private static func mediaAsset(fromPickedFileURL url: URL) -> AddedAsset? {
-        _ = url.startAccessingSecurityScopedResource()
+        let didStartAccessing = url.startAccessingSecurityScopedResource()
+        defer {
+            if didStartAccessing {
+                url.stopAccessingSecurityScopedResource()
+            }
+        }
 
         switch AttachmentType(fileExtension: url.pathExtension) {
         case .image:
@@ -986,9 +991,14 @@ open class MessageComposerViewModel: ObservableObject {
     
     private func checkAttachmentSize(with url: URL?) -> Bool {
         guard let url = url else { return true }
-        
-        _ = url.startAccessingSecurityScopedResource()
-        
+
+        let didStartAccessing = url.startAccessingSecurityScopedResource()
+        defer {
+            if didStartAccessing {
+                url.stopAccessingSecurityScopedResource()
+            }
+        }
+
         do {
             let fileSize = try AttachmentFile(url: url).size
             let canAdd = fileSize < chatClient.maxAttachmentSize(for: url)
@@ -1070,7 +1080,12 @@ class MessageAttachmentsConverter {
 
         var attachments = try mediaAssets.map { try $0.toAttachmentPayload() }
         attachments += try fileAssets.map { file in
-            _ = file.url.startAccessingSecurityScopedResource()
+            let didStartAccessing = file.url.startAccessingSecurityScopedResource()
+            defer {
+                if didStartAccessing {
+                    file.url.stopAccessingSecurityScopedResource()
+                }
+            }
             if let filePayload = file.payload {
                 return AnyAttachmentPayload(payload: filePayload)
             }
@@ -1086,7 +1101,12 @@ class MessageAttachmentsConverter {
             return try AnyAttachmentPayload(localFileURL: file.url, attachmentType: attachmentType)
         }
         attachments += try voiceAssets.map { recording in
-            _ = recording.url.startAccessingSecurityScopedResource()
+            let didStartAccessing = recording.url.startAccessingSecurityScopedResource()
+            defer {
+                if didStartAccessing {
+                    recording.url.stopAccessingSecurityScopedResource()
+                }
+            }
             var localMetadata = AnyAttachmentLocalMetadata()
             localMetadata.duration = recording.duration
             localMetadata.waveformData = recording.waveform

--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerViewModel.swift
@@ -2,7 +2,6 @@
 // Copyright © 2026 Stream.io Inc. All rights reserved.
 //
 
-import AVFoundation
 import Combine
 import Photos
 import StreamChat
@@ -89,10 +88,6 @@ open class MessageComposerViewModel: ObservableObject {
                 || !checkAttachmentSize(with: addedFileURLs.last) {
                 addedFileURLs.removeLast()
             }
-            // Move images and videos picked from the Files/iCloud picker into media
-            // assets, so they render inline in the composer and are sent as their proper
-            // type instead of as a generic file.
-            routePickedMediaFilesToAssets(newlyAdded: addedFileURLs.filter { !oldValue.contains($0) })
             checkPickerSelectionState()
 
             if shouldDeleteDraftMessage(oldValue: oldValue) {
@@ -570,90 +565,7 @@ open class MessageComposerViewModel: ObservableObject {
         )
         addedAssets.append(addedImage)
     }
-
-    /// Moves the given picked file URLs that are images or videos out of `addedFileURLs`
-    /// and into `addedAssets` as media, so they render inline and are sent as their
-    /// proper type. Other files are left untouched as regular file attachments.
-    private func routePickedMediaFilesToAssets(newlyAdded urls: [URL]) {
-        let mediaAssets = urls.compactMap { mediaAsset(fromPickedFileURL: $0) }
-        guard !mediaAssets.isEmpty else { return }
-        let mediaURLs = Set(urls.filter { AttachmentType(fileExtension: $0.pathExtension) == .image
-                || AttachmentType(fileExtension: $0.pathExtension) == .video
-        })
-        addedFileURLs.removeAll { mediaURLs.contains($0) }
-        addedAssets.append(contentsOf: mediaAssets)
-    }
-
-    /// Builds a media asset from a file picked in the Files/iCloud picker when it is an
-    /// image or a video. Returns `nil` for other files (and when the media can't be read).
-    private func mediaAsset(fromPickedFileURL url: URL) -> AddedAsset? {
-        let attachmentType = AttachmentType(fileExtension: url.pathExtension)
-        guard attachmentType == .image || attachmentType == .video else { return nil }
-
-        // Copy into an app-owned temporary file so the asset behaves like the other media
-        // sources (camera/photos/paste) and no longer depends on the security-scoped
-        // picker URL when it is uploaded.
-        let didStartAccessing = url.startAccessingSecurityScopedResource()
-        defer { if didStartAccessing { url.stopAccessingSecurityScopedResource() } }
-        guard let localURL = try? copyToTemporaryFile(from: url) else { return nil }
-
-        switch attachmentType {
-        case .image:
-            guard let data = try? Data(contentsOf: localURL), let image = UIImage(data: data) else {
-                try? FileManager.default.removeItem(at: localURL)
-                return nil
-            }
-            let scale = image.scale
-            return AddedAsset(
-                image: image,
-                id: UUID().uuidString,
-                url: localURL,
-                type: .image,
-                originalWidth: Double(image.size.width * scale),
-                originalHeight: Double(image.size.height * scale)
-            )
-        case .video:
-            let asset = AVURLAsset(url: localURL, options: nil)
-            let imageGenerator = AVAssetImageGenerator(asset: asset)
-            imageGenerator.appliesPreferredTrackTransform = true
-            guard let cgImage = try? imageGenerator.copyCGImage(
-                at: CMTimeMake(value: 0, timescale: 1),
-                actualTime: nil
-            ) else {
-                try? FileManager.default.removeItem(at: localURL)
-                return nil
-            }
-            let duration = CMTimeGetSeconds(asset.duration)
-            // Apply the track's preferred transform so portrait videos report the
-            // displayed dimensions, consistent with the (transformed) thumbnail, instead
-            // of the raw natural size which can have width/height swapped.
-            var displaySize = CGSize.zero
-            if let track = asset.tracks(withMediaType: .video).first {
-                let transformed = track.naturalSize.applying(track.preferredTransform)
-                displaySize = CGSize(width: abs(transformed.width), height: abs(transformed.height))
-            }
-            return AddedAsset(
-                image: UIImage(cgImage: cgImage),
-                id: UUID().uuidString,
-                url: localURL,
-                type: .video,
-                originalWidth: Double(displaySize.width),
-                originalHeight: Double(displaySize.height),
-                duration: duration.isFinite ? duration : nil
-            )
-        default:
-            return nil
-        }
-    }
-
-    private func copyToTemporaryFile(from url: URL) throws -> URL {
-        let temporaryURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString)
-            .appendingPathExtension(url.pathExtension)
-        try FileManager.default.copyItem(at: url, to: temporaryURL)
-        return temporaryURL
-    }
-
+    
     public func removeAttachment(with id: String) {
         if id.isURL, let url = URL(string: id) {
             var urls = [URL]()
@@ -1083,7 +995,16 @@ class MessageAttachmentsConverter {
             if let filePayload = file.payload {
                 return AnyAttachmentPayload(payload: filePayload)
             }
-            return try AnyAttachmentPayload(localFileURL: file.url, attachmentType: .file)
+            // Resolve the attachment type from the file's extension so that images and
+            // videos picked from the Files/iCloud picker are sent as their proper type
+            // (and render inline) instead of always being sent as a generic file.
+            var attachmentType = AttachmentType(fileExtension: file.url.pathExtension)
+            // Audio files are treated as regular files, since the composer only
+            // supports audio through voice recordings.
+            if attachmentType == .audio {
+                attachmentType = .file
+            }
+            return try AnyAttachmentPayload(localFileURL: file.url, attachmentType: attachmentType)
         }
         attachments += try voiceAssets.map { recording in
             _ = recording.url.startAccessingSecurityScopedResource()

--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerViewModel.swift
@@ -624,14 +624,21 @@ open class MessageComposerViewModel: ObservableObject {
                 return nil
             }
             let duration = CMTimeGetSeconds(asset.duration)
-            let naturalSize = asset.tracks(withMediaType: .video).first?.naturalSize ?? .zero
+            // Apply the track's preferred transform so portrait videos report the
+            // displayed dimensions, consistent with the (transformed) thumbnail, instead
+            // of the raw natural size which can have width/height swapped.
+            var displaySize = CGSize.zero
+            if let track = asset.tracks(withMediaType: .video).first {
+                let transformed = track.naturalSize.applying(track.preferredTransform)
+                displaySize = CGSize(width: abs(transformed.width), height: abs(transformed.height))
+            }
             return AddedAsset(
                 image: UIImage(cgImage: cgImage),
                 id: UUID().uuidString,
                 url: localURL,
                 type: .video,
-                originalWidth: Double(naturalSize.width),
-                originalHeight: Double(naturalSize.height),
+                originalWidth: Double(displaySize.width),
+                originalHeight: Double(displaySize.height),
                 duration: duration.isFinite ? duration : nil
             )
         default:

--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerViewModel.swift
@@ -2,6 +2,7 @@
 // Copyright © 2026 Stream.io Inc. All rights reserved.
 //
 
+import AVFoundation
 import Combine
 import Photos
 import StreamChat
@@ -88,6 +89,10 @@ open class MessageComposerViewModel: ObservableObject {
                 || !checkAttachmentSize(with: addedFileURLs.last) {
                 addedFileURLs.removeLast()
             }
+            // Move images and videos picked from the Files/iCloud picker into media
+            // assets, so they render inline in the composer and are sent as their proper
+            // type instead of as a generic file.
+            routePickedMediaFilesToAssets(newlyAdded: addedFileURLs.filter { !oldValue.contains($0) })
             checkPickerSelectionState()
 
             if shouldDeleteDraftMessage(oldValue: oldValue) {
@@ -565,7 +570,83 @@ open class MessageComposerViewModel: ObservableObject {
         )
         addedAssets.append(addedImage)
     }
-    
+
+    /// Moves the given picked file URLs that are images or videos out of `addedFileURLs`
+    /// and into `addedAssets` as media, so they render inline and are sent as their
+    /// proper type. Other files are left untouched as regular file attachments.
+    private func routePickedMediaFilesToAssets(newlyAdded urls: [URL]) {
+        let mediaAssets = urls.compactMap { mediaAsset(fromPickedFileURL: $0) }
+        guard !mediaAssets.isEmpty else { return }
+        let mediaURLs = Set(urls.filter { AttachmentType(fileExtension: $0.pathExtension) == .image
+                || AttachmentType(fileExtension: $0.pathExtension) == .video
+        })
+        addedFileURLs.removeAll { mediaURLs.contains($0) }
+        addedAssets.append(contentsOf: mediaAssets)
+    }
+
+    /// Builds a media asset from a file picked in the Files/iCloud picker when it is an
+    /// image or a video. Returns `nil` for other files (and when the media can't be read).
+    private func mediaAsset(fromPickedFileURL url: URL) -> AddedAsset? {
+        let attachmentType = AttachmentType(fileExtension: url.pathExtension)
+        guard attachmentType == .image || attachmentType == .video else { return nil }
+
+        // Copy into an app-owned temporary file so the asset behaves like the other media
+        // sources (camera/photos/paste) and no longer depends on the security-scoped
+        // picker URL when it is uploaded.
+        let didStartAccessing = url.startAccessingSecurityScopedResource()
+        defer { if didStartAccessing { url.stopAccessingSecurityScopedResource() } }
+        guard let localURL = try? copyToTemporaryFile(from: url) else { return nil }
+
+        switch attachmentType {
+        case .image:
+            guard let data = try? Data(contentsOf: localURL), let image = UIImage(data: data) else {
+                try? FileManager.default.removeItem(at: localURL)
+                return nil
+            }
+            let scale = image.scale
+            return AddedAsset(
+                image: image,
+                id: UUID().uuidString,
+                url: localURL,
+                type: .image,
+                originalWidth: Double(image.size.width * scale),
+                originalHeight: Double(image.size.height * scale)
+            )
+        case .video:
+            let asset = AVURLAsset(url: localURL, options: nil)
+            let imageGenerator = AVAssetImageGenerator(asset: asset)
+            imageGenerator.appliesPreferredTrackTransform = true
+            guard let cgImage = try? imageGenerator.copyCGImage(
+                at: CMTimeMake(value: 0, timescale: 1),
+                actualTime: nil
+            ) else {
+                try? FileManager.default.removeItem(at: localURL)
+                return nil
+            }
+            let duration = CMTimeGetSeconds(asset.duration)
+            let naturalSize = asset.tracks(withMediaType: .video).first?.naturalSize ?? .zero
+            return AddedAsset(
+                image: UIImage(cgImage: cgImage),
+                id: UUID().uuidString,
+                url: localURL,
+                type: .video,
+                originalWidth: Double(naturalSize.width),
+                originalHeight: Double(naturalSize.height),
+                duration: duration.isFinite ? duration : nil
+            )
+        default:
+            return nil
+        }
+    }
+
+    private func copyToTemporaryFile(from url: URL) throws -> URL {
+        let temporaryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension(url.pathExtension)
+        try FileManager.default.copyItem(at: url, to: temporaryURL)
+        return temporaryURL
+    }
+
     public func removeAttachment(with id: String) {
         if id.isURL, let url = URL(string: id) {
             var urls = [URL]()
@@ -995,16 +1076,7 @@ class MessageAttachmentsConverter {
             if let filePayload = file.payload {
                 return AnyAttachmentPayload(payload: filePayload)
             }
-            // Resolve the attachment type from the file's extension so that images and
-            // videos picked from the Files/iCloud picker are sent as their proper type
-            // (and render inline) instead of always being sent as a generic file.
-            var attachmentType = AttachmentType(fileExtension: file.url.pathExtension)
-            // Audio files are treated as regular files, since the composer only
-            // supports audio through voice recordings.
-            if attachmentType == .audio {
-                attachmentType = .file
-            }
-            return try AnyAttachmentPayload(localFileURL: file.url, attachmentType: attachmentType)
+            return try AnyAttachmentPayload(localFileURL: file.url, attachmentType: .file)
         }
         attachments += try voiceAssets.map { recording in
             _ = recording.url.startAccessingSecurityScopedResource()

--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerViewModel.swift
@@ -2,6 +2,7 @@
 // Copyright © 2026 Stream.io Inc. All rights reserved.
 //
 
+import AVFoundation
 import Combine
 import Photos
 import StreamChat
@@ -602,6 +603,84 @@ open class MessageComposerViewModel: ObservableObject {
         }
         pickerState = .photos
     }
+
+    /// Binding that routes newly picked files through `addFileURLs(_:)`, so that images and
+    /// videos are added as inline media assets rather than always ending up in
+    /// `addedFileURLs`. Pass this (instead of a plain binding to `addedFileURLs`) to the file
+    /// picker so only new picks are classified, leaving removals and draft/edit restores
+    /// (which mutate `addedFileURLs` directly) unaffected.
+    public var pickedFileURLsBinding: Binding<[URL]> {
+        Binding(
+            get: { self.addedFileURLs },
+            set: { newValue in
+                let newlyAdded = newValue.filter { !self.addedFileURLs.contains($0) }
+                self.addFileURLs(newlyAdded)
+            }
+        )
+    }
+
+    /// Appends newly picked files to the composer.
+    ///
+    /// Images and videos are added as media assets (with an inline thumbnail), the same
+    /// way the camera and Photos pickers add them, so they render inline in the composer.
+    /// Other files (and media that can't be read) are added as regular file attachments.
+    public func addFileURLs(_ urls: [URL]) {
+        for url in urls {
+            guard canAddAttachment(with: url) else { continue }
+            if let mediaAsset = Self.mediaAsset(fromPickedFileURL: url) {
+                addedAssets.append(mediaAsset)
+            } else {
+                addedFileURLs.append(url)
+            }
+        }
+    }
+
+    /// Builds a media asset for an image or video picked from the Files/iCloud picker,
+    /// mirroring how camera/Photos picks are already added as inline media. Returns `nil`
+    /// for other files, or if the media can't be read (e.g. a corrupted or not-yet-downloaded
+    /// iCloud file), in which case the caller falls back to a generic file attachment;
+    /// `MessageAttachmentsConverter` still resolves the correct attachment type from the file
+    /// extension when sending it.
+    private static func mediaAsset(fromPickedFileURL url: URL) -> AddedAsset? {
+        _ = url.startAccessingSecurityScopedResource()
+
+        switch AttachmentType(fileExtension: url.pathExtension) {
+        case .image:
+            guard let data = try? Data(contentsOf: url), let image = UIImage(data: data) else { return nil }
+            let scale = image.scale
+            return AddedAsset(
+                image: image,
+                id: UUID().uuidString,
+                url: url,
+                type: .image,
+                originalWidth: Double(image.size.width * scale),
+                originalHeight: Double(image.size.height * scale)
+            )
+        case .video:
+            let asset = AVURLAsset(url: url, options: nil)
+            let imageGenerator = AVAssetImageGenerator(asset: asset)
+            imageGenerator.appliesPreferredTrackTransform = true
+            guard let cgImage = try? imageGenerator.copyCGImage(
+                at: CMTimeMake(value: 0, timescale: 1),
+                actualTime: nil
+            ) else { return nil }
+            let durationSeconds = CMTimeGetSeconds(asset.duration)
+            let duration: TimeInterval? = durationSeconds.isFinite && !durationSeconds.isNaN ? durationSeconds : nil
+            let naturalSize = asset.tracks(withMediaType: .video).first?.naturalSize ?? .zero
+            return AddedAsset(
+                image: UIImage(cgImage: cgImage),
+                id: UUID().uuidString,
+                url: url,
+                type: .video,
+                extraData: duration.map { ["duration": .string($0.composerVideoDurationString)] } ?? [:],
+                originalWidth: Double(naturalSize.width),
+                originalHeight: Double(naturalSize.height),
+                duration: duration
+            )
+        default:
+            return nil
+        }
+    }
     
     public func isImageSelected(with id: String) -> Bool {
         for image in addedAssets {
@@ -995,9 +1074,9 @@ class MessageAttachmentsConverter {
             if let filePayload = file.payload {
                 return AnyAttachmentPayload(payload: filePayload)
             }
-            // Resolve the attachment type from the file's extension so that images and
-            // videos picked from the Files/iCloud picker are sent as their proper type
-            // (and render inline) instead of always being sent as a generic file.
+            // Resolve the attachment type from the file's extension as a fallback, so that
+            // images/videos that couldn't be read as inline media (e.g. an undownloaded
+            // iCloud file) are still sent as their proper type instead of a generic file.
             var attachmentType = AttachmentType(fileExtension: file.url.pathExtension)
             // Audio files are treated as regular files, since the composer only
             // supports audio through voice recordings.

--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerViewModel.swift
@@ -995,7 +995,16 @@ class MessageAttachmentsConverter {
             if let filePayload = file.payload {
                 return AnyAttachmentPayload(payload: filePayload)
             }
-            return try AnyAttachmentPayload(localFileURL: file.url, attachmentType: .file)
+            // Resolve the attachment type from the file's extension so that images and
+            // videos picked from the Files/iCloud picker are sent as their proper type
+            // (and render inline) instead of always being sent as a generic file.
+            var attachmentType = AttachmentType(fileExtension: file.url.pathExtension)
+            // Audio files are treated as regular files, since the composer only
+            // supports audio through voice recordings.
+            if attachmentType == .audio {
+                attachmentType = .file
+            }
+            return try AnyAttachmentPayload(localFileURL: file.url, attachmentType: attachmentType)
         }
         attachments += try voiceAssets.map { recording in
             _ = recording.url.startAccessingSecurityScopedResource()

--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/PhotoAssetsUtils.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/PhotoAssetsUtils.swift
@@ -52,9 +52,16 @@ public class PhotoAssetLoader: NSObject, ObservableObject {
     }
 
     func assetExceedsAllowedSize(url: URL?) -> Bool {
-        _ = url?.startAccessingSecurityScopedResource()
-        if let assetURL = url,
-           let file = try? AttachmentFile(url: assetURL),
+        guard let assetURL = url else { return false }
+
+        let didStartAccessing = assetURL.startAccessingSecurityScopedResource()
+        defer {
+            if didStartAccessing {
+                assetURL.stopAccessingSecurityScopedResource()
+            }
+        }
+
+        if let file = try? AttachmentFile(url: assetURL),
            file.size >= chatClient.maxAttachmentSize(for: assetURL) {
             return true
         } else {

--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/PhotoAssetsUtils.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/PhotoAssetsUtils.swift
@@ -90,11 +90,11 @@ public class PhotoAssetLoader: NSObject, ObservableObject {
     }
 }
 
-public extension PHAsset {
-    /// Return a formatted duration string of an asset.
-    var durationString: String {
-        let minutes = Int(duration / 60)
-        let seconds = Int(duration.truncatingRemainder(dividingBy: 60))
+extension TimeInterval {
+    /// Formatted duration string for composer video previews (e.g. "01:23").
+    var composerVideoDurationString: String {
+        let minutes = Int(self / 60)
+        let seconds = Int(truncatingRemainder(dividingBy: 60))
         var minutesString = "\(minutes)"
         var secondsString = "\(seconds)"
         if minutes < 10 {
@@ -105,6 +105,13 @@ public extension PHAsset {
         }
 
         return "\(minutesString):\(secondsString)"
+    }
+}
+
+public extension PHAsset {
+    /// Return a formatted duration string of an asset.
+    var durationString: String {
+        duration.composerVideoDurationString
     }
 }
 

--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/PhotoAssetsUtils.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/PhotoAssetsUtils.swift
@@ -52,16 +52,9 @@ public class PhotoAssetLoader: NSObject, ObservableObject {
     }
 
     func assetExceedsAllowedSize(url: URL?) -> Bool {
-        guard let assetURL = url else { return false }
-
-        let didStartAccessing = assetURL.startAccessingSecurityScopedResource()
-        defer {
-            if didStartAccessing {
-                assetURL.stopAccessingSecurityScopedResource()
-            }
-        }
-
-        if let file = try? AttachmentFile(url: assetURL),
+        _ = url?.startAccessingSecurityScopedResource()
+        if let assetURL = url,
+           let file = try? AttachmentFile(url: assetURL),
            file.size >= chatClient.maxAttachmentSize(for: assetURL) {
             return true
         } else {

--- a/StreamChatSwiftUITests/Tests/ChatChannel/MessageComposerViewModel_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/MessageComposerViewModel_Tests.swift
@@ -2,7 +2,6 @@
 // Copyright © 2026 Stream.io Inc. All rights reserved.
 //
 
-import AVFoundation
 @testable import StreamChat
 @testable import StreamChatSwiftUI
 @testable import StreamChatTestTools
@@ -879,68 +878,42 @@ class MessageComposerViewModel_Tests: StreamChatTestCase {
         XCTAssertEqual(payload.originalHeight, 600)
     }
 
-    func test_addedFileURLs_imageURL_addsInlineMediaAssetSentAsImage() throws {
+    func test_convertAddedAssetsToPayloads_fileURLImage_isSentAsImageAttachment() throws {
         let viewModel = makeComposerViewModel()
+        let image = UIImage(systemName: "person")!
         let url = URL.newTemporaryFileURL().appendingPathExtension("png")
         defer { try? FileManager.default.removeItem(at: url) }
-        try makeImageData().write(to: url)
-
+        try image.pngData()?.write(to: url)
         viewModel.addedFileURLs = [url]
 
-        // Moved out of the file attachments and rendered inline as a media asset.
-        XCTAssertTrue(viewModel.addedFileURLs.isEmpty)
-        XCTAssertEqual(viewModel.addedAssets.count, 1)
-        XCTAssertEqual(viewModel.addedAssets.first?.type, .image)
-
-        // Sent as an image attachment.
         let payloads = try viewModel.convertAddedAssetsToPayloads()
+        XCTAssertEqual(payloads.count, 1)
         XCTAssertEqual(payloads.first?.type, .image)
         XCTAssertNotNil(payloads.first?.payload as? ImageAttachmentPayload)
     }
 
-    func test_addedFileURLs_videoURL_addsInlineMediaAssetSentAsVideo() throws {
+    func test_convertAddedAssetsToPayloads_fileURLVideo_isSentAsVideoAttachment() throws {
         let viewModel = makeComposerViewModel()
-        let url = try makeVideoFileURL()
+        let url = URL.newTemporaryFileURL().appendingPathExtension("mp4")
         defer { try? FileManager.default.removeItem(at: url) }
-
+        try Data("mock video".utf8).write(to: url)
         viewModel.addedFileURLs = [url]
 
-        XCTAssertTrue(viewModel.addedFileURLs.isEmpty)
-        XCTAssertEqual(viewModel.addedAssets.count, 1)
-        XCTAssertEqual(viewModel.addedAssets.first?.type, .video)
-
         let payloads = try viewModel.convertAddedAssetsToPayloads()
+        XCTAssertEqual(payloads.count, 1)
         XCTAssertEqual(payloads.first?.type, .video)
         XCTAssertNotNil(payloads.first?.payload as? VideoAttachmentPayload)
     }
 
-    func test_addedFileURLs_rotatedVideoURL_reportsDisplayDimensions() throws {
-        let viewModel = makeComposerViewModel()
-        // 16x32 encoded, rotated 90° → displayed as 32x16.
-        let url = try makeVideoFileURL(width: 16, height: 32, transform: CGAffineTransform(rotationAngle: .pi / 2))
-        defer { try? FileManager.default.removeItem(at: url) }
-
-        viewModel.addedFileURLs = [url]
-
-        let asset = try XCTUnwrap(viewModel.addedAssets.first)
-        // Dimensions reflect the preferred transform (swapped), matching the thumbnail.
-        XCTAssertEqual(asset.originalWidth, 32)
-        XCTAssertEqual(asset.originalHeight, 16)
-    }
-
-    func test_addedFileURLs_documentURL_addsFileAttachment() throws {
+    func test_convertAddedAssetsToPayloads_fileURLDocument_isSentAsFileAttachment() throws {
         let viewModel = makeComposerViewModel()
         let url = URL.newTemporaryFileURL().appendingPathExtension("pdf")
         defer { try? FileManager.default.removeItem(at: url) }
         try Data("mock pdf".utf8).write(to: url)
-
         viewModel.addedFileURLs = [url]
 
-        // Left as a regular file attachment.
-        XCTAssertEqual(viewModel.addedFileURLs, [url])
-        XCTAssertTrue(viewModel.addedAssets.isEmpty)
-
         let payloads = try viewModel.convertAddedAssetsToPayloads()
+        XCTAssertEqual(payloads.count, 1)
         XCTAssertEqual(payloads.first?.type, .file)
         XCTAssertNotNil(payloads.first?.payload as? FileAttachmentPayload)
     }
@@ -1595,50 +1568,6 @@ class MessageComposerViewModel_Tests: StreamChatTestCase {
     private func writeMockData(for url: URL) {
         let data = UIImage(systemName: "checkmark")?.pngData()
         try? data?.write(to: url)
-    }
-
-    private func makeImageData() -> Data {
-        UIGraphicsImageRenderer(size: CGSize(width: 10, height: 10)).image { context in
-            UIColor.red.setFill()
-            context.fill(CGRect(x: 0, y: 0, width: 10, height: 10))
-        }.pngData()!
-    }
-
-    /// Writes a real (decodable) one-frame video to a temporary `.mp4` so that a thumbnail
-    /// can be generated, exercising the picked-video path end to end.
-    private func makeVideoFileURL(
-        width: Int = 16,
-        height: Int = 16,
-        transform: CGAffineTransform = .identity
-    ) throws -> URL {
-        let url = URL.newTemporaryFileURL().appendingPathExtension("mp4")
-        let writer = try AVAssetWriter(outputURL: url, fileType: .mp4)
-        let input = AVAssetWriterInput(
-            mediaType: .video,
-            outputSettings: [
-                AVVideoCodecKey: AVVideoCodecType.h264,
-                AVVideoWidthKey: width,
-                AVVideoHeightKey: height
-            ]
-        )
-        input.transform = transform
-        let adaptor = AVAssetWriterInputPixelBufferAdaptor(
-            assetWriterInput: input,
-            sourcePixelBufferAttributes: nil
-        )
-        writer.add(input)
-        writer.startWriting()
-        writer.startSession(atSourceTime: .zero)
-
-        var pixelBuffer: CVPixelBuffer?
-        CVPixelBufferCreate(kCFAllocatorDefault, width, height, kCVPixelFormatType_32ARGB, nil, &pixelBuffer)
-        adaptor.append(try XCTUnwrap(pixelBuffer), withPresentationTime: .zero)
-        input.markAsFinished()
-
-        let expectation = XCTestExpectation(description: "Finish writing video")
-        writer.finishWriting { expectation.fulfill() }
-        wait(for: [expectation], timeout: 5.0)
-        return url
     }
 }
 

--- a/StreamChatSwiftUITests/Tests/ChatChannel/MessageComposerViewModel_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/MessageComposerViewModel_Tests.swift
@@ -878,6 +878,46 @@ class MessageComposerViewModel_Tests: StreamChatTestCase {
         XCTAssertEqual(payload.originalHeight, 600)
     }
 
+    func test_convertAddedAssetsToPayloads_fileURLImage_isSentAsImageAttachment() throws {
+        let viewModel = makeComposerViewModel()
+        let image = UIImage(systemName: "person")!
+        let url = URL.newTemporaryFileURL().appendingPathExtension("png")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try image.pngData()?.write(to: url)
+        viewModel.addedFileURLs = [url]
+
+        let payloads = try viewModel.convertAddedAssetsToPayloads()
+        XCTAssertEqual(payloads.count, 1)
+        XCTAssertEqual(payloads.first?.type, .image)
+        XCTAssertNotNil(payloads.first?.payload as? ImageAttachmentPayload)
+    }
+
+    func test_convertAddedAssetsToPayloads_fileURLVideo_isSentAsVideoAttachment() throws {
+        let viewModel = makeComposerViewModel()
+        let url = URL.newTemporaryFileURL().appendingPathExtension("mp4")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try Data("mock video".utf8).write(to: url)
+        viewModel.addedFileURLs = [url]
+
+        let payloads = try viewModel.convertAddedAssetsToPayloads()
+        XCTAssertEqual(payloads.count, 1)
+        XCTAssertEqual(payloads.first?.type, .video)
+        XCTAssertNotNil(payloads.first?.payload as? VideoAttachmentPayload)
+    }
+
+    func test_convertAddedAssetsToPayloads_fileURLDocument_isSentAsFileAttachment() throws {
+        let viewModel = makeComposerViewModel()
+        let url = URL.newTemporaryFileURL().appendingPathExtension("pdf")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try Data("mock pdf".utf8).write(to: url)
+        viewModel.addedFileURLs = [url]
+
+        let payloads = try viewModel.convertAddedAssetsToPayloads()
+        XCTAssertEqual(payloads.count, 1)
+        XCTAssertEqual(payloads.first?.type, .file)
+        XCTAssertNotNil(payloads.first?.payload as? FileAttachmentPayload)
+    }
+
     func test_addedAsset_toAttachmentPayload_includesWidthHeightDurationForVideo() throws {
         let thumbnail = UIImage(systemName: "video")!
         let url = URL.newTemporaryFileURL().appendingPathExtension("mp4")

--- a/StreamChatSwiftUITests/Tests/ChatChannel/MessageComposerViewModel_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/MessageComposerViewModel_Tests.swift
@@ -914,6 +914,20 @@ class MessageComposerViewModel_Tests: StreamChatTestCase {
         XCTAssertNotNil(payloads.first?.payload as? VideoAttachmentPayload)
     }
 
+    func test_addedFileURLs_rotatedVideoURL_reportsDisplayDimensions() throws {
+        let viewModel = makeComposerViewModel()
+        // 16x32 encoded, rotated 90° → displayed as 32x16.
+        let url = try makeVideoFileURL(width: 16, height: 32, transform: CGAffineTransform(rotationAngle: .pi / 2))
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        viewModel.addedFileURLs = [url]
+
+        let asset = try XCTUnwrap(viewModel.addedAssets.first)
+        // Dimensions reflect the preferred transform (swapped), matching the thumbnail.
+        XCTAssertEqual(asset.originalWidth, 32)
+        XCTAssertEqual(asset.originalHeight, 16)
+    }
+
     func test_addedFileURLs_documentURL_addsFileAttachment() throws {
         let viewModel = makeComposerViewModel()
         let url = URL.newTemporaryFileURL().appendingPathExtension("pdf")
@@ -1592,18 +1606,22 @@ class MessageComposerViewModel_Tests: StreamChatTestCase {
 
     /// Writes a real (decodable) one-frame video to a temporary `.mp4` so that a thumbnail
     /// can be generated, exercising the picked-video path end to end.
-    private func makeVideoFileURL() throws -> URL {
+    private func makeVideoFileURL(
+        width: Int = 16,
+        height: Int = 16,
+        transform: CGAffineTransform = .identity
+    ) throws -> URL {
         let url = URL.newTemporaryFileURL().appendingPathExtension("mp4")
-        let size = 16
         let writer = try AVAssetWriter(outputURL: url, fileType: .mp4)
         let input = AVAssetWriterInput(
             mediaType: .video,
             outputSettings: [
                 AVVideoCodecKey: AVVideoCodecType.h264,
-                AVVideoWidthKey: size,
-                AVVideoHeightKey: size
+                AVVideoWidthKey: width,
+                AVVideoHeightKey: height
             ]
         )
+        input.transform = transform
         let adaptor = AVAssetWriterInputPixelBufferAdaptor(
             assetWriterInput: input,
             sourcePixelBufferAttributes: nil
@@ -1613,7 +1631,7 @@ class MessageComposerViewModel_Tests: StreamChatTestCase {
         writer.startSession(atSourceTime: .zero)
 
         var pixelBuffer: CVPixelBuffer?
-        CVPixelBufferCreate(kCFAllocatorDefault, size, size, kCVPixelFormatType_32ARGB, nil, &pixelBuffer)
+        CVPixelBufferCreate(kCFAllocatorDefault, width, height, kCVPixelFormatType_32ARGB, nil, &pixelBuffer)
         adaptor.append(try XCTUnwrap(pixelBuffer), withPresentationTime: .zero)
         input.markAsFinished()
 

--- a/StreamChatSwiftUITests/Tests/ChatChannel/MessageComposerViewModel_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/MessageComposerViewModel_Tests.swift
@@ -2,6 +2,7 @@
 // Copyright © 2026 Stream.io Inc. All rights reserved.
 //
 
+import AVFoundation
 @testable import StreamChat
 @testable import StreamChatSwiftUI
 @testable import StreamChatTestTools
@@ -1077,6 +1078,113 @@ class MessageComposerViewModel_Tests: StreamChatTestCase {
         XCTAssertEqual(imagePayload.originalHeight, 200)
     }
 
+    func test_addFileURLs_imageURL_addsInlineMediaAssetSentAsImage() throws {
+        let viewModel = makeComposerViewModel()
+        let url = URL.newTemporaryFileURL().appendingPathExtension("png")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try makeImageData().write(to: url)
+
+        viewModel.addFileURLs([url])
+
+        // Rendered inline in the composer as a media asset (not a file chip).
+        XCTAssertEqual(viewModel.addedAssets.count, 1)
+        XCTAssertTrue(viewModel.addedFileURLs.isEmpty)
+        XCTAssertEqual(viewModel.addedAssets.first?.type, .image)
+
+        // Sent as an image attachment.
+        let payloads = try viewModel.convertAddedAssetsToPayloads()
+        XCTAssertEqual(payloads.count, 1)
+        XCTAssertEqual(payloads.first?.type, .image)
+        XCTAssertNotNil(payloads.first?.payload as? ImageAttachmentPayload)
+    }
+
+    func test_addFileURLs_videoURL_addsInlineMediaAssetSentAsVideo() throws {
+        let viewModel = makeComposerViewModel()
+        let url = try makeVideoFileURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        viewModel.addFileURLs([url])
+
+        XCTAssertEqual(viewModel.addedAssets.count, 1)
+        XCTAssertTrue(viewModel.addedFileURLs.isEmpty)
+        XCTAssertEqual(viewModel.addedAssets.first?.type, .video)
+        XCTAssertNotNil(viewModel.addedAssets.first?.extraData["duration"]?.stringValue)
+
+        let payloads = try viewModel.convertAddedAssetsToPayloads()
+        XCTAssertEqual(payloads.count, 1)
+        XCTAssertEqual(payloads.first?.type, .video)
+        XCTAssertNotNil(payloads.first?.payload as? VideoAttachmentPayload)
+    }
+
+    func test_addFileURLs_unreadableVideoURL_isStillSentAsVideoAttachment() throws {
+        let viewModel = makeComposerViewModel()
+        let url = URL.newTemporaryFileURL().appendingPathExtension("mp4")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try Data("not a real video".utf8).write(to: url)
+
+        viewModel.addFileURLs([url])
+
+        // No thumbnail could be generated, so it falls back to a file chip in the composer...
+        XCTAssertTrue(viewModel.addedAssets.isEmpty)
+        XCTAssertEqual(viewModel.addedFileURLs.count, 1)
+
+        // ...but it's still sent as a video attachment, resolved from the file extension.
+        let payloads = try viewModel.convertAddedAssetsToPayloads()
+        XCTAssertEqual(payloads.count, 1)
+        XCTAssertEqual(payloads.first?.type, .video)
+        XCTAssertNotNil(payloads.first?.payload as? VideoAttachmentPayload)
+    }
+
+    func test_addFileURLs_audioURL_isSentAsFileAttachment() throws {
+        let viewModel = makeComposerViewModel()
+        let url = URL.newTemporaryFileURL().appendingPathExtension("mp3")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try Data("mock audio".utf8).write(to: url)
+
+        viewModel.addFileURLs([url])
+        XCTAssertEqual(viewModel.addedFileURLs.count, 1)
+
+        let payloads = try viewModel.convertAddedAssetsToPayloads()
+        XCTAssertEqual(payloads.count, 1)
+        XCTAssertEqual(payloads.first?.type, .file)
+        XCTAssertNotNil(payloads.first?.payload as? FileAttachmentPayload)
+    }
+
+    func test_addFileURLs_documentURL_isSentAsFileAttachment() throws {
+        let viewModel = makeComposerViewModel()
+        let url = URL.newTemporaryFileURL().appendingPathExtension("pdf")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try Data("mock pdf".utf8).write(to: url)
+
+        viewModel.addFileURLs([url])
+        XCTAssertEqual(viewModel.addedFileURLs.count, 1)
+
+        let payloads = try viewModel.convertAddedAssetsToPayloads()
+        XCTAssertEqual(payloads.count, 1)
+        XCTAssertEqual(payloads.first?.type, .file)
+        XCTAssertNotNil(payloads.first?.payload as? FileAttachmentPayload)
+    }
+
+    func test_pickedFileURLsBinding_onlyClassifiesNewlyAddedURLs() throws {
+        let viewModel = makeComposerViewModel()
+        let existingFileURL = URL.newTemporaryFileURL().appendingPathExtension("pdf")
+        defer { try? FileManager.default.removeItem(at: existingFileURL) }
+        try Data("mock pdf".utf8).write(to: existingFileURL)
+        viewModel.addedFileURLs = [existingFileURL]
+
+        let imageURL = URL.newTemporaryFileURL().appendingPathExtension("png")
+        defer { try? FileManager.default.removeItem(at: imageURL) }
+        try makeImageData().write(to: imageURL)
+
+        // Simulates the file picker appending a newly picked image to the existing files.
+        viewModel.pickedFileURLsBinding.wrappedValue.append(imageURL)
+
+        // The pre-existing file is untouched, and the new image is routed to inline media.
+        XCTAssertEqual(viewModel.addedFileURLs, [existingFileURL])
+        XCTAssertEqual(viewModel.addedAssets.count, 1)
+        XCTAssertEqual(viewModel.addedAssets.first?.type, .image)
+    }
+
     func test_imagePickerCoordinator_imageSelection_setsOriginalWidthAndHeightOnAsset() throws {
         var captured: AddedAsset?
         let view = ImagePickerView(sourceType: .photoLibrary, onAssetPicked: { captured = $0 })
@@ -1568,6 +1676,45 @@ class MessageComposerViewModel_Tests: StreamChatTestCase {
     private func writeMockData(for url: URL) {
         let data = UIImage(systemName: "checkmark")?.pngData()
         try? data?.write(to: url)
+    }
+
+    private func makeImageData() -> Data {
+        UIGraphicsImageRenderer(size: CGSize(width: 10, height: 10)).image { context in
+            UIColor.red.setFill()
+            context.fill(CGRect(x: 0, y: 0, width: 10, height: 10))
+        }.pngData()!
+    }
+
+    /// Writes a real (decodable) one-frame video to a temporary `.mp4` so that a thumbnail
+    /// can be generated, exercising the picked-video path end to end.
+    private func makeVideoFileURL(width: Int = 16, height: Int = 16) throws -> URL {
+        let url = URL.newTemporaryFileURL().appendingPathExtension("mp4")
+        let writer = try AVAssetWriter(outputURL: url, fileType: .mp4)
+        let input = AVAssetWriterInput(
+            mediaType: .video,
+            outputSettings: [
+                AVVideoCodecKey: AVVideoCodecType.h264,
+                AVVideoWidthKey: width,
+                AVVideoHeightKey: height
+            ]
+        )
+        let adaptor = AVAssetWriterInputPixelBufferAdaptor(
+            assetWriterInput: input,
+            sourcePixelBufferAttributes: nil
+        )
+        writer.add(input)
+        writer.startWriting()
+        writer.startSession(atSourceTime: .zero)
+
+        var pixelBuffer: CVPixelBuffer?
+        CVPixelBufferCreate(kCFAllocatorDefault, width, height, kCVPixelFormatType_32ARGB, nil, &pixelBuffer)
+        adaptor.append(try XCTUnwrap(pixelBuffer), withPresentationTime: .zero)
+        input.markAsFinished()
+
+        let expectation = XCTestExpectation(description: "Finish writing video")
+        writer.finishWriting { expectation.fulfill() }
+        wait(for: [expectation], timeout: 5.0)
+        return url
     }
 }
 

--- a/StreamChatSwiftUITests/Tests/ChatChannel/MessageComposerViewModel_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/MessageComposerViewModel_Tests.swift
@@ -2,6 +2,7 @@
 // Copyright © 2026 Stream.io Inc. All rights reserved.
 //
 
+import AVFoundation
 @testable import StreamChat
 @testable import StreamChatSwiftUI
 @testable import StreamChatTestTools
@@ -878,42 +879,54 @@ class MessageComposerViewModel_Tests: StreamChatTestCase {
         XCTAssertEqual(payload.originalHeight, 600)
     }
 
-    func test_convertAddedAssetsToPayloads_fileURLImage_isSentAsImageAttachment() throws {
+    func test_addedFileURLs_imageURL_addsInlineMediaAssetSentAsImage() throws {
         let viewModel = makeComposerViewModel()
-        let image = UIImage(systemName: "person")!
         let url = URL.newTemporaryFileURL().appendingPathExtension("png")
         defer { try? FileManager.default.removeItem(at: url) }
-        try image.pngData()?.write(to: url)
+        try makeImageData().write(to: url)
+
         viewModel.addedFileURLs = [url]
 
+        // Moved out of the file attachments and rendered inline as a media asset.
+        XCTAssertTrue(viewModel.addedFileURLs.isEmpty)
+        XCTAssertEqual(viewModel.addedAssets.count, 1)
+        XCTAssertEqual(viewModel.addedAssets.first?.type, .image)
+
+        // Sent as an image attachment.
         let payloads = try viewModel.convertAddedAssetsToPayloads()
-        XCTAssertEqual(payloads.count, 1)
         XCTAssertEqual(payloads.first?.type, .image)
         XCTAssertNotNil(payloads.first?.payload as? ImageAttachmentPayload)
     }
 
-    func test_convertAddedAssetsToPayloads_fileURLVideo_isSentAsVideoAttachment() throws {
+    func test_addedFileURLs_videoURL_addsInlineMediaAssetSentAsVideo() throws {
         let viewModel = makeComposerViewModel()
-        let url = URL.newTemporaryFileURL().appendingPathExtension("mp4")
+        let url = try makeVideoFileURL()
         defer { try? FileManager.default.removeItem(at: url) }
-        try Data("mock video".utf8).write(to: url)
+
         viewModel.addedFileURLs = [url]
 
+        XCTAssertTrue(viewModel.addedFileURLs.isEmpty)
+        XCTAssertEqual(viewModel.addedAssets.count, 1)
+        XCTAssertEqual(viewModel.addedAssets.first?.type, .video)
+
         let payloads = try viewModel.convertAddedAssetsToPayloads()
-        XCTAssertEqual(payloads.count, 1)
         XCTAssertEqual(payloads.first?.type, .video)
         XCTAssertNotNil(payloads.first?.payload as? VideoAttachmentPayload)
     }
 
-    func test_convertAddedAssetsToPayloads_fileURLDocument_isSentAsFileAttachment() throws {
+    func test_addedFileURLs_documentURL_addsFileAttachment() throws {
         let viewModel = makeComposerViewModel()
         let url = URL.newTemporaryFileURL().appendingPathExtension("pdf")
         defer { try? FileManager.default.removeItem(at: url) }
         try Data("mock pdf".utf8).write(to: url)
+
         viewModel.addedFileURLs = [url]
 
+        // Left as a regular file attachment.
+        XCTAssertEqual(viewModel.addedFileURLs, [url])
+        XCTAssertTrue(viewModel.addedAssets.isEmpty)
+
         let payloads = try viewModel.convertAddedAssetsToPayloads()
-        XCTAssertEqual(payloads.count, 1)
         XCTAssertEqual(payloads.first?.type, .file)
         XCTAssertNotNil(payloads.first?.payload as? FileAttachmentPayload)
     }
@@ -1568,6 +1581,46 @@ class MessageComposerViewModel_Tests: StreamChatTestCase {
     private func writeMockData(for url: URL) {
         let data = UIImage(systemName: "checkmark")?.pngData()
         try? data?.write(to: url)
+    }
+
+    private func makeImageData() -> Data {
+        UIGraphicsImageRenderer(size: CGSize(width: 10, height: 10)).image { context in
+            UIColor.red.setFill()
+            context.fill(CGRect(x: 0, y: 0, width: 10, height: 10))
+        }.pngData()!
+    }
+
+    /// Writes a real (decodable) one-frame video to a temporary `.mp4` so that a thumbnail
+    /// can be generated, exercising the picked-video path end to end.
+    private func makeVideoFileURL() throws -> URL {
+        let url = URL.newTemporaryFileURL().appendingPathExtension("mp4")
+        let size = 16
+        let writer = try AVAssetWriter(outputURL: url, fileType: .mp4)
+        let input = AVAssetWriterInput(
+            mediaType: .video,
+            outputSettings: [
+                AVVideoCodecKey: AVVideoCodecType.h264,
+                AVVideoWidthKey: size,
+                AVVideoHeightKey: size
+            ]
+        )
+        let adaptor = AVAssetWriterInputPixelBufferAdaptor(
+            assetWriterInput: input,
+            sourcePixelBufferAttributes: nil
+        )
+        writer.add(input)
+        writer.startWriting()
+        writer.startSession(atSourceTime: .zero)
+
+        var pixelBuffer: CVPixelBuffer?
+        CVPixelBufferCreate(kCFAllocatorDefault, size, size, kCVPixelFormatType_32ARGB, nil, &pixelBuffer)
+        adaptor.append(try XCTUnwrap(pixelBuffer), withPresentationTime: .zero)
+        input.markAsFinished()
+
+        let expectation = XCTestExpectation(description: "Finish writing video")
+        writer.finishWriting { expectation.fulfill() }
+        wait(for: [expectation], timeout: 5.0)
+        return url
     }
 }
 


### PR DESCRIPTION
### 🔗 Issue Links

Resolve https://linear.app/stream/issue/IOS-1818

### 🎯 Goal

Images and videos picked from the Files/iCloud document picker were always sent as `type: file`, so they rendered as downloadable files everywhere instead of inline. The Photos/Media picker was unaffected because it builds assets with a proper type. This makes the document-picker path behave consistently.

### 📝 Summary

- Resolve the attachment type from the picked file's extension instead of hardcoding `.file`, so images and videos are sent as `image`/`video` and render inline.
- Audio files continue to be treated as regular files (the composer only supports audio through voice recordings).

### 🛠 Implementation

- In `MessageAttachmentsConverter.assetsToPayloads(_:)`, derive the type via StreamChat's existing `AttachmentType(fileExtension:)` (resolves image/video/audio/file from the MIME type), mirroring the UIKit SDK's `ComposerVC.documentPicker(_:didPickDocumentsAt:)`.
- `AnyAttachmentPayload(localFileURL:attachmentType:)` already builds the correct payload from a local URL — the same path the Photos picker uses — so the upload pipeline supports it unchanged.

### 🎨 Showcase

| Before | After |
| ------ | ----- |
| Image from Files sent as a file attachment | Image from Files rendered inline |

### 🧪 Manual Testing Notes

1. Open a channel, tap the attachment button, choose **Files** / iCloud.
2. Pick an image (and a video). Send.
3. The image/video renders inline in the message list, on web, and on other clients (previously appeared as a downloadable file).

### ☑️ Contributor Checklist

- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
