### PR TITLE
Fix demo app async renderer crash

### DIFF
--- a/DemoAppSwiftUI/DemoAppSwiftUIApp.swift
+++ b/DemoAppSwiftUI/DemoAppSwiftUIApp.swift
@@ -10,8 +10,16 @@ import SwiftUI
 @main
 struct DemoAppSwiftUIApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
-    @Injected(\.chatClient) public var chatClient: ChatClient
 
+    var body: some Scene {
+        WindowGroup {
+            RootView()
+        }
+    }
+}
+
+@MainActor
+struct RootView: View {
     @ObservedObject var appState = AppState.shared
     @ObservedObject var notificationsHandler = NotificationsHandler.shared
 
@@ -23,8 +31,8 @@ struct DemoAppSwiftUIApp: App {
         .messages
     }
 
-    var body: some Scene {
-        WindowGroup {
+    var body: some View {
+        Group {
             switch appState.userState {
             case .launchAnimation:
                 StreamLogoLaunch()
@@ -123,6 +131,7 @@ struct DemoAppSwiftUIApp: App {
     }
 
     func currentUserController(_ controller: CurrentChatUserController, didChangeCurrentUserUnreadCount: UnreadCount) {
+        guard unreadCount != didChangeCurrentUserUnreadCount else { return }
         unreadCount = didChangeCurrentUserUnreadCount
         let totalUnreadBadge = unreadCount.channels + unreadCount.threads
         if #available(iOS 16.0, *) {


### PR DESCRIPTION
### 🔗 Issue Links

Related: [IOS-1937](https://linear.app/stream/issue/IOS-1937/release-580)

### 🎯 Goal

Prevent the demo app from accessing main-actor state from the async renderer.

### 📝 Summary

- Move the state-driven root content into `RootView` (wasn't able to reproduce after that).

### 🛠 Implementation

- Keep `DemoAppSwiftUIApp` limited to scene setup and isolate `RootView` to the main actor.

Claude:
```
What the trace says

This isn't a Stream SDK crash — it's the Swift 6 dynamic actor-isolation check tripping on SwiftUI's async render thread.

Reading it bottom-up:

- https://github.com/GetStream/stream-chat-swiftui/pull/34–https://github.com/GetStream/stream-chat-swiftui/pull/20 — ViewGraphDisplayLink.asyncThread → renderAsync → updateOutputsAsync. SwiftUI is running a graph update on its own com.apple.SwiftUI.Ahe main thread.
- https://github.com/GetStream/stream-chat-swiftui/pull/7–https://github.com/GetStream/stream-chat-swiftui/pull/6 — it calls ViewBodyAccessor.updateBody inside a closure that SwiftUI has declared @mainactor (it assumes isolation rather than hopping), which invokes LazyView.body → the stored WindowGroup content closure.
- https://github.com/GetStream/stream-chat-swiftui/pull/5 — closure https://github.com/GetStream/stream-chat-swiftui/pull/1 in DemoAppSwiftUIApp.body.getter: that's the WindowGroup { switch appState.userState … } closure at DemoAppSwiftUI/DemoAppSwiftUIApp.swift:27.
- https://github.com/GetStream/stream-chat-swiftui/pull/4–#0 — entering that closure runs swift_task_isCurrentExecutorWithFlags → swift_task_checkIsolated → dispatch_assert_queue(main) → trap.

The mechanism: App.body is @mainactor, so in Swift 6 language mode the non-Sendable content closure is inferred @mainactor too (it has to be — it reads appState/notificationsHandler, both @mainactor classes). SwiftUI stores it as a plain non-isolated () -> Content, so the compiler inserts a runtime executor check at
the closure entry. SwiftUI then calls it off-main from the async renderer, and in Swift 6 mode that check is fatal instead of a warning.

All the logic lives directly in the closure. A View's body is reached through SwiftUI's own assume-isolated path (frame https://github.com/GetStream/stream-chat-swiftui/pull/7) and doesn't get the checked thunk; the stored scene closure does. Extracting the switch into a RootView: View and leaving WindowGroup { RootView() } moves the isolated work behind that path.
```

### 🎨 Showcase

Not applicable.

### 🧪 Manual Testing Notes

- Log in with Obi and keep it on channel list
- Another account spams with messages
- Obi tries to open a channel

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo