### PR TITLE
Preserve Markdown link destinations when display text looks like a URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### 🐞 Fixed
 - Pass the channel's team when starting a direct message with a member [#1541](https://github.com/GetStream/stream-chat-swiftui/pull/1541)
+- Fix Markdown links with URL-shaped display text opening the wrong destination, e.g. `[https://text-link.com](https://real-link.com)` [#1543](https://github.com/GetStream/stream-chat-swiftui/pull/1543)
 
 ### 🔄 Changed
 

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/GetStream/stream-chat-swift.git", branch: "nuno/ios-1906-preserve-markdown-links")
+        .package(url: "https://github.com/GetStream/stream-chat-swift.git", revision: "72976679e3a4bda655fbf5ec5c1c515a94483228")
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/GetStream/stream-chat-swift.git", from: "5.7.0")
+        .package(url: "https://github.com/GetStream/stream-chat-swift.git", branch: "nuno/ios-1906-preserve-markdown-links")
     ],
     targets: [
         .target(

--- a/Sources/StreamChatSwiftUI/Utils/Common/ChatMessage+Extensions.swift
+++ b/Sources/StreamChatSwiftUI/Utils/Common/ChatMessage+Extensions.swift
@@ -166,11 +166,7 @@ extension ChatMessage {
             if mentionedChannel {
                 addMentionLink(for: "channel", mentionId: "channel", in: &attributedString)
             }
-            for link in utils.linkDetector.links(in: String(attributedString.characters)) {
-                if let attributedStringRange = Range(link.range, in: attributedString) {
-                    attributedString[attributedStringRange].link = link.url
-                }
-            }
+            attributedString.addLinks(detectedBy: utils.linkDetector)
         }
 
         // Link styling

--- a/StreamChatSwiftUI.xcodeproj/project.pbxproj
+++ b/StreamChatSwiftUI.xcodeproj/project.pbxproj
@@ -1532,8 +1532,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/GetStream/stream-chat-swift.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 5.7.0;
+				kind = branch;
+				branch = "nuno/ios-1906-preserve-markdown-links";
 			};
 		};
 		E3A1C01A282BAC66002D1E26 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {

--- a/StreamChatSwiftUI.xcodeproj/project.pbxproj
+++ b/StreamChatSwiftUI.xcodeproj/project.pbxproj
@@ -1532,8 +1532,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/GetStream/stream-chat-swift.git";
 			requirement = {
-				kind = branch;
-				branch = "nuno/ios-1906-preserve-markdown-links";
+				kind = revision;
+				revision = 72976679e3a4bda655fbf5ec5c1c515a94483228;
 			};
 		};
 		E3A1C01A282BAC66002D1E26 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {

--- a/StreamChatSwiftUITests/Tests/ChatChannel/MessageView_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/MessageView_Tests.swift
@@ -179,6 +179,46 @@ import XCTest
         )
     }
 
+    func test_attributedTextContent_whenMarkdownLinkDisplayTextLooksLikeAURL_usesTheHrefFromMarkdown() {
+        // Given
+        let realURL = URL(string: "https://real-link.com")!
+        let message = ChatMessage.mock(
+            id: .unique,
+            cid: .unique,
+            text: "[https://text-link.com](https://real-link.com)",
+            author: .mock(id: .unique)
+        )
+
+        // When
+        let attributed = message.attributedTextContent(
+            layoutDirection: .leftToRight,
+            translationLanguage: nil
+        )
+
+        // Then
+        XCTAssertEqual(firstLink(in: attributed), realURL)
+    }
+
+    func test_attributedTextContent_whenPlainTextURLHasNoMarkdownLink_stillDetectsIt() {
+        // Given
+        let detectedURL = URL(string: "https://getstream.io")!
+        let message = ChatMessage.mock(
+            id: .unique,
+            cid: .unique,
+            text: "visit https://getstream.io now",
+            author: .mock(id: .unique)
+        )
+
+        // When
+        let attributed = message.attributedTextContent(
+            layoutDirection: .leftToRight,
+            translationLanguage: nil
+        )
+
+        // Then
+        XCTAssertEqual(firstLink(in: attributed), detectedURL)
+    }
+
     func test_messageViewTextMentionAllTypes_snapshot() {
         // Given
         let textMessage = ChatMessage.mock(
@@ -1947,6 +1987,13 @@ import XCTest
         case .file, .voice:
             return CGSize(width: defaultScreenSize.width, height: hasCaption ? 220 : 180)
         }
+    }
+
+    private func firstLink(in attributedString: AttributedString) -> URL? {
+        for (value, _) in attributedString.runs[\.link] where value != nil {
+            return value
+        }
+        return nil
     }
 }
 


### PR DESCRIPTION
### 🔗 Issue Links

- [IOS-1906](https://linear.app/stream/issue/IOS-1906/preserve-markdown-link-destinations-when-display-text-is-a-url)
- Depends on LLC PR [#4181](https://github.com/GetStream/stream-chat-swift/pull/4181)

### 🎯 Goal

Prevent SwiftUI message text from replacing a Markdown link's destination when its visible text also looks like a URL.

### 📝 Summary

- Point the StreamChat dependency at `nuno/ios-1906-preserve-markdown-links` so we can use the new shared API.
- Use `AttributedString.addLinks(detectedBy:)` in `ChatMessage.attributedTextContent(...)`.
- Add regression tests for Markdown links with URL-shaped display text and for plain-text URLs.

### 🛠 Implementation

Plain-text link detection used to overwrite any `.link` already set by Markdown parsing. That meant:

`[https://text-link.com](https://real-link.com)`

could open `https://text-link.com` instead of `https://real-link.com`.

The LLC now exposes `AttributedString.addLinks(detectedBy:)`, which skips ranges that already have a link. SwiftUI reuses that API instead of reimplementing the preserve-existing-links logic.

**Note:** the StreamChat dependency is temporarily pinned to the LLC feature branch. After [#4181](https://github.com/GetStream/stream-chat-swift/pull/4181) is released, this PR (or a follow-up) should switch back to a versioned dependency.

### 🎨 Showcase

N/A — text-only rendering behavior.

### 🧪 Manual Testing Notes

Send `[https://text-link.com](https://real-link.com)` and verify that tapping it opens `https://real-link.com`. Also verify that a plain-text URL such as `https://getstream.io` remains clickable.

Targeted tests:

```
xcodebuild -project StreamChatSwiftUI.xcodeproj -scheme StreamChatSwiftUI -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -configuration Debug -only-testing:StreamChatSwiftUITests/MessageView_Tests/test_attributedTextContent_whenMarkdownLinkDisplayTextLooksLikeAURL_usesTheHrefFromMarkdown -only-testing:StreamChatSwiftUITests/MessageView_Tests/test_attributedTextContent_whenPlainTextURLHasNoMarkdownLink_stillDetectsIt test
```

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Markdown links whose visible text resembles a URL opening the wrong destination.
  - Markdown links now consistently open the URL specified in the link target.
  - Improved detection of plain-text URLs so they continue to open the correct destination.
  - Link handling is now more reliable across chat message content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->