### PR TITLE
Add DemoApp option for attachment downloads directory

### DIFF
--- a/.github/actions/xcode-cache/action.yml
+++ b/.github/actions/xcode-cache/action.yml
@@ -10,5 +10,6 @@ runs:
       id: spm-cache
       with:
         path: spm_cache
-        key: ${{ env.IMAGE }}-spm-${{ hashFiles('**/Package.resolved') }}
-        restore-keys: ${{ env.IMAGE }}-spm-
+        # Package.resolved is gitignored, so key off Package.swift. Avoid broad
+        # restore-keys that reuse stale branch checkouts of stream-chat-swift.
+        key: ${{ env.IMAGE }}-spm-${{ hashFiles('Package.swift') }}

--- a/.github/actions/xcode-cache/action.yml
+++ b/.github/actions/xcode-cache/action.yml
@@ -10,6 +10,5 @@ runs:
       id: spm-cache
       with:
         path: spm_cache
-        # Package.resolved is gitignored, so key off Package.swift. Avoid broad
-        # restore-keys that reuse stale branch checkouts of stream-chat-swift.
-        key: ${{ env.IMAGE }}-spm-${{ hashFiles('Package.swift') }}
+        key: ${{ env.IMAGE }}-spm-${{ hashFiles('**/Package.resolved') }}
+        restore-keys: ${{ env.IMAGE }}-spm-

--- a/DemoAppSwiftUI/AppConfiguration/AppConfiguration.swift
+++ b/DemoAppSwiftUI/AppConfiguration/AppConfiguration.swift
@@ -22,10 +22,77 @@ final class AppConfiguration {
     var appStyle: AppStyle = .regular
     /// When enabled, releasing a hold-to-record gesture sends the voice message instantly.
     var isVoiceRecordingAutoSendEnabled = false
+    /// Base directory used for Stream Chat attachment downloads.
+    ///
+    /// Applied when creating `ChatClient`, so changes take effect on the next app launch.
+    var attachmentDownloadsDirectory: AttachmentDownloadsDirectory = .stored {
+        didSet { AttachmentDownloadsDirectory.stored = attachmentDownloadsDirectory }
+    }
 
     enum AppStyle: String, CaseIterable {
         case regular
         case liquidGlass
+    }
+
+    /// Common sandbox locations for storing downloaded attachments.
+    enum AttachmentDownloadsDirectory: String, CaseIterable, Identifiable {
+        case documents
+        case applicationSupport
+        case caches
+
+        private static let userDefaultsKey = "demo.attachmentDownloadsDirectory"
+
+        var id: String { rawValue }
+
+        var title: String {
+            switch self {
+            case .documents:
+                return "Documents"
+            case .applicationSupport:
+                return "Application Support"
+            case .caches:
+                return "Caches"
+            }
+        }
+
+        var subtitle: String {
+            switch self {
+            case .documents:
+                return "User-visible, included in backups"
+            case .applicationSupport:
+                return "Hidden, included in backups"
+            case .caches:
+                return "Hidden, excluded from backups"
+            }
+        }
+
+        /// Persisted selection used when building `ChatClientConfig`.
+        static var stored: AttachmentDownloadsDirectory {
+            get {
+                guard let rawValue = UserDefaults.standard.string(forKey: userDefaultsKey),
+                      let value = Self(rawValue: rawValue) else {
+                    return .documents
+                }
+                return value
+            }
+            set {
+                UserDefaults.standard.set(newValue.rawValue, forKey: userDefaultsKey)
+            }
+        }
+
+        var folderURL: URL? {
+            let fileManager = FileManager.default
+            switch self {
+            case .documents:
+                return fileManager.urls(for: .documentDirectory, in: .userDomainMask).first
+            case .applicationSupport:
+                return fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first?
+                    .appendingPathComponent("io.getstream.StreamChat", isDirectory: true)
+            case .caches:
+                return fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first?
+                    .appendingPathComponent("io.getstream.StreamChat", isDirectory: true)
+            }
+        }
     }
 
     /// Builds the demo app's `ComposerConfig` using current app configuration.

--- a/DemoAppSwiftUI/AppConfiguration/AppConfigurationView.swift
+++ b/DemoAppSwiftUI/AppConfiguration/AppConfigurationView.swift
@@ -12,6 +12,7 @@ struct AppConfigurationView: View {
     @State private var reactionsPlacement = AppConfiguration.default.reactionsPlacement
     @State private var appStyle = AppConfiguration.default.appStyle
     @State private var voiceRecordingAutoSend = AppConfiguration.default.isVoiceRecordingAutoSendEnabled
+    @State private var attachmentDownloadsDirectory = AppConfiguration.default.attachmentDownloadsDirectory
 
     var body: some View {
         NavigationView {
@@ -41,6 +42,20 @@ struct AppConfigurationView: View {
                 Section("Voice Recording") {
                     Toggle("Auto-send on release", isOn: $voiceRecordingAutoSend)
                 }
+                Section {
+                    Picker("Directory", selection: $attachmentDownloadsDirectory) {
+                        ForEach(AppConfiguration.AttachmentDownloadsDirectory.allCases) { directory in
+                            Text(directory.title).tag(directory)
+                        }
+                    }
+                    Text(attachmentDownloadsDirectory.subtitle)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                } header: {
+                    Text("Attachment Downloads")
+                } footer: {
+                    Text("Takes effect on the next app launch. Downloaded files are stored in a StreamAttachmentDownloads subfolder.")
+                }
             }
             .navigationBarTitleDisplayMode(.inline)
             .navigationTitle("App Configuration")
@@ -60,6 +75,9 @@ struct AppConfigurationView: View {
         .onChange(of: voiceRecordingAutoSend) { newValue in
             AppConfiguration.default.isVoiceRecordingAutoSendEnabled = newValue
             InjectedValues[\.utils].composerConfig = AppConfiguration.makeComposerConfig()
+        }
+        .onChange(of: attachmentDownloadsDirectory) { newValue in
+            AppConfiguration.default.attachmentDownloadsDirectory = newValue
         }
     }
 }

--- a/DemoAppSwiftUI/AppDelegate.swift
+++ b/DemoAppSwiftUI/AppDelegate.swift
@@ -15,6 +15,10 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         var config = ChatClientConfig(apiKey: .init(apiKeyString))
         config.isLocalStorageEnabled = true
         config.applicationGroupIdentifier = applicationGroupIdentifier
+        if let downloadsFolderURL = AppConfiguration.AttachmentDownloadsDirectory.stored.folderURL {
+            try? FileManager.default.createDirectory(at: downloadsFolderURL, withIntermediateDirectories: true)
+            config.localAttachmentDownloadsFolderURL = downloadsFolderURL
+        }
 
         let client = ChatClient(config: config)
         return client

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/GetStream/stream-chat-swift.git", branch: "add/configurable-attachment-downloads-directory")
+        .package(url: "https://github.com/GetStream/stream-chat-swift.git", branch: "develop")
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -16,8 +16,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        // Pinned until CI can reliably resolve the develop tip that includes localAttachmentDownloadsFolderURL.
-        .package(url: "https://github.com/GetStream/stream-chat-swift.git", revision: "1591fe37d6e3c5cba38d6be189aba75bed510736")
+        .package(url: "https://github.com/GetStream/stream-chat-swift.git", branch: "develop")
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/GetStream/stream-chat-swift.git", branch: "develop")
+        .package(url: "https://github.com/GetStream/stream-chat-swift.git", branch: "add/configurable-attachment-downloads-directory")
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,8 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/GetStream/stream-chat-swift.git", branch: "develop")
+        // Pinned until CI can reliably resolve the develop tip that includes localAttachmentDownloadsFolderURL.
+        .package(url: "https://github.com/GetStream/stream-chat-swift.git", revision: "1591fe37d6e3c5cba38d6be189aba75bed510736")
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/GetStream/stream-chat-swift.git", branch: "develop")
+        .package(url: "https://github.com/GetStream/stream-chat-swift.git", revision: "1591fe37d6e3c5cba38d6be189aba75bed510736")
     ],
     targets: [
         .target(

--- a/StreamChatSwiftUI.xcodeproj/project.pbxproj
+++ b/StreamChatSwiftUI.xcodeproj/project.pbxproj
@@ -1532,8 +1532,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/GetStream/stream-chat-swift.git";
 			requirement = {
-				branch = develop;
-				kind = branch;
+				kind = revision;
+				revision = 1591fe37d6e3c5cba38d6be189aba75bed510736;
 			};
 		};
 		E3A1C01A282BAC66002D1E26 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {

--- a/StreamChatSwiftUI.xcodeproj/project.pbxproj
+++ b/StreamChatSwiftUI.xcodeproj/project.pbxproj
@@ -1532,7 +1532,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/GetStream/stream-chat-swift.git";
 			requirement = {
-				branch = add/configurable-attachment-downloads-directory;
+				branch = develop;
 				kind = branch;
 			};
 		};

--- a/StreamChatSwiftUI.xcodeproj/project.pbxproj
+++ b/StreamChatSwiftUI.xcodeproj/project.pbxproj
@@ -1532,8 +1532,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/GetStream/stream-chat-swift.git";
 			requirement = {
-				kind = revision;
-				revision = 1591fe37d6e3c5cba38d6be189aba75bed510736;
+				branch = develop;
+				kind = branch;
 			};
 		};
 		E3A1C01A282BAC66002D1E26 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {

--- a/StreamChatSwiftUI.xcodeproj/project.pbxproj
+++ b/StreamChatSwiftUI.xcodeproj/project.pbxproj
@@ -1532,7 +1532,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/GetStream/stream-chat-swift.git";
 			requirement = {
-				branch = develop;
+				branch = add/configurable-attachment-downloads-directory;
 				kind = branch;
 			};
 		};

--- a/StreamChatSwiftUITests/Tests/ChatChannel/MessageComposerViewModel_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/MessageComposerViewModel_Tests.swift
@@ -2581,7 +2581,7 @@ import XCTest
     }
 
     private func makeUserGroup(name: String) -> UserGroup {
-        UserGroup(id: .unique, name: name, createdAt: .init(), updatedAt: .init())
+        UserGroup(createdAt: .init(), id: .unique, name: name, updatedAt: .init())
     }
 
     private func populateAllMentionTypes(in viewModel: MessageComposerViewModel) {

--- a/StreamChatSwiftUITests/Tests/ChatChannel/MessageComposerViewModel_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/MessageComposerViewModel_Tests.swift
@@ -2581,7 +2581,7 @@ import XCTest
     }
 
     private func makeUserGroup(name: String) -> UserGroup {
-        UserGroup(createdAt: .init(), id: .unique, name: name, updatedAt: .init())
+        UserGroup(id: .unique, name: name, createdAt: .init(), updatedAt: .init())
     }
 
     private func populateAllMentionTypes(in viewModel: MessageComposerViewModel) {

--- a/StreamChatSwiftUITests/Tests/ChatChannel/MessageView_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/MessageView_Tests.swift
@@ -158,7 +158,7 @@ import XCTest
             ],
             mentionedHere: true,
             mentionedChannel: true,
-            mentionedGroups: [.init(id: "eng", name: "Engineering")],
+            mentionedGroups: [.init(createdAt: .init(), id: "eng", name: "Engineering", updatedAt: .init())],
             mentionedRoles: ["admin"]
         )
 
@@ -189,7 +189,7 @@ import XCTest
             mentionedUsers: [.mock(id: "martin", name: "Martin")],
             mentionedHere: true,
             mentionedChannel: true,
-            mentionedGroups: [.init(id: "eng", name: "Engineering")],
+            mentionedGroups: [.init(createdAt: .init(), id: "eng", name: "Engineering", updatedAt: .init())],
             mentionedRoles: ["admin"]
         )
 

--- a/StreamChatSwiftUITests/Tests/ChatChannel/Suggestions/MentionSuggestion_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/Suggestions/MentionSuggestion_Tests.swift
@@ -59,12 +59,12 @@ final class MentionSuggestion_Tests: StreamChatTestCase {
 private extension UserGroup {
     static func mock(id: String, name: String, memberCount: Int = 0) -> UserGroup {
         UserGroup(
-            createdAt: .init(),
             id: id,
-            members: (0..<memberCount).map {
-                UserGroupMember(createdAt: .init(), groupId: id, isAdmin: false, userId: "member-\($0)")
-            },
             name: name,
+            members: (0..<memberCount).map {
+                UserGroupMember(groupId: id, userId: "member-\($0)", isAdmin: false, createdAt: .init())
+            },
+            createdAt: .init(),
             updatedAt: .init()
         )
     }

--- a/StreamChatSwiftUITests/Tests/ChatChannel/Suggestions/MentionSuggestion_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/Suggestions/MentionSuggestion_Tests.swift
@@ -59,12 +59,12 @@ final class MentionSuggestion_Tests: StreamChatTestCase {
 private extension UserGroup {
     static func mock(id: String, name: String, memberCount: Int = 0) -> UserGroup {
         UserGroup(
-            id: id,
-            name: name,
-            members: (0..<memberCount).map {
-                UserGroupMember(groupId: id, userId: "member-\($0)", isAdmin: false, createdAt: .init())
-            },
             createdAt: .init(),
+            id: id,
+            members: (0..<memberCount).map {
+                UserGroupMember(createdAt: .init(), groupId: id, isAdmin: false, userId: "member-\($0)")
+            },
+            name: name,
             updatedAt: .init()
         )
     }

--- a/StreamChatSwiftUITests/Tests/ChatChannel/Suggestions/MentionSuggestionsView_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/Suggestions/MentionSuggestionsView_Tests.swift
@@ -44,12 +44,12 @@ final class MentionSuggestionsView_Tests: StreamChatTestCase {
 private extension UserGroup {
     static func mock(id: String, name: String, memberCount: Int = 0) -> UserGroup {
         UserGroup(
-            createdAt: .init(),
             id: id,
-            members: (0..<memberCount).map {
-                UserGroupMember(createdAt: .init(), groupId: id, isAdmin: false, userId: "member-\($0)")
-            },
             name: name,
+            members: (0..<memberCount).map {
+                UserGroupMember(groupId: id, userId: "member-\($0)", isAdmin: false, createdAt: .init())
+            },
+            createdAt: .init(),
             updatedAt: .init()
         )
     }

--- a/StreamChatSwiftUITests/Tests/ChatChannel/Suggestions/MentionSuggestionsView_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/Suggestions/MentionSuggestionsView_Tests.swift
@@ -44,12 +44,12 @@ final class MentionSuggestionsView_Tests: StreamChatTestCase {
 private extension UserGroup {
     static func mock(id: String, name: String, memberCount: Int = 0) -> UserGroup {
         UserGroup(
-            id: id,
-            name: name,
-            members: (0..<memberCount).map {
-                UserGroupMember(groupId: id, userId: "member-\($0)", isAdmin: false, createdAt: .init())
-            },
             createdAt: .init(),
+            id: id,
+            members: (0..<memberCount).map {
+                UserGroupMember(createdAt: .init(), groupId: id, isAdmin: false, userId: "member-\($0)")
+            },
+            name: name,
             updatedAt: .init()
         )
     }

--- a/StreamChatSwiftUITests/Tests/ChatChannel/Suggestions/MentionsCommandHandler_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/Suggestions/MentionsCommandHandler_Tests.swift
@@ -312,7 +312,7 @@ import XCTest
     }
 
     private func makeGroup(name: String) -> UserGroup {
-        UserGroup(id: .unique, name: name, createdAt: .init(), updatedAt: .init())
+        UserGroup(createdAt: .init(), id: .unique, name: name, updatedAt: .init())
     }
 }
 

--- a/StreamChatSwiftUITests/Tests/ChatChannel/Suggestions/MentionsCommandHandler_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/Suggestions/MentionsCommandHandler_Tests.swift
@@ -312,7 +312,7 @@ import XCTest
     }
 
     private func makeGroup(name: String) -> UserGroup {
-        UserGroup(createdAt: .init(), id: .unique, name: name, updatedAt: .init())
+        UserGroup(id: .unique, name: name, createdAt: .init(), updatedAt: .init())
     }
 }
 


### PR DESCRIPTION
### 🔗 Issue Links

- https://linear.app/stream/issue/IOS-1889/allow-configuring-attachment-downloads-directory-avoid-documents
- LLC: https://github.com/GetStream/stream-chat-swift/pull/4174

### 🎯 Goal

Exercise the new `ChatClientConfig.localAttachmentDownloadsFolderURL` API from the SwiftUI DemoApp, so we can validate Documents vs Application Support vs Caches storage for downloaded attachments.

### 📝 Summary

- Add an Attachment Downloads directory picker in App Configuration (Documents / Application Support / Caches)
- Persist the selection and apply it when creating `ChatClient`

### 🛠 Implementation

The picker stores the chosen sandbox directory in `UserDefaults` and sets `config.localAttachmentDownloadsFolderURL` in `AppDelegate` at client creation time, so changes take effect on the next app launch.

### 🎨 Showcase

N/A — DemoApp settings UI for selecting the downloads directory.

### 🧪 Manual Testing Notes

1. On the login screen, open App Configuration → Attachment Downloads
2. Select Application Support or Caches, then force-quit and relaunch
3. Download an attachment and confirm it is stored under the chosen base directory's `StreamAttachmentDownloads` subfolder
4. Switch back to Documents and relaunch to confirm default behavior

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an “Attachment Downloads” setting to choose where attachment files are stored: Documents, Application Support, or Caches.
  - Updated the configuration UI to show the selected location and clarify when the change takes effect.
- **Bug Fixes**
  - Ensures the selected attachment downloads directory is created at startup when available.
- **Chores**
  - Pinned the Stream Chat Swift package to a specific revision for more consistent builds.
- **Tests**
  - Updated test data construction to match initializer argument ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->