### PR TITLE
Pass team when sending a DM to a member

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
+### 🐞 Fixed
+- Pass the channel's team when starting a direct message with a member [#1541](https://github.com/GetStream/stream-chat-swiftui/pull/1541)
+
 ### 🔄 Changed
 
 # [5.7.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/5.7.0)

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/ChatChannelInfoViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChannelInfo/ChatChannelInfoViewModel.swift
@@ -388,11 +388,7 @@ import SwiftUI
             confirmationPopup: nil,
             isDestructive: false
         )
-        if let currentUserId = chatClient.currentUserId,
-           let channelController = try? chatClient.channelController(
-               createDirectMessageChannelWith: [currentUserId, participant.id],
-               extraData: [:]
-           ) {
+        if let channelController = directMessageChannelController(for: participant) {
             directMessageAction.navigationDestination = AnyView(
                 ChatChannelView(channelController: channelController)
             )
@@ -437,7 +433,16 @@ import SwiftUI
         
         return actions
     }
-    
+
+    func directMessageChannelController(for participant: ParticipantInfo) -> ChatChannelController? {
+        guard let currentUserId = chatClient.currentUserId else { return nil }
+        return try? chatClient.channelController(
+            createDirectMessageChannelWith: [currentUserId, participant.id],
+            team: channel.team,
+            extraData: [:]
+        )
+    }
+
     public func muteAction(
         participant: ParticipantInfo,
         onDismiss: @escaping () -> Void,

--- a/StreamChatSwiftUITests/Tests/ChatChannel/ChannelInfo/ChatChannelInfoViewModel_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/ChannelInfo/ChatChannelInfoViewModel_Tests.swift
@@ -348,6 +348,8 @@ import XCTest
         let controller = viewModel.directMessageChannelController(for: participant)
 
         // Then
+        XCTAssertNotNil(controller)
+        XCTAssertNotNil(controller?.channelQuery.channelPayload)
         XCTAssertNil(controller?.channelQuery.channelPayload?.team)
     }
 

--- a/StreamChatSwiftUITests/Tests/ChatChannel/ChannelInfo/ChatChannelInfoViewModel_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/ChannelInfo/ChatChannelInfoViewModel_Tests.swift
@@ -315,6 +315,42 @@ import XCTest
         XCTAssertFalse(actions.contains { $0.title == L10n.Alert.Actions.cancel })
     }
 
+    func test_chatChannelInfoVM_directMessageChannelController_passesTeam() {
+        // Given
+        let channel = mockGroup(with: 5, team: "red")
+        let viewModel = ChatChannelInfoViewModel(channel: channel)
+        let participant = ParticipantInfo(
+            chatUser: ChatUser.mock(id: .unique),
+            displayName: "Test User",
+            onlineInfoText: "online",
+            isDeactivated: false
+        )
+
+        // When
+        let controller = viewModel.directMessageChannelController(for: participant)
+
+        // Then
+        XCTAssertEqual(controller?.channelQuery.channelPayload?.team, "red")
+    }
+
+    func test_chatChannelInfoVM_directMessageChannelController_withoutTeam() {
+        // Given
+        let channel = mockGroup(with: 5)
+        let viewModel = ChatChannelInfoViewModel(channel: channel)
+        let participant = ParticipantInfo(
+            chatUser: ChatUser.mock(id: .unique),
+            displayName: "Test User",
+            onlineInfoText: "online",
+            isDeactivated: false
+        )
+
+        // When
+        let controller = viewModel.directMessageChannelController(for: participant)
+
+        // Then
+        XCTAssertNil(controller?.channelQuery.channelPayload?.team)
+    }
+
     func test_chatChannelInfoVM_participantActions_withMutesDisabled() {
         // Given
         let channel = mockGroup(with: 5, updateCapabilities: true, mutesEnabled: false)
@@ -1073,7 +1109,8 @@ import XCTest
     private func mockGroup(
         with memberCount: Int,
         updateCapabilities: Bool = true,
-        mutesEnabled: Bool = true
+        mutesEnabled: Bool = true,
+        team: TeamId? = nil
     ) -> ChatChannel {
         let cid: ChannelId = .unique
         let activeMembers = ChannelInfoMockUtils.setupMockMembers(
@@ -1087,14 +1124,15 @@ import XCTest
             capabilities.insert(.leaveChannel)
             capabilities.insert(.updateChannelMembers)
         }
-        
+
         let channelConfig = ChannelConfig(mutesEnabled: mutesEnabled)
-        
+
         let channel = ChatChannel.mock(
             cid: cid,
             config: channelConfig,
             ownCapabilities: capabilities,
             lastActiveMembers: activeMembers,
+            team: team,
             memberCount: activeMembers.count
         )
         return channel


### PR DESCRIPTION
### 🔗 Issue Links

- [IOS-1892](https://linear.app/stream/issue/IOS-1892/planday-pass-team-when-sending-dm-to-a-member)

### 🎯 Goal

In multi-tenant (teams) setups, starting a direct message with a member from the channel info screen created the new channel without a team. The DM therefore ended up outside the team of the channel it was started from.

### 📝 Summary

- The direct message created when tapping a member in the channel info screen now inherits the team of the channel it is started from.

### 🛠 Implementation

- `ChatChannelInfoViewModel` now passes the source channel's `team` when creating the direct message channel controller.
- Extracted the controller creation into a dedicated method so the team propagation is covered by unit tests.

### 🧪 Manual Testing Notes

1. Log in as a user that belongs to a team-scoped channel.
2. Open the channel info screen and tap a member, then choose "Send Direct Message".
3. Verify the created DM channel belongs to the same team as the source channel.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Direct messages started from a channel now retain the channel’s team context.
  * Improved handling when the current user is unavailable or direct-message channel creation fails.

* **Tests**
  * Added coverage for direct messages with and without team information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->