### PR TITLE
Fix snapshot recording push permissions on CI

### DIFF
--- a/.github/workflows/smoke-checks.yml
+++ b/.github/workflows/smoke-checks.yml
@@ -102,6 +102,9 @@ jobs:
     name: Test SwiftUI (Debug)
     runs-on: macos-15
     needs: guard
+    permissions:
+      contents: write # to push the snapshots branch
+      pull-requests: write
     env:
       GITHUB_TOKEN: ${{ secrets.CI_BOT_GITHUB_TOKEN }} # to open a PR
     steps:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated UI smoke checks to support publishing test snapshots to dedicated branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->