### PR TITLE
Add providerName to demo app APN device registration

### DIFF
--- a/DemoAppSwiftUI/AppDelegate.swift
+++ b/DemoAppSwiftUI/AppDelegate.swift
@@ -125,7 +125,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
             return
         }
 
-        chatClient.currentUserController().addDevice(.apn(token: deviceToken)) { error in
+        chatClient.currentUserController().addDevice(.apn(token: deviceToken, providerName: "APN")) { error in
             if let error {
                 log.error("adding a device failed with an error \(error)")
                 return


### PR DESCRIPTION
### 🔗 Issue Links

_N/A_

### 🎯 Goal

Register the demo app's device with a named APN push provider configuration.

### 📝 Summary

- Pass `providerName: "APN"` to the `addDevice(.apn(...))` call in the demo app.

### 🛠 Implementation

The `.apn` push device factory accepts an optional `providerName` used to associate the device with a specific named push provider configuration on the Stream backend. The demo app now sets it to `"APN"`.

### 🎨 Showcase

_N/A_

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

Run the demo app, register for push notifications, and confirm the device is added without error.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved push notification device registration by providing the required provider information.
  * Existing user validation, error handling, and registration persistence remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->