### PR TITLE
[CI] Add verbose input to smoke and cron checks

### DIFF
--- a/.github/workflows/cron-checks.yml
+++ b/.github/workflows/cron-checks.yml
@@ -6,6 +6,12 @@ on:
     - cron: '0 2 * * 1-5'
 
   workflow_dispatch:
+    inputs:
+      verbose:
+        description: 'Run tests in verbose mode?'
+        type: boolean
+        required: false
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -17,6 +23,7 @@ permissions:
 env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1 # Disable cleanup for homebrew, we don't need it on CI
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  VERBOSE: ${{ github.event.inputs.verbose == 'true' && '--verbose' || '' }}
 
 jobs:
   test-e2e-debug:
@@ -60,7 +67,7 @@ jobs:
     - name: Launch Allure TestOps
       run: bundle exec fastlane allure_launch cron:true
     - name: Run UI Tests (Debug)
-      run: bundle exec fastlane test_e2e_mock device:"${{ env.IOS_SIMULATOR_DEVICE }}"
+      run: bundle exec fastlane test_e2e_mock device:"${{ env.IOS_SIMULATOR_DEVICE }}" ${{ env.VERBOSE }}
       timeout-minutes: 90
     - name: Allure TestOps Upload
       if: success() || failure()
@@ -101,7 +108,7 @@ jobs:
     - uses: ./.github/actions/ruby-cache
     - uses: ./.github/actions/xcode-cache
     - name: Build Demo App
-      run: bundle exec fastlane build_demo
+      run: bundle exec fastlane build_demo ${{ env.VERBOSE }}
       env:
         XCODE_VERSION: ${{ matrix.xcode }}
 
@@ -119,7 +126,7 @@ jobs:
     - uses: ./.github/actions/xcode-cache
     - uses: ./.github/actions/ruby-cache
     - name: Build SwiftUI
-      run: bundle exec fastlane test_ui device:"iPhone 16" build_for_testing:true
+      run: bundle exec fastlane test_ui device:"iPhone 16" build_for_testing:true ${{ env.VERBOSE }}
       timeout-minutes: 25
 
   automated-code-review:

--- a/.github/workflows/sdk-size-metrics.yml
+++ b/.github/workflows/sdk-size-metrics.yml
@@ -8,6 +8,12 @@ on:
       - '**/*.png'
 
   workflow_dispatch:
+    inputs:
+      verbose:
+        description: 'Run in verbose mode?'
+        type: boolean
+        required: false
+        default: false
 
   push:
     branches:
@@ -15,6 +21,7 @@ on:
 
 env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1 # Disable cleanup for homebrew, we don't need it on CI
+  VERBOSE: ${{ github.event.inputs.verbose == 'true' && '--verbose' || '' }}
   GITHUB_TOKEN: '${{ secrets.CI_BOT_GITHUB_TOKEN }}'
   GITHUB_PR_NUM: ${{ github.event.pull_request.number }}
   GITHUB_EVENT_ACTION: ${{ github.event.action }}
@@ -53,5 +60,5 @@ jobs:
           APPSTORE_API_KEY: ${{ secrets.APPSTORE_API_KEY }}
 
       - name: Run Detailed SDK Size Metrics
-        run: bundle exec fastlane size_analyze
+        run: bundle exec fastlane size_analyze ${{ env.VERBOSE }}
         timeout-minutes: 30

--- a/.github/workflows/smoke-checks.yml
+++ b/.github/workflows/smoke-checks.yml
@@ -10,6 +10,11 @@ on:
         type: boolean
         required: false
         default: false
+      verbose:
+        description: 'Run tests in verbose mode?'
+        type: boolean
+        required: false
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -27,6 +32,7 @@ env:
   GITHUB_EVENT_ACTION: ${{ github.event.action }}
   GITHUB_EVENT_BEFORE: ${{ github.event.before }}
   GITHUB_EVENT_AFTER: ${{ github.event.after }}
+  VERBOSE: ${{ github.event.inputs.verbose == 'true' && '--verbose' || '' }}
 
 jobs:
   guard:
@@ -48,7 +54,7 @@ jobs:
     - uses: ./.github/actions/ruby-cache
     - uses: ./.github/actions/xcode-cache
     - name: Build
-      run: bundle exec fastlane build_test_app_and_frameworks
+      run: bundle exec fastlane build_test_app_and_frameworks ${{ env.VERBOSE }}
       timeout-minutes: 60
     - uses: actions/upload-artifact@v4
       if: success()
@@ -95,7 +101,7 @@ jobs:
     - uses: ./.github/actions/xcode-cache
     - uses: ./.github/actions/ruby-cache
     - name: Build SwiftUI
-      run: bundle exec fastlane test_ui device:"iPhone 16 (18.1)" build_for_testing:true
+      run: bundle exec fastlane test_ui device:"iPhone 16 (18.1)" build_for_testing:true ${{ env.VERBOSE }}
       timeout-minutes: 25
 
   test-ui-debug:
@@ -114,7 +120,7 @@ jobs:
         INSTALL_YEETD: true
         INSTALL_SONAR: true
     - name: Run UI Tests (Debug)
-      run: bundle exec fastlane test_ui device:"${{ env.IOS_SIMULATOR_DEVICE }}" record:"${{ github.event.inputs.record_snapshots }}"
+      run: bundle exec fastlane test_ui device:"${{ env.IOS_SIMULATOR_DEVICE }}" record:"${{ github.event.inputs.record_snapshots }}" ${{ env.VERBOSE }}
       timeout-minutes: 120
     - name: Run Sonar analysis
       if: ${{ github.event.inputs.record_snapshots != 'true' }}
@@ -189,7 +195,7 @@ jobs:
         INSTALL_YEETD: true
         SKIP_SWIFT_BOOTSTRAP: true
     - name: Run UI Tests (Debug)
-      run: bundle exec fastlane test_e2e_mock device:"${{ env.IOS_SIMULATOR_DEVICE }}" batch:'${{ matrix.batch }}' test_without_building:true
+      run: bundle exec fastlane test_e2e_mock device:"${{ env.IOS_SIMULATOR_DEVICE }}" batch:'${{ matrix.batch }}' test_without_building:true ${{ env.VERBOSE }}
       timeout-minutes: 100
       env:
         MATRIX_SIZE: ${{ strategy.job-total }}
@@ -234,4 +240,4 @@ jobs:
     - uses: ./.github/actions/ruby-cache
     - uses: ./.github/actions/xcode-cache
     - name: Build Demo App
-      run: bundle exec fastlane build_demo
+      run: bundle exec fastlane build_demo ${{ env.VERBOSE }}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -18,6 +18,7 @@ is_localhost = !is_ci
 mock_server_driver_port = 4568
 swift_environment_path = File.absolute_path('../Sources/StreamChatSwiftUI/Generated/SystemEnvironment+Version.swift')
 @force_check = false
+xcodebuild_formatter = FastlaneCore::Globals.verbose? ? '' : nil
 @impact = nil
 
 before_all do |lane|
@@ -211,7 +212,8 @@ lane :test_ui do |options|
     build_for_testing: options[:build_for_testing],
     skip_build: options[:skip_build],
     number_of_retries: options[:record].to_s.empty? ? 1 : nil,
-    fail_build: !record_mode
+    fail_build: !record_mode,
+    xcodebuild_formatter: xcodebuild_formatter
   )
 
   if record_mode && is_ci
@@ -243,7 +245,8 @@ lane :build_test_app_and_frameworks do
     derived_data_path: derived_data_path,
     cloned_source_packages_path: source_packages_path,
     clean: is_localhost,
-    build_for_testing: true
+    build_for_testing: true,
+    xcodebuild_formatter: xcodebuild_formatter
   )
 end
 
@@ -293,7 +296,8 @@ lane :test_e2e_mock do |options|
     test_without_building: options[:test_without_building],
     devices: options[:device],
     prelaunch_simulator: is_ci,
-    number_of_retries: 3
+    number_of_retries: 3,
+    xcodebuild_formatter: xcodebuild_formatter
   }
 
   if ENV['MATRIX_SIZE'] && options[:batch]
@@ -350,7 +354,8 @@ lane :build_demo do |options|
     derived_data_path: derived_data_path,
     cloned_source_packages_path: source_packages_path,
     build_for_testing: true,
-    devices: options[:device]
+    devices: options[:device],
+    xcodebuild_formatter: xcodebuild_formatter
   )
 end
 
@@ -562,7 +567,8 @@ lane :size_analyze do
     skip_package_pkg: true,
     skip_codesigning: true,
     derived_data_path: derived_data_path,
-    cloned_source_packages_path: source_packages_path
+    cloned_source_packages_path: source_packages_path,
+    xcodebuild_formatter: xcodebuild_formatter
   )
 
   show_detailed_sdk_size(sdk_names: sdk_names, threshold: 42)


### PR DESCRIPTION
### 🎯 Goal

When a CI test job fails for a non-obvious reason, get the unfiltered `xcodebuild` output without having to edit the workflow, push, and wait.

### 🛠 Implementation

- New `workflow_dispatch` input `verbose` (boolean, **default `false`**) on `smoke-checks.yml` and `cron-checks.yml`.
- One workflow-level env instead of repeating the expression per step:
  ```yaml
  VERBOSE: ${{ github.event.inputs.verbose == 'true' && '--verbose' || '' }}
  ```
  appended as `${{ env.VERBOSE }}` to the test steps only (build-only steps are left alone).
- `Fastfile` bridges the flag into `scan`, so `--verbose` also stops the output being formatted:
  ```ruby
  xcodebuild_formatter = FastlaneCore::Globals.verbose? ? '' : nil
  ```
  passed to the `scan` calls of the test lanes. No lane option needed — fastlane sets `Globals.verbose` from `ARGV` before the `Fastfile` is loaded.

On `pull_request` / `schedule` runs the input is absent, the expression yields `''`, and both the commands and the `scan` config are identical to today (`nil` keeps fastlane's default formatter).

### 🧐 Why `xcodebuild_formatter: ''` and not `output_style: 'raw'`

Both drop the formatter, but who writes `test_output/report.junit` depends on the *resolved* formatter: xcpretty's pipe when it resolves to `xcpretty`, otherwise trainer parsing the xcresult. `output_style: 'raw'` removes the pipe while leaving the resolved formatter at `xcpretty`, so no junit is written and the `retreive_failed_tests` retry path dies with "There is no junit report to parse", masking the real failure. `xcodebuild_formatter: ''` moves junit generation to trainer, so retries keep working. This matters because the default is dynamic — `xcbeautify` if installed, else `xcpretty`.

### 🧪 Verification

- Probed the repo's own fastlane (2.228.0) with a real `Scan.config`: unset → resolved `"xcpretty"`, pipe `| tee <log> | xcpretty --report junit …`; `''` → resolved `""`, pipe `| tee <log>` only, junit via trainer.
- `bundle exec fastlane rubocop` clean; workflows parse as YAML.
- No new secret exposure: no secret is passed as a CLI arg or into xcodebuild by these lanes, `--verbose` does not dump `ENV`, fastlane masks `sensitive:` config items, and raw xcodebuild output echoes build settings rather than the runner environment.

Same change is being applied across the iOS SDK repos.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an optional verbose mode to manually triggered smoke and scheduled checks.
  * Enabled more detailed output for UI and end-to-end test runs when verbose mode is selected.
  * Improved test output formatting in verbose runs to make diagnostics easier to read.
  * Standard runs continue using the existing concise output format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->