### PR TITLE
Fix lighter edge ring in the message actions scrim blur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix showing the typing indicator in the middle of the screen when a channel has no messages [#1545](https://github.com/GetStream/stream-chat-swiftui/pull/1545)
 - Show a muted icon for muted members in the channel info member list and member details [#1547](https://github.com/GetStream/stream-chat-swiftui/pull/1547)
 - Show a media preview in the thread list when the thread's parent message only contains attachments [#1548](https://github.com/GetStream/stream-chat-swiftui/pull/1548)
+- Fix a lighter ring appearing along the screen edges of the blurred background behind the message action menu [#1552](https://github.com/GetStream/stream-chat-swiftui/pull/1552)
 
 ### 🔄 Changed
 - Replace vendored Nuke image loading with `StreamImageDownloader` from StreamChatCommonUI [#1531](https://github.com/GetStream/stream-chat-swiftui/pull/1531)

--- a/Sources/StreamChatSwiftUI/ChatMessageList/Reactions/ReactionsOverlayView.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/Reactions/ReactionsOverlayView.swift
@@ -208,18 +208,18 @@ public struct ReactionsOverlayView<Factory: ViewFactory>: View {
         ZStack {
             if !orientationChanged {
                 Image(uiImage: currentSnapshot)
-                    .overlay(
-                        Color(colors.backgroundCoreScrim)
-                            .edgesIgnoringSafeArea(.all)
-                            .opacity(popIn ? 1 : 0)
-                    )
-                    .blur(radius: popIn ? 4 : 0)
+                    // A non-opaque blur samples transparency outside the snapshot's bounds,
+                    // which fades its edges and lets the view's background bleed through as
+                    // a lighter ring. An opaque blur clamps at the edges instead.
+                    .blur(radius: popIn ? 4 : 0, opaque: true)
                     .edgesIgnoringSafeArea(.all)
                     .offset(y: overlayOffsetY)
-            } else {
-                Color(colors.backgroundCoreScrim)
-                    .edgesIgnoringSafeArea(.all)
             }
+            // The scrim is layered on top of the blur rather than blurred with the snapshot:
+            // blurring a translucent color only thins it out along the edges.
+            Color(colors.backgroundCoreScrim)
+                .opacity(orientationChanged || popIn ? 1 : 0)
+                .edgesIgnoringSafeArea(.all)
         }
         // The blurred snapshot and scrim are purely decorative; keep them out of
         // the accessibility tree so VoiceOver focuses the overlay's content.


### PR DESCRIPTION
### 🔗 Issue Links

[IOS-1914](https://linear.app/stream/issue/IOS-1914/v5-ui-polish-scrim-blur-behind-message-action-menu-shows-inner)

### 🎯 Goal

The scrim behind the message action menu showed a visible inner glow: a lighter ring hugging the left and right screen edges instead of an evenly dimmed background.

### 📝 Summary

- Blur the background snapshot with an opaque blur, so it no longer fades out along the screen edges
- Layer the scrim above the blurred snapshot instead of blurring it together with the snapshot

### 🛠 Implementation

`ReactionsOverlayView.backgroundView` composited the translucent scrim into the snapshot layer via `.overlay(...)` and then blurred the pair with `.blur(radius: 4)`.

SwiftUI's default non-opaque blur treats everything outside the layer's bounds as transparent, so the outer ~4pt of the composite got averaged toward clear. That thinned both the scrim and the snapshot at the edges and let the overlay's own `backgroundCoreElevation1` background bleed through as a lighter ring.

Two changes address it:

- `.blur(radius:opaque:)` with `opaque: true` clamps at the edges rather than fading to transparent.
- The scrim moved out of the blurred layer into a full screen sibling above it. Blurring a flat translucent colour has no visual effect other than thinning it at the edges, so it never belonged inside the blur.

As a side effect the scrim now spans the full screen rather than only the snapshot's frame, so on iPad with a visible tab bar the 20pt strip the snapshot is offset by is dimmed consistently with the rest of the screen.

### 🎨 Showcase

Edge pixel luminance measured on device screenshots of the open action menu, sampled across a uniform area of the scrim (iPhone 17 Pro, 3x, light mode):

| Pixel column from edge | 0 | 1 | 2 | 4 | 8 | 15 | centre |
| ---------------------- | - | - | - | - | - | -- | ------ |
| Before (left edge) | 196 | 192 | 188 | 181 | 168 | 152 | 141 |
| Before (right edge) | 195 | 192 | 188 | 181 | 169 | 152 | 141 |
| After (both edges) | 141 | 141 | 141 | 141 | 141 | 141 | 141 |

The ramp spanned roughly the 4pt blur radius at 3x. The centre value is unchanged, so the scrim keeps its density and only the edge falloff is gone.

### 🧪 Manual Testing Notes

Long press a message to open the action menu and look at the left and right screen edges: the background should be evenly dimmed, with no lighter band along the edges. Worth checking in both light and dark mode, and on iPad in both orientations (rotating while the overlay is open falls back to a plain scrim without the snapshot).

Note on unit tests: the existing `ReactionsOverlayView` snapshot tests pass unchanged, because the unit test process renders view layers without applying `CALayer` filters, so the blur never appears in recorded snapshots. This change is only observable in a real app process.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a visual issue on iOS where a lighter ring could appear around the screen edges of the blurred background behind the message action menu.
  * Improved background rendering during message reaction interactions for a cleaner, more consistent appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->