### PR TITLE
Update StreamChat dependency to 5.7.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/GetStream/stream-chat-swift.git", revision: "1591fe37d6e3c5cba38d6be189aba75bed510736")
+        .package(url: "https://github.com/GetStream/stream-chat-swift.git", from: "5.7.0")
     ],
     targets: [
         .target(

--- a/StreamChatSwiftUI.xcodeproj/project.pbxproj
+++ b/StreamChatSwiftUI.xcodeproj/project.pbxproj
@@ -1532,8 +1532,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/GetStream/stream-chat-swift.git";
 			requirement = {
-				kind = revision;
-				revision = 1591fe37d6e3c5cba38d6be189aba75bed510736;
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.7.0;
 			};
 		};
 		E3A1C01A282BAC66002D1E26 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {


### PR DESCRIPTION
### 🔗 Issue Links

https://linear.app/stream/issue/IOS-1880/release-570

### 🎯 Goal

Point StreamChatSwiftUI at the newly published StreamChat `5.7.0` release (release step 7).

### 📝 Summary

- Update `Package.swift` StreamChat dependency from a develop revision pin to `from: "5.7.0"`
- Align the Xcode project package requirement to `upToNextMajorVersion` / `5.7.0`

### 🛠 Implementation

Manual equivalent of `bundle exec fastlane update_stream_chat version:5.7.0` (the lane currently expects an existing `from:` / `minimumVersion` pin; develop was temporarily on a revision pin).

### 🎨 Showcase

N/A

### 🧪 Manual Testing Notes

Resolve packages and confirm the DemoApp builds against StreamChat 5.7.0.

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Stream Chat Swift package requirement to use semantic versioning, starting with version 5.7.0.
  * Future compatible updates within the same major version can now be adopted automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->