### PR TITLE
ci: add least-privilege permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/cron-checks.yml
+++ b/.github/workflows/cron-checks.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1 # Disable cleanup for homebrew, we don't need it on CI
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/record-snapshots.yml
+++ b/.github/workflows/record-snapshots.yml
@@ -5,7 +5,7 @@ on:
 
 permissions:
   contents: read
-    actions: write
+  actions: write
 
 jobs:
   record:

--- a/.github/workflows/record-snapshots.yml
+++ b/.github/workflows/record-snapshots.yml
@@ -3,6 +3,10 @@ name: Record Snapshots
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+    actions: write
+
 jobs:
   record:
     name: Record

--- a/.github/workflows/release-merge.yml
+++ b/.github/workflows/release-merge.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
   contents: read
-    issues: read
+  issues: read
 
   workflow_dispatch:
 

--- a/.github/workflows/release-merge.yml
+++ b/.github/workflows/release-merge.yml
@@ -4,6 +4,10 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  contents: read
+    issues: read
+
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release-merge.yml
+++ b/.github/workflows/release-merge.yml
@@ -4,11 +4,10 @@ on:
   issue_comment:
     types: [created]
 
+  workflow_dispatch:
+
 permissions:
   contents: read
-  issues: read
-
-  workflow_dispatch:
 
 jobs:
   merge-release-to-main:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -3,6 +3,9 @@ name: "Publish new release"
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   release:
     name: Publish new release

--- a/.github/workflows/release-start.yml
+++ b/.github/workflows/release-start.yml
@@ -8,6 +8,10 @@ on:
         type: string
         required: true
 
+permissions:
+  contents: read
+    actions: write
+
 jobs:
   test-release:
     name: Start new release

--- a/.github/workflows/release-start.yml
+++ b/.github/workflows/release-start.yml
@@ -10,7 +10,7 @@ on:
 
 permissions:
   contents: read
-    actions: write
+  actions: write
 
 jobs:
   test-release:

--- a/.github/workflows/sdk-size-metrics.yml
+++ b/.github/workflows/sdk-size-metrics.yml
@@ -23,7 +23,7 @@ env:
 
 permissions:
   contents: read
-    pull-requests: read
+  pull-requests: read
 
 jobs:
   sdk_size:

--- a/.github/workflows/sdk-size-metrics.yml
+++ b/.github/workflows/sdk-size-metrics.yml
@@ -21,6 +21,10 @@ env:
   GITHUB_EVENT_BEFORE: ${{ github.event.before }}
   GITHUB_EVENT_AFTER: ${{ github.event.after }}
 
+permissions:
+  contents: read
+    pull-requests: read
+
 jobs:
   sdk_size:
     name: Metrics

--- a/.github/workflows/smoke-checks.yml
+++ b/.github/workflows/smoke-checks.yml
@@ -15,6 +15,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+    pull-requests: read
+
 env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1 # Disable cleanup for homebrew, we don't need it on CI
   IOS_SIMULATOR_DEVICE: "iPhone 17 Pro (26.2)"

--- a/.github/workflows/smoke-checks.yml
+++ b/.github/workflows/smoke-checks.yml
@@ -17,7 +17,7 @@ concurrency:
 
 permissions:
   contents: read
-    pull-requests: read
+  pull-requests: read
 
 env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1 # Disable cleanup for homebrew, we don't need it on CI

--- a/.github/workflows/smoke-checks.yml
+++ b/.github/workflows/smoke-checks.yml
@@ -62,6 +62,9 @@ jobs:
   automated-code-review:
     name: Automated Code Review
     runs-on: macos-14
+    permissions:
+      contents: read
+      pull-requests: write
     needs: guard
     if: ${{ github.event.inputs.record_snapshots != 'true' }}
     env:

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -12,6 +12,7 @@ concurrency:
 permissions:
   contents: read
   pull-requests: read
+  actions: read
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -9,6 +9,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+    pull-requests: read
+
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -11,7 +11,7 @@ concurrency:
 
 permissions:
   contents: read
-    pull-requests: read
+  pull-requests: read
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -22,6 +22,10 @@ on:
 env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1
 
+permissions:
+  contents: read
+    pull-requests: read
+
 jobs:
   deploy:
     runs-on: macos-15

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -24,7 +24,7 @@ env:
 
 permissions:
   contents: read
-    pull-requests: read
+  pull-requests: read
 
 jobs:
   deploy:

--- a/.github/workflows/update-copyright.yml
+++ b/.github/workflows/update-copyright.yml
@@ -10,6 +10,9 @@ on:
 env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1 # Disable cleanup for homebrew, we don't need it on CI
 
+permissions:
+  contents: read
+
 jobs:
   copyright:
     name: Copyright


### PR DESCRIPTION
## Summary
- Add explicit workflow-level `permissions` blocks for CodeQL `actions/missing-workflow-permissions` alerts.
- Minimal scopes only; `actions: write` where `gh workflow run` / cancel is used.

## Linear
- Parent: [APPSEC-164](https://linear.app/stream/issue/APPSEC-164)

## Test plan
- [x] CI passes
- [ ] Code scanning alerts close after merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tightened GitHub Actions permissions across multiple workflows.
  * Added explicit, least-privilege access for workflow runs (for repository contents, pull requests, issues, and Actions as needed).
  * No workflow triggers, job steps, or release behavior were changed—only access scopes were updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->