### PR TITLE
Fix TestFlight deploy failing on changelog emoji

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### 🔄 Changed
 - Debounce channel and message search dynamically based on query length [#1560](https://github.com/GetStream/stream-chat-swiftui/pull/1560)
 
-### ⚠️ Deprecated
+### ⚠ Deprecated
 - Deprecate `ChatChannelListViewModel.channelListSearchController` in favor of `channelSearchController` [#1560](https://github.com/GetStream/stream-chat-swiftui/pull/1560)
 
 # [5.8.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/5.8.0)
@@ -32,10 +32,10 @@ _August 03, 2026_
 - Replace vendored Nuke image loading with `StreamImageDownloader` from StreamChatCommonUI [#1531](https://github.com/GetStream/stream-chat-swiftui/pull/1531)
 - Remove the separators between the message action menu items, keeping one before the destructive actions [#1549](https://github.com/GetStream/stream-chat-swiftui/pull/1549)
 
-### ⚡️ Performance
+### ⚡ Performance
 - Reduce SDK size by 400 KB [#1531](https://github.com/GetStream/stream-chat-swiftui/pull/1531)
 
-### ⚠️ Deprecated
+### ⚠ Deprecated
 - Deprecate `AttachmentMediaPickerItemView.init(assetLoader:requestId:asset:onImageTap:imageSelected:selectedAssetIds:)`, the request id is no longer used. Use the initializer without it. [#1546](https://github.com/GetStream/stream-chat-swiftui/pull/1546)
 
 # [5.7.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/5.7.0)
@@ -48,7 +48,7 @@ _July 22, 2026_
 ### 🐞 Fixed
 - Send images and videos picked from the file picker as their original type instead of always file type [#1515](https://github.com/GetStream/stream-chat-swiftui/pull/1515)
 
-### ⚡️ Performance
+### ⚡ Performance
 - Fix the channel list rebuilding on every scroll tick after returning from a channel [#1525](https://github.com/GetStream/stream-chat-swiftui/pull/1525)
 - Render channel list dividers as row overlays instead of sibling views [#1529](https://github.com/GetStream/stream-chat-swiftui/pull/1529)
 - Reduce SDK size by 2.5 MB [#1529](https://github.com/GetStream/stream-chat-swiftui/pull/1529)
@@ -318,7 +318,7 @@ _February 11, 2026_
 - Add public init for `ImageContainerView` [#1174](https://github.com/GetStream/stream-chat-swiftui/pull/1174)
 - Expose Keyboard Handling methods [#1175](https://github.com/GetStream/stream-chat-swiftui/pull/1175)
 
-### ⚡️ Performance
+### ⚡ Performance
 - Reduction of the SDK size by 2MB [#1173
 ](https://github.com/GetStream/stream-chat-swiftui/pull/1173)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,7 +165,7 @@ GEM
       fastlane
       pry
     fastlane-plugin-sonarcloud_metric_kit (0.2.1)
-    fastlane-plugin-stream_actions (0.4.5)
+    fastlane-plugin-stream_actions (0.4.7)
       xctest_list (= 1.2.1)
     fastlane-plugin-versioning (0.7.1)
     fastlane-plugin-xcsize (1.2.0)
@@ -385,7 +385,7 @@ DEPENDENCIES
   fastlane
   fastlane-plugin-lizard
   fastlane-plugin-sonarcloud_metric_kit
-  fastlane-plugin-stream_actions (= 0.4.5)
+  fastlane-plugin-stream_actions (= 0.4.7)
   fastlane-plugin-versioning
   fastlane-plugin-xcsize (= 1.2.0)
   faye-websocket

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -4,5 +4,5 @@
 
 gem 'fastlane-plugin-versioning'
 gem 'fastlane-plugin-sonarcloud_metric_kit'
-gem 'fastlane-plugin-stream_actions', '0.4.5'
+gem 'fastlane-plugin-stream_actions', '0.4.7'
 gem 'fastlane-plugin-xcsize', '1.2.0'


### PR DESCRIPTION
Resolve: https://linear.app/stream/issue/IOS-1942

### 🎯 Goal

Every `Test Flight Deploy DemoApp` run for **both 5.7.0 and 5.8.0** failed ([5.7.0](https://github.com/GetStream/stream-chat-swiftui/actions/runs/29937360312), [5.8.0](https://github.com/GetStream/stream-chat-swiftui/actions/runs/30819944241)) with:

```
Could not set changelog: An attribute value has invalid text. - Text for whatsNew contains invalid characters:'[️]'. - whatsNew
```

Deploys have been silently broken since the `### ⚡️ Performance` heading first appeared in the 5.7.0 changelog. That emoji is two codepoints (`U+26A1` + `U+FE0F`); pilot strips emoji from the changelog before upload but leaves the invisible variation selector behind, and App Store Connect rejects it. The binary itself uploads and processes fine — the lane dies at the What's New step, skipping external distribution.

### 🛠 Implementation

- `CHANGELOG.md`: drop the variation selector from the headings that can still be uploaded (`# Upcoming` + 5.8.0 sections, and all `⚡️`); deep-history occurrences are left alone since `read_changelog` never extracts them.
- Bump `fastlane-plugin-stream_actions` 0.4.5 → [0.4.7](https://github.com/GetStream/fastlane-plugin-stream_actions), which now strips `U+FE0E`/`U+FE0F`/`U+200D` from the changelog before handing it to pilot — so no future changelog emoji can kill a deploy.

Same fix applied across the iOS SDK repos.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated changelog warning and performance section labels for more consistent emoji rendering and improved readability.

- **Maintenance**
  - Applied routine release tooling updates to support ongoing project maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
