### PR TITLE
Add code documentation guidelines for AI agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,6 +165,13 @@ The project uses Swift 6.0 strict concurrency. Many public types and view models
 
 ### Development guidelines
 
+Code documentation
+
+- Write doc comments (`///`) only for `public` declarations — types, methods, and properties that are part of the SDK's public API.
+- Do not add doc comments to `internal`, `private`, or test code.
+- Keep doc comments concise: a one-line summary; add parameter/return docs only when they are not obvious from the signature.
+- Do not add inline comments narrating what the code or a change does; comment only non-obvious constraints or reasoning.
+
 Accessibility & UI quality
 
 - Ensure components have accessibility labels, traits, and dynamic type support.


### PR DESCRIPTION
### 🔗 Issue Links

None.

### 🎯 Goal

Prevent AI coding agents from generating verbose doc comments by documenting that only public API gets doc comments.

### 📝 Summary

- Added a "Code documentation" policy to `AGENTS.md`: doc comments (`///`) only for public declarations, kept concise, and no comments narrating changes.

### 🛠 Implementation

Documentation-only change to the agent guidance file; no source code affected.

### 🎨 Showcase

Not applicable — documentation-only change.

### 🧪 Manual Testing Notes

Not applicable — documentation-only change.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for writing code comments and doc comments, including when to use them and how concise they should be.
  * Clarified that documentation comments are intended for public-facing declarations only.
  * Added a reminder to avoid inline comments that restate obvious behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->