### PR TITLE
Download media picker assets on tap instead of on appear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # Upcoming
 
 ### 🐞 Fixed
+- Fix media attachment picker being unresponsive when the photo library has many videos [#1544](https://github.com/GetStream/stream-chat-swiftui/pull/1544)
 - Pass the channel's team when starting a direct message with a member [#1541](https://github.com/GetStream/stream-chat-swiftui/pull/1541)
 
 ### 🔄 Changed

--- a/Sources/StreamChatSwiftUI/ChatComposer/AttachmentPicker/AttachmentMediaPicker/AttachmentMediaPickerItemView.swift
+++ b/Sources/StreamChatSwiftUI/ChatComposer/AttachmentPicker/AttachmentMediaPicker/AttachmentMediaPickerItemView.swift
@@ -67,9 +67,7 @@ public struct AttachmentMediaPickerItemView: View {
                             .clipped()
                             .allowsHitTesting(true)
                             .onTapGesture {
-                                withAnimation {
-                                    handleAssetTap(image: image, currentlySelected: selected)
-                                }
+                                handleTap(image: image, currentlySelected: selected)
                             }
                     }
                     .overlay(
@@ -118,45 +116,13 @@ public struct AttachmentMediaPickerItemView: View {
         .accessibilityAddTraits(selected ? .isSelected : [])
         .accessibilityAction {
             guard let image = assetLoader.loadedImages[asset.localIdentifier] else { return }
-            handleAssetTap(image: image, currentlySelected: selected)
+            handleTap(image: image, currentlySelected: selected)
         }
         .onAppear {
-            loading = false
-            
             assetLoader.loadImage(from: asset)
-            
-            if assetURL != nil {
-                return
-            }
-            
-            let options = PHContentEditingInputRequestOptions()
-            options.isNetworkAccessAllowed = true
-            loading = true
-            
-            requestId = asset.requestContentEditingInput(with: options) { input, _ in
-                loading = false
-                if asset.mediaType == .image {
-                    assetURL = input?.fullSizeImageURL
-                } else if let url = (input?.audiovisualAsset as? AVURLAsset)?.url {
-                    assetURL = url
-                }
-                
-                // Check file size.
-                if let assetURL, assetLoader.assetExceedsAllowedSize(url: assetURL) {
-                    compressing = true
-                    assetLoader.compressAsset(at: assetURL, type: assetType) { url in
-                        self.assetURL = url
-                        compressing = false
-                    }
-                }
-            }
         }
         .onDisappear {
-            if let requestId {
-                asset.cancelContentEditingInputRequest(requestId)
-                self.requestId = nil
-                loading = false
-            }
+            cancelAssetURLRequest()
         }
     }
 
@@ -182,7 +148,63 @@ public struct AttachmentMediaPickerItemView: View {
         return formatter
     }()
 
-    private func handleAssetTap(image: UIImage, currentlySelected: Bool) {
+    // Toggling off, or an already-downloaded asset, is applied immediately.
+    // Otherwise the asset (which may live in iCloud) is downloaded on demand and
+    // only selected once the download finishes, so an idle picker never downloads.
+    private func handleTap(image: UIImage, currentlySelected: Bool) {
+        if currentlySelected || assetURL != nil {
+            withAnimation {
+                selectAsset(image: image, currentlySelected: currentlySelected)
+            }
+            return
+        }
+
+        guard !loading, !compressing else { return }
+
+        loadAssetURL {
+            guard assetURL != nil else { return }
+            withAnimation {
+                selectAsset(image: image, currentlySelected: false)
+            }
+        }
+    }
+
+    private func loadAssetURL(completion: @escaping () -> Void) {
+        let options = PHContentEditingInputRequestOptions()
+        options.isNetworkAccessAllowed = true
+        loading = true
+
+        requestId = asset.requestContentEditingInput(with: options) { input, _ in
+            loading = false
+            if asset.mediaType == .image {
+                assetURL = input?.fullSizeImageURL
+            } else if let url = (input?.audiovisualAsset as? AVURLAsset)?.url {
+                assetURL = url
+            }
+
+            // Check file size.
+            if assetType == .video, let assetURL, assetLoader.assetExceedsAllowedSize(url: assetURL) {
+                compressing = true
+                assetLoader.compressAsset(at: assetURL, type: assetType) { url in
+                    self.assetURL = url
+                    compressing = false
+                    completion()
+                }
+            } else {
+                completion()
+            }
+        }
+    }
+
+    private func cancelAssetURLRequest() {
+        if let requestId {
+            asset.cancelContentEditingInputRequest(requestId)
+            self.requestId = nil
+        }
+        loading = false
+    }
+
+    private func selectAsset(image: UIImage, currentlySelected: Bool) {
         let resolvedURL = asset.mediaType == .image ? assetJpgURL() : assetURL
         guard let url = resolvedURL else { return }
         let width = Double(asset.pixelWidth)


### PR DESCRIPTION
### 🔗 Issue Links

[IOS-1801](https://linear.app/stream/issue/IOS-1801/attachment-gallery-picker-gets-stuck-when-there-are-multiple-videos)

### 🎯 Goal

When the photo library contains many videos (or iCloud assets), the attachment media picker became unusable — no attachment could be selected until every visible item finished downloading and processing. This makes selection instant again, deferring the heavy work until the user actually picks an item, similar to WhatsApp.

### 📝 Summary

- Media picker items no longer download and process their underlying asset automatically when they appear.
- Tapping an item now starts the download on demand (showing a loading spinner) and selects it once the download finishes.
- Deselecting or re-tapping an already-downloaded item stays instant.

### 🛠 Implementation

`AttachmentMediaPickerItemView` previously called `requestContentEditingInput` (with iCloud network access enabled) in `onAppear` for every visible item, so all visible videos downloaded and compressed in parallel and blocked selection. That work moved into the tap handler: `onAppear` now only loads the lightweight thumbnail, and the full asset is fetched lazily on tap, after which the item is selected. Toggling off or selecting an already-loaded asset remains immediate.

### 🎨 Showcase

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

Use a device/simulator with several large videos in the photo library (ideally iCloud-optimised). Open the attachment picker: the grid should be immediately interactive. Tap a video — a spinner appears while it downloads, then it becomes selected. Tapping again deselects instantly.

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the media attachment picker becoming unresponsive when the photo library contains many videos.
  * Improved media selection responsiveness by loading and processing assets only when selected.
  * Added safeguards to prevent duplicate loading and compression work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->