### PR TITLE
Render picked images/videos inline in the composer on v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🐞 Fixed
 - Fix the composer attachment picker collapsing the paperclip icon into an arrow while typing when only a single picker item is available [#1496](https://github.com/GetStream/stream-chat-swiftui/pull/1496)
-- Send images and videos picked from the Files/iCloud picker as their proper type so they render inline instead of as downloadable files [#1516](https://github.com/GetStream/stream-chat-swiftui/pull/1516)
+- Send images and videos picked from the Files/iCloud picker as their proper type so they render inline instead of as downloadable files [#1516](https://github.com/GetStream/stream-chat-swiftui/pull/1516) [#1527](https://github.com/GetStream/stream-chat-swiftui/pull/1527)
 
 ### 🔄 Changed
 

--- a/DemoAppSwiftUI/AppleMessageComposerView.swift
+++ b/DemoAppSwiftUI/AppleMessageComposerView.swift
@@ -103,7 +103,7 @@ struct AppleMessageComposerView<Factory: ViewFactory>: View, KeyboardReadable {
                 attachmentPickerState: $viewModel.pickerState,
                 filePickerShown: $viewModel.filePickerShown,
                 cameraPickerShown: $viewModel.cameraPickerShown,
-                addedFileURLs: $viewModel.addedFileURLs,
+                addedFileURLs: viewModel.pickedFileURLsBinding,
                 onPickerStateChange: viewModel.change(pickerState:),
                 photoLibraryAssets: viewModel.imageAssets,
                 onAssetTap: viewModel.imageTapped(_:),

--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerView.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerView.swift
@@ -149,7 +149,7 @@ public struct MessageComposerView<Factory: ViewFactory>: View, KeyboardReadable 
                 attachmentPickerState: $viewModel.pickerState,
                 filePickerShown: $viewModel.filePickerShown,
                 cameraPickerShown: $viewModel.cameraPickerShown,
-                addedFileURLs: $viewModel.addedFileURLs,
+                addedFileURLs: viewModel.pickedFileURLsBinding,
                 onPickerStateChange: viewModel.change(pickerState:),
                 photoLibraryAssets: viewModel.imageAssets,
                 onAssetTap: viewModel.imageTapped(_:),

--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerViewModel.swift
@@ -664,16 +664,18 @@ open class MessageComposerViewModel: ObservableObject {
                 at: CMTimeMake(value: 0, timescale: 1),
                 actualTime: nil
             ) else { return nil }
-            let duration = CMTimeGetSeconds(asset.duration)
+            let durationSeconds = CMTimeGetSeconds(asset.duration)
+            let duration: TimeInterval? = durationSeconds.isFinite && !durationSeconds.isNaN ? durationSeconds : nil
             let naturalSize = asset.tracks(withMediaType: .video).first?.naturalSize ?? .zero
             return AddedAsset(
                 image: UIImage(cgImage: cgImage),
                 id: UUID().uuidString,
                 url: url,
                 type: .video,
+                extraData: duration.map { ["duration": .string($0.composerVideoDurationString)] } ?? [:],
                 originalWidth: Double(naturalSize.width),
                 originalHeight: Double(naturalSize.height),
-                duration: duration.isFinite ? duration : nil
+                duration: duration
             )
         default:
             return nil

--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/MessageComposerViewModel.swift
@@ -2,6 +2,7 @@
 // Copyright © 2026 Stream.io Inc. All rights reserved.
 //
 
+import AVFoundation
 import Combine
 import Photos
 import StreamChat
@@ -602,6 +603,82 @@ open class MessageComposerViewModel: ObservableObject {
         }
         pickerState = .photos
     }
+
+    /// Binding that routes newly picked files through `addFileURLs(_:)`, so that images and
+    /// videos are added as inline media assets rather than always ending up in
+    /// `addedFileURLs`. Pass this (instead of a plain binding to `addedFileURLs`) to the file
+    /// picker so only new picks are classified, leaving removals and draft/edit restores
+    /// (which mutate `addedFileURLs` directly) unaffected.
+    public var pickedFileURLsBinding: Binding<[URL]> {
+        Binding(
+            get: { self.addedFileURLs },
+            set: { newValue in
+                let newlyAdded = newValue.filter { !self.addedFileURLs.contains($0) }
+                self.addFileURLs(newlyAdded)
+            }
+        )
+    }
+
+    /// Appends newly picked files to the composer.
+    ///
+    /// Images and videos are added as media assets (with an inline thumbnail), the same
+    /// way the camera and Photos pickers add them, so they render inline in the composer.
+    /// Other files (and media that can't be read) are added as regular file attachments.
+    public func addFileURLs(_ urls: [URL]) {
+        for url in urls {
+            guard canAddAttachment(with: url) else { continue }
+            if let mediaAsset = Self.mediaAsset(fromPickedFileURL: url) {
+                addedAssets.append(mediaAsset)
+            } else {
+                addedFileURLs.append(url)
+            }
+        }
+    }
+
+    /// Builds a media asset for an image or video picked from the Files/iCloud picker,
+    /// mirroring how camera/Photos picks are already added as inline media. Returns `nil`
+    /// for other files, or if the media can't be read (e.g. a corrupted or not-yet-downloaded
+    /// iCloud file), in which case the caller falls back to a generic file attachment;
+    /// `MessageAttachmentsConverter` still resolves the correct attachment type from the file
+    /// extension when sending it.
+    private static func mediaAsset(fromPickedFileURL url: URL) -> AddedAsset? {
+        _ = url.startAccessingSecurityScopedResource()
+
+        switch AttachmentType(fileExtension: url.pathExtension) {
+        case .image:
+            guard let data = try? Data(contentsOf: url), let image = UIImage(data: data) else { return nil }
+            let scale = image.scale
+            return AddedAsset(
+                image: image,
+                id: UUID().uuidString,
+                url: url,
+                type: .image,
+                originalWidth: Double(image.size.width * scale),
+                originalHeight: Double(image.size.height * scale)
+            )
+        case .video:
+            let asset = AVURLAsset(url: url, options: nil)
+            let imageGenerator = AVAssetImageGenerator(asset: asset)
+            imageGenerator.appliesPreferredTrackTransform = true
+            guard let cgImage = try? imageGenerator.copyCGImage(
+                at: CMTimeMake(value: 0, timescale: 1),
+                actualTime: nil
+            ) else { return nil }
+            let duration = CMTimeGetSeconds(asset.duration)
+            let naturalSize = asset.tracks(withMediaType: .video).first?.naturalSize ?? .zero
+            return AddedAsset(
+                image: UIImage(cgImage: cgImage),
+                id: UUID().uuidString,
+                url: url,
+                type: .video,
+                originalWidth: Double(naturalSize.width),
+                originalHeight: Double(naturalSize.height),
+                duration: duration.isFinite ? duration : nil
+            )
+        default:
+            return nil
+        }
+    }
     
     public func isImageSelected(with id: String) -> Bool {
         for image in addedAssets {
@@ -995,9 +1072,9 @@ class MessageAttachmentsConverter {
             if let filePayload = file.payload {
                 return AnyAttachmentPayload(payload: filePayload)
             }
-            // Resolve the attachment type from the file's extension so that images and
-            // videos picked from the Files/iCloud picker are sent as their proper type
-            // (and render inline) instead of always being sent as a generic file.
+            // Resolve the attachment type from the file's extension as a fallback, so that
+            // images/videos that couldn't be read as inline media (e.g. an undownloaded
+            // iCloud file) are still sent as their proper type instead of a generic file.
             var attachmentType = AttachmentType(fileExtension: file.url.pathExtension)
             // Audio files are treated as regular files, since the composer only
             // supports audio through voice recordings.

--- a/Sources/StreamChatSwiftUI/ChatChannel/Composer/PhotoAssetsUtils.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/Composer/PhotoAssetsUtils.swift
@@ -90,11 +90,11 @@ public class PhotoAssetLoader: NSObject, ObservableObject {
     }
 }
 
-public extension PHAsset {
-    /// Return a formatted duration string of an asset.
-    var durationString: String {
-        let minutes = Int(duration / 60)
-        let seconds = Int(duration.truncatingRemainder(dividingBy: 60))
+extension TimeInterval {
+    /// Formatted duration string for composer video previews (e.g. "01:23").
+    var composerVideoDurationString: String {
+        let minutes = Int(self / 60)
+        let seconds = Int(truncatingRemainder(dividingBy: 60))
         var minutesString = "\(minutes)"
         var secondsString = "\(seconds)"
         if minutes < 10 {
@@ -105,6 +105,13 @@ public extension PHAsset {
         }
 
         return "\(minutesString):\(secondsString)"
+    }
+}
+
+public extension PHAsset {
+    /// Return a formatted duration string of an asset.
+    var durationString: String {
+        duration.composerVideoDurationString
     }
 }
 

--- a/StreamChatSwiftUITests/Tests/ChatChannel/MessageComposerViewModel_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/MessageComposerViewModel_Tests.swift
@@ -2,6 +2,7 @@
 // Copyright © 2026 Stream.io Inc. All rights reserved.
 //
 
+import AVFoundation
 @testable import StreamChat
 @testable import StreamChatSwiftUI
 @testable import StreamChatTestTools
@@ -1077,6 +1078,112 @@ class MessageComposerViewModel_Tests: StreamChatTestCase {
         XCTAssertEqual(imagePayload.originalHeight, 200)
     }
 
+    func test_addFileURLs_imageURL_addsInlineMediaAssetSentAsImage() throws {
+        let viewModel = makeComposerViewModel()
+        let url = URL.newTemporaryFileURL().appendingPathExtension("png")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try makeImageData().write(to: url)
+
+        viewModel.addFileURLs([url])
+
+        // Rendered inline in the composer as a media asset (not a file chip).
+        XCTAssertEqual(viewModel.addedAssets.count, 1)
+        XCTAssertTrue(viewModel.addedFileURLs.isEmpty)
+        XCTAssertEqual(viewModel.addedAssets.first?.type, .image)
+
+        // Sent as an image attachment.
+        let payloads = try viewModel.convertAddedAssetsToPayloads()
+        XCTAssertEqual(payloads.count, 1)
+        XCTAssertEqual(payloads.first?.type, .image)
+        XCTAssertNotNil(payloads.first?.payload as? ImageAttachmentPayload)
+    }
+
+    func test_addFileURLs_videoURL_addsInlineMediaAssetSentAsVideo() throws {
+        let viewModel = makeComposerViewModel()
+        let url = try makeVideoFileURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        viewModel.addFileURLs([url])
+
+        XCTAssertEqual(viewModel.addedAssets.count, 1)
+        XCTAssertTrue(viewModel.addedFileURLs.isEmpty)
+        XCTAssertEqual(viewModel.addedAssets.first?.type, .video)
+
+        let payloads = try viewModel.convertAddedAssetsToPayloads()
+        XCTAssertEqual(payloads.count, 1)
+        XCTAssertEqual(payloads.first?.type, .video)
+        XCTAssertNotNil(payloads.first?.payload as? VideoAttachmentPayload)
+    }
+
+    func test_addFileURLs_unreadableVideoURL_isStillSentAsVideoAttachment() throws {
+        let viewModel = makeComposerViewModel()
+        let url = URL.newTemporaryFileURL().appendingPathExtension("mp4")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try Data("not a real video".utf8).write(to: url)
+
+        viewModel.addFileURLs([url])
+
+        // No thumbnail could be generated, so it falls back to a file chip in the composer...
+        XCTAssertTrue(viewModel.addedAssets.isEmpty)
+        XCTAssertEqual(viewModel.addedFileURLs.count, 1)
+
+        // ...but it's still sent as a video attachment, resolved from the file extension.
+        let payloads = try viewModel.convertAddedAssetsToPayloads()
+        XCTAssertEqual(payloads.count, 1)
+        XCTAssertEqual(payloads.first?.type, .video)
+        XCTAssertNotNil(payloads.first?.payload as? VideoAttachmentPayload)
+    }
+
+    func test_addFileURLs_audioURL_isSentAsFileAttachment() throws {
+        let viewModel = makeComposerViewModel()
+        let url = URL.newTemporaryFileURL().appendingPathExtension("mp3")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try Data("mock audio".utf8).write(to: url)
+
+        viewModel.addFileURLs([url])
+        XCTAssertEqual(viewModel.addedFileURLs.count, 1)
+
+        let payloads = try viewModel.convertAddedAssetsToPayloads()
+        XCTAssertEqual(payloads.count, 1)
+        XCTAssertEqual(payloads.first?.type, .file)
+        XCTAssertNotNil(payloads.first?.payload as? FileAttachmentPayload)
+    }
+
+    func test_addFileURLs_documentURL_isSentAsFileAttachment() throws {
+        let viewModel = makeComposerViewModel()
+        let url = URL.newTemporaryFileURL().appendingPathExtension("pdf")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try Data("mock pdf".utf8).write(to: url)
+
+        viewModel.addFileURLs([url])
+        XCTAssertEqual(viewModel.addedFileURLs.count, 1)
+
+        let payloads = try viewModel.convertAddedAssetsToPayloads()
+        XCTAssertEqual(payloads.count, 1)
+        XCTAssertEqual(payloads.first?.type, .file)
+        XCTAssertNotNil(payloads.first?.payload as? FileAttachmentPayload)
+    }
+
+    func test_pickedFileURLsBinding_onlyClassifiesNewlyAddedURLs() throws {
+        let viewModel = makeComposerViewModel()
+        let existingFileURL = URL.newTemporaryFileURL().appendingPathExtension("pdf")
+        defer { try? FileManager.default.removeItem(at: existingFileURL) }
+        try Data("mock pdf".utf8).write(to: existingFileURL)
+        viewModel.addedFileURLs = [existingFileURL]
+
+        let imageURL = URL.newTemporaryFileURL().appendingPathExtension("png")
+        defer { try? FileManager.default.removeItem(at: imageURL) }
+        try makeImageData().write(to: imageURL)
+
+        // Simulates the file picker appending a newly picked image to the existing files.
+        viewModel.pickedFileURLsBinding.wrappedValue.append(imageURL)
+
+        // The pre-existing file is untouched, and the new image is routed to inline media.
+        XCTAssertEqual(viewModel.addedFileURLs, [existingFileURL])
+        XCTAssertEqual(viewModel.addedAssets.count, 1)
+        XCTAssertEqual(viewModel.addedAssets.first?.type, .image)
+    }
+
     func test_imagePickerCoordinator_imageSelection_setsOriginalWidthAndHeightOnAsset() throws {
         var captured: AddedAsset?
         let view = ImagePickerView(sourceType: .photoLibrary, onAssetPicked: { captured = $0 })
@@ -1568,6 +1675,45 @@ class MessageComposerViewModel_Tests: StreamChatTestCase {
     private func writeMockData(for url: URL) {
         let data = UIImage(systemName: "checkmark")?.pngData()
         try? data?.write(to: url)
+    }
+
+    private func makeImageData() -> Data {
+        UIGraphicsImageRenderer(size: CGSize(width: 10, height: 10)).image { context in
+            UIColor.red.setFill()
+            context.fill(CGRect(x: 0, y: 0, width: 10, height: 10))
+        }.pngData()!
+    }
+
+    /// Writes a real (decodable) one-frame video to a temporary `.mp4` so that a thumbnail
+    /// can be generated, exercising the picked-video path end to end.
+    private func makeVideoFileURL(width: Int = 16, height: Int = 16) throws -> URL {
+        let url = URL.newTemporaryFileURL().appendingPathExtension("mp4")
+        let writer = try AVAssetWriter(outputURL: url, fileType: .mp4)
+        let input = AVAssetWriterInput(
+            mediaType: .video,
+            outputSettings: [
+                AVVideoCodecKey: AVVideoCodecType.h264,
+                AVVideoWidthKey: width,
+                AVVideoHeightKey: height
+            ]
+        )
+        let adaptor = AVAssetWriterInputPixelBufferAdaptor(
+            assetWriterInput: input,
+            sourcePixelBufferAttributes: nil
+        )
+        writer.add(input)
+        writer.startWriting()
+        writer.startSession(atSourceTime: .zero)
+
+        var pixelBuffer: CVPixelBuffer?
+        CVPixelBufferCreate(kCFAllocatorDefault, width, height, kCVPixelFormatType_32ARGB, nil, &pixelBuffer)
+        adaptor.append(try XCTUnwrap(pixelBuffer), withPresentationTime: .zero)
+        input.markAsFinished()
+
+        let expectation = XCTestExpectation(description: "Finish writing video")
+        writer.finishWriting { expectation.fulfill() }
+        wait(for: [expectation], timeout: 5.0)
+        return url
     }
 }
 

--- a/StreamChatSwiftUITests/Tests/ChatChannel/MessageComposerViewModel_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/MessageComposerViewModel_Tests.swift
@@ -1108,6 +1108,7 @@ class MessageComposerViewModel_Tests: StreamChatTestCase {
         XCTAssertEqual(viewModel.addedAssets.count, 1)
         XCTAssertTrue(viewModel.addedFileURLs.isEmpty)
         XCTAssertEqual(viewModel.addedAssets.first?.type, .video)
+        XCTAssertNotNil(viewModel.addedAssets.first?.extraData["duration"]?.stringValue)
 
         let payloads = try viewModel.convertAddedAssetsToPayloads()
         XCTAssertEqual(payloads.count, 1)


### PR DESCRIPTION
### 🔗 Issue Links

Related to https://linear.app/stream/issue/IOS-1818

### 🎯 Goal

#1516 fixed images/videos picked from the Files/iCloud picker being **sent** with the wrong attachment type, but they still render as a generic file chip in the composer itself, unlike camera/Photos picks. This PR adds the same inline preview that already exists on `develop`, adapted to v4's composer architecture.

### 📝 Summary

- `MessageComposerViewModel.addFileURLs(_:)` now builds an inline media asset (with a synchronous thumbnail) for picked images/videos, the same way the camera and Photos pickers already add them, so they render inline instead of as a file chip.
- Other files (and media that can't be read, e.g. an undownloaded iCloud file) still fall back to a regular file attachment; `MessageAttachmentsConverter` resolves the correct type from the extension when sending, so it's still sent as the right type either way.
- Only newly picked files are routed through this — draft/edit restoration and attachment removal continue to mutate `addedFileURLs` directly and are unaffected.

### 🛠 Implementation

v4's composer doesn't have a single entry point for picker additions — `addedFileURLs: [URL]` is a plain `@Published` array bound directly to the native file picker, and also reused for draft/edit restoration and removal. A previous attempt at this fix hooked into `addedFileURLs.didSet`, which fired for **all** of those cases (not just new picks) and was reverted because it broke draft/edit restoration and unrelated tests.

This PR avoids that by not touching `addedFileURLs`'s own setter at all. Instead:
- `MessageComposerViewModel.pickedFileURLsBinding` is a new binding that reads `addedFileURLs` and, on write, diffs the newly appended URLs and routes them through `addFileURLs(_:)`.
- `MessageComposerView` and the demo's `AppleMessageComposerView` now pass this binding (instead of `$viewModel.addedFileURLs`) to `makeAttachmentPickerView(...)`.

Since draft restoration (`updateComposerAssets`) and removal (`removeAttachment(with:)`) mutate `addedFileURLs` directly in Swift code rather than through this SwiftUI binding, they're completely unaffected — the only thing that writes through `pickedFileURLsBinding` is the native file picker appending newly picked URLs.

### 🎨 Showcase

| Before | After |
| ------ | ----- |
| Image from Files rendered as a file chip in the composer | Image from Files rendered inline in the composer |

### 🧪 Manual Testing Notes

1. Open a channel, tap the attachment button, choose **Files** / iCloud.
2. Pick an image and a video.
3. Both should render inline in the composer (thumbnail, not a file chip), and inline in the message list after sending.
4. Sanity check that removing an attachment, restoring a draft with a file attachment, and editing a message with an existing file attachment all still work as before.

### ☑️ Contributor Checklist

- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests