### PR TITLE
[v4] Update StreamChat dependency to 4.102.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/GetStream/stream-chat-swift.git", from: "4.101.1")
+        .package(url: "https://github.com/GetStream/stream-chat-swift.git", from: "4.102.0")
     ],
     targets: [
         .target(

--- a/StreamChatSwiftUI-XCFramework.podspec
+++ b/StreamChatSwiftUI-XCFramework.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |spec|
 
   spec.framework = 'Foundation', 'UIKit', 'SwiftUI'
 
-  spec.dependency 'StreamChat-XCFramework', '~> 4.101.1'
+  spec.dependency 'StreamChat-XCFramework', '~> 4.102.0'
 
   spec.cocoapods_version = '>= 1.11.0'
 end

--- a/StreamChatSwiftUI.podspec
+++ b/StreamChatSwiftUI.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |spec|
 
   spec.framework = 'Foundation', 'UIKit', 'SwiftUI'
 
-  spec.dependency 'StreamChat', '~> 4.101.1'
+  spec.dependency 'StreamChat', '~> 4.102.0'
 end

--- a/StreamChatSwiftUI.xcodeproj/project.pbxproj
+++ b/StreamChatSwiftUI.xcodeproj/project.pbxproj
@@ -1464,7 +1464,7 @@
 			repositoryURL = "https://github.com/GetStream/stream-chat-swift.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 4.101.1;
+				minimumVersion = 4.102.0;
 			};
 		};
 		E3A1C01A282BAC66002D1E26 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {


### PR DESCRIPTION
### 🔗 Issue Links

[IOS-1889](https://linear.app/stream/issue/IOS-1889/allow-configuring-attachment-downloads-directory-avoid-documents)

### 🎯 Goal

Bump the StreamChat (LLC) dependency to 4.102.0 on the v4 SwiftUI branch so the SDK picks up the configurable attachment downloads directory API and other v4.102.0 fixes.

### 📝 Summary

- Update StreamChat dependency from 4.101.1 to 4.102.0 in `Package.swift`, Xcode project, and CocoaPods podspecs

### 🛠 Implementation

Ran `bundle exec fastlane update_stream_chat version:4.102.0` on `v4` (file updates + branch push). PR opened with `gh` because Fastlane `pr_create` requires `GITHUB_TOKEN`.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo