### PR TITLE
Clear stale mention suggestions when the query ends

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/GetStream/stream-chat-swift.git", revision: "412e8a01c00481c60ae86e8184620023f136e0b7")
+        .package(url: "https://github.com/GetStream/stream-chat-swift.git", branch: "fix/mention-suggestions-large-channels")
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/GetStream/stream-chat-swift.git", branch: "fix/mention-suggestions-large-channels")
+        .package(url: "https://github.com/GetStream/stream-chat-swift.git", revision: "8263bddc2f9395fb1c4a275c86db711ceda954ed")
     ],
     targets: [
         .target(

--- a/Sources/StreamChatSwiftUI/ChatComposer/MessageComposerViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatComposer/MessageComposerViewModel.swift
@@ -38,13 +38,18 @@ import SwiftUI
             } else {
                 // Mentions use `displayInfo == nil`, so clear any non-instant command
                 // (not only commands with `isInstant == false`).
-                if composerCommand?.displayInfo?.isInstant != true {
+                // When a command is cleared here, `composerCommand` didSet clears suggestions;
+                // otherwise clear them explicitly (instant command kept, or no command).
+                let clearingCommand = composerCommand != nil
+                    && composerCommand?.displayInfo?.isInstant != true
+                if clearingCommand {
                     withAnimation(.easeInOut(duration: 0.2)) {
                         composerCommand = nil
                     }
+                } else {
+                    clearComposerSuggestions()
                 }
                 selectedRangeLocation = 0
-                clearComposerSuggestions()
                 clearMentions()
 
                 if shouldDeleteDraftMessage(oldValue: oldValue) {

--- a/Sources/StreamChatSwiftUI/ChatComposer/MessageComposerViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatComposer/MessageComposerViewModel.swift
@@ -36,12 +36,15 @@ import SwiftUI
                     channelController.sendKeystrokeEvent()
                 }
             } else {
-                if composerCommand?.displayInfo?.isInstant == false {
+                // Mentions use `displayInfo == nil`, so clear any non-instant command
+                // (not only commands with `isInstant == false`).
+                if composerCommand?.displayInfo?.isInstant != true {
                     withAnimation(.easeInOut(duration: 0.2)) {
                         composerCommand = nil
                     }
                 }
                 selectedRangeLocation = 0
+                suggestionsCancellable?.cancel()
                 withAnimation(.easeInOut(duration: 0.2)) {
                     suggestions = [String: Any]()
                 }
@@ -211,6 +214,8 @@ import SwiftUI
     }
     
     private var cancellables = Set<AnyCancellable>()
+    /// Tracks the in-flight suggestions request so stale results can be discarded.
+    private var suggestionsCancellable: AnyCancellable?
     public lazy var commandsHandler = utils
         .commandsConfig
         .makeCommandsHandler(
@@ -1040,17 +1045,33 @@ import SwiftUI
     }
     
     private func showTypingSuggestions() {
-        if let composerCommand {
-            commandsHandler.showSuggestions(for: composerCommand)
-                .sink { _ in
-                    log.debug("Finished showing suggestions")
-                } receiveValue: { [weak self] suggestionInfo in
-                    withAnimation {
-                        self?.suggestions[suggestionInfo.key] = suggestionInfo.value
-                    }
-                }
-                .store(in: &cancellables)
+        suggestionsCancellable?.cancel()
+
+        guard let composerCommand else {
+            withAnimation(.easeInOut(duration: 0.2)) {
+                suggestions = [String: Any]()
+            }
+            return
         }
+
+        // Capture the query that started this request so a slower, superseded
+        // search cannot overwrite newer (or cleared) suggestions while deleting.
+        let expectedCommandId = composerCommand.id
+        let expectedTypingText = composerCommand.typingSuggestion.text
+
+        suggestionsCancellable = commandsHandler.showSuggestions(for: composerCommand)
+            .sink { _ in
+                log.debug("Finished showing suggestions")
+            } receiveValue: { [weak self] suggestionInfo in
+                guard let self else { return }
+                guard self.composerCommand?.id == expectedCommandId,
+                      self.composerCommand?.typingSuggestion.text == expectedTypingText else {
+                    return
+                }
+                withAnimation {
+                    self.suggestions[suggestionInfo.key] = suggestionInfo.value
+                }
+            }
     }
     
     private func listenToCooldownUpdates() {

--- a/Sources/StreamChatSwiftUI/ChatComposer/MessageComposerViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatComposer/MessageComposerViewModel.swift
@@ -44,10 +44,7 @@ import SwiftUI
                     }
                 }
                 selectedRangeLocation = 0
-                suggestionsCancellable?.cancel()
-                withAnimation(.easeInOut(duration: 0.2)) {
-                    suggestions = [String: Any]()
-                }
+                clearComposerSuggestions()
                 clearMentions()
 
                 if shouldDeleteDraftMessage(oldValue: oldValue) {
@@ -122,6 +119,7 @@ import SwiftUI
             }
             if oldValue != nil && composerCommand == nil {
                 pickerTypeState = .expanded(.none)
+                clearComposerSuggestions()
             }
         }
     }
@@ -1048,9 +1046,7 @@ import SwiftUI
         suggestionsCancellable?.cancel()
 
         guard let composerCommand else {
-            withAnimation(.easeInOut(duration: 0.2)) {
-                suggestions = [String: Any]()
-            }
+            clearComposerSuggestions()
             return
         }
 
@@ -1072,6 +1068,14 @@ import SwiftUI
                     self.suggestions[suggestionInfo.key] = suggestionInfo.value
                 }
             }
+    }
+
+    private func clearComposerSuggestions() {
+        suggestionsCancellable?.cancel()
+        commandsHandler.clearSuggestions()
+        withAnimation(.easeInOut(duration: 0.2)) {
+            suggestions = [String: Any]()
+        }
     }
     
     private func listenToCooldownUpdates() {

--- a/Sources/StreamChatSwiftUI/ChatComposer/MessageComposerViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatComposer/MessageComposerViewModel.swift
@@ -1061,17 +1061,19 @@ import SwiftUI
         let expectedTypingText = composerCommand.typingSuggestion.text
 
         suggestionsCancellable = commandsHandler.showSuggestions(for: composerCommand)
-            .sink(receiveCompletion: { _ in },
-                  receiveValue: { [weak self] suggestionInfo in
-                guard let self else { return }
-                guard self.composerCommand?.id == expectedCommandId,
-                      self.composerCommand?.typingSuggestion.text == expectedTypingText else {
-                    return
+            .sink(
+                receiveCompletion: { _ in },
+                receiveValue: { [weak self] suggestionInfo in
+                    guard let self else { return }
+                    guard self.composerCommand?.id == expectedCommandId,
+                          self.composerCommand?.typingSuggestion.text == expectedTypingText else {
+                        return
+                    }
+                    withAnimation {
+                        self.suggestions[suggestionInfo.key] = suggestionInfo.value
+                    }
                 }
-                withAnimation {
-                    self.suggestions[suggestionInfo.key] = suggestionInfo.value
-                }
-            })
+            )
     }
 
     private func clearComposerSuggestions() {

--- a/Sources/StreamChatSwiftUI/ChatComposer/MessageComposerViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatComposer/MessageComposerViewModel.swift
@@ -1061,7 +1061,8 @@ import SwiftUI
         let expectedTypingText = composerCommand.typingSuggestion.text
 
         suggestionsCancellable = commandsHandler.showSuggestions(for: composerCommand)
-            .sink { [weak self] suggestionInfo in
+            .sink(receiveCompletion: { _ in },
+                  receiveValue: { [weak self] suggestionInfo in
                 guard let self else { return }
                 guard self.composerCommand?.id == expectedCommandId,
                       self.composerCommand?.typingSuggestion.text == expectedTypingText else {
@@ -1070,7 +1071,7 @@ import SwiftUI
                 withAnimation {
                     self.suggestions[suggestionInfo.key] = suggestionInfo.value
                 }
-            }
+            })
     }
 
     private func clearComposerSuggestions() {

--- a/Sources/StreamChatSwiftUI/ChatComposer/MessageComposerViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatComposer/MessageComposerViewModel.swift
@@ -1061,9 +1061,7 @@ import SwiftUI
         let expectedTypingText = composerCommand.typingSuggestion.text
 
         suggestionsCancellable = commandsHandler.showSuggestions(for: composerCommand)
-            .sink { _ in
-                log.debug("Finished showing suggestions")
-            } receiveValue: { [weak self] suggestionInfo in
+            .sink { [weak self] suggestionInfo in
                 guard let self else { return }
                 guard self.composerCommand?.id == expectedCommandId,
                       self.composerCommand?.typingSuggestion.text == expectedTypingText else {
@@ -1079,7 +1077,7 @@ import SwiftUI
         suggestionsCancellable?.cancel()
         commandsHandler.clearSuggestions()
         withAnimation(.easeInOut(duration: 0.2)) {
-            suggestions = [String: Any]()
+            suggestions.removeAll()
         }
     }
     

--- a/Sources/StreamChatSwiftUI/ChatComposer/Suggestions/CommandsHandler.swift
+++ b/Sources/StreamChatSwiftUI/ChatComposer/Suggestions/CommandsHandler.swift
@@ -65,6 +65,12 @@ import SwiftUI
         composerCommand: ComposerCommand,
         completion: @escaping @MainActor (Error?) -> Void
     )
+
+    /// Cancels any pending suggestion work and clears cached search results.
+    ///
+    /// Called when the active command ends so a slower, superseded search cannot
+    /// resurface stale suggestions.
+    func clearSuggestions()
 }
 
 /// Default implementations.
@@ -82,6 +88,10 @@ extension CommandHandler {
 
     public func canBeExecuted(composerCommand: ComposerCommand) -> Bool {
         !composerCommand.typingSuggestion.text.isEmpty
+    }
+
+    public func clearSuggestions() {
+        // optional method.
     }
 }
 
@@ -253,6 +263,12 @@ public class CommandsHandler: CommandHandler {
         }
 
         return StreamChatError.noSuggestionsAvailable.asFailedPromise()
+    }
+
+    public func clearSuggestions() {
+        for command in commands {
+            command.clearSuggestions()
+        }
     }
 
     public func handleCommand(

--- a/Sources/StreamChatSwiftUI/ChatComposer/Suggestions/Mentions/MentionsCommandHandler.swift
+++ b/Sources/StreamChatSwiftUI/ChatComposer/Suggestions/Mentions/MentionsCommandHandler.swift
@@ -15,6 +15,7 @@ public final class MentionsCommandHandler: CommandHandler {
 
     private let channelController: ChatChannelController
     private let provider: MentionSuggestionsProvider
+    private var suggestionsTask: Task<Void, Never>?
 
     /// Creates a new mentions command handler.
     ///
@@ -123,6 +124,12 @@ public final class MentionsCommandHandler: CommandHandler {
         )
     }
 
+    public func clearSuggestions() {
+        suggestionsTask?.cancel()
+        suggestionsTask = nil
+        Task { await provider.clearResults() }
+    }
+
     func mentionText(for suggestion: MentionSuggestion) -> String {
         switch suggestion.kind {
         case let userSuggestion as MentionSuggestion.User:
@@ -147,14 +154,16 @@ public final class MentionsCommandHandler: CommandHandler {
         mentionRange: NSRange
     ) -> Future<SuggestionInfo, Error> {
         let id = id
+        suggestionsTask?.cancel()
         return Future { [weak self] promise in
             guard let self else {
                 promise(.success(SuggestionInfo(key: id, value: [MentionSuggestion]())))
                 return
             }
             nonisolated(unsafe) let unsafePromise = promise
-            Task { @MainActor in
+            self.suggestionsTask = Task { @MainActor in
                 let suggestions = await self.makeSuggestions(for: typingMention)
+                guard !Task.isCancelled else { return }
                 unsafePromise(.success(SuggestionInfo(key: id, value: suggestions)))
             }
         }

--- a/StreamChatSwiftUI.xcodeproj/project.pbxproj
+++ b/StreamChatSwiftUI.xcodeproj/project.pbxproj
@@ -1543,8 +1543,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/GetStream/stream-chat-swift.git";
 			requirement = {
-				kind = branch;
-				branch = "fix/mention-suggestions-large-channels";
+				kind = revision;
+				revision = 8263bddc2f9395fb1c4a275c86db711ceda954ed;
 			};
 		};
 		E3A1C01A282BAC66002D1E26 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {

--- a/StreamChatSwiftUI.xcodeproj/project.pbxproj
+++ b/StreamChatSwiftUI.xcodeproj/project.pbxproj
@@ -1543,8 +1543,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/GetStream/stream-chat-swift.git";
 			requirement = {
-				kind = revision;
-				revision = 412e8a01c00481c60ae86e8184620023f136e0b7;
+				kind = branch;
+				branch = "fix/mention-suggestions-large-channels";
 			};
 		};
 		E3A1C01A282BAC66002D1E26 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {

--- a/StreamChatSwiftUITests/Tests/ChatChannel/MessageComposerViewModel_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/MessageComposerViewModel_Tests.swift
@@ -715,20 +715,29 @@ import XCTest
     }
 
     func test_messageComposerVM_deletingMentionQuery_doesNotShowStaleSuggestionsWhenEmpty() async {
-        let viewModel = makeComposerViewModel()
+        let requestStarted = expectation(description: "delayed mention request started")
+        let requestFinished = expectation(description: "delayed mention request finished")
+        let provider = DelayedMentionSuggestionsProvider(
+            suggestions: [.user(.mock(id: "ios", name: "iOS"))],
+            delayNanoseconds: 100_000_000,
+            onStarted: { requestStarted.fulfill() },
+            onFinished: { requestFinished.fulfill() }
+        )
+        let viewModel = MessageComposerViewModel(
+            channelController: makeChannelController(),
+            messageController: nil
+        )
+        viewModel.utils = Utils(
+            commandsConfig: MentionsProviderCommandsConfig(provider: provider)
+        )
+
         viewModel.selectedRangeLocation = 4
         viewModel.text = "@iOS"
-        viewModel.selectedRangeLocation = 3
-        viewModel.text = "@iO"
-        viewModel.selectedRangeLocation = 2
-        viewModel.text = "@i"
-        viewModel.selectedRangeLocation = 1
-        viewModel.text = "@"
+        await fulfillment(of: [requestStarted], timeout: defaultTimeout)
+
         viewModel.selectedRangeLocation = 0
         viewModel.text = ""
-
-        // Allow any in-flight / debounced suggestion request to finish.
-        try? await Task.sleep(nanoseconds: 800_000_000)
+        await fulfillment(of: [requestFinished], timeout: defaultTimeout)
 
         XCTAssertNil(viewModel.composerCommand)
         XCTAssertTrue(viewModel.suggestions.isEmpty)
@@ -2837,5 +2846,54 @@ enum MessageComposerTestUtils {
             chatClient: chatClient,
             messages: messages
         )
+    }
+}
+
+private final class MentionsProviderCommandsConfig: CommandsConfig {
+    let mentionsSymbol = "@"
+    let instantCommandsSymbol = "/"
+    private let provider: MentionSuggestionsProvider
+
+    init(provider: MentionSuggestionsProvider) {
+        self.provider = provider
+    }
+
+    func makeCommandsHandler(with channelController: ChatChannelController) -> CommandsHandler {
+        let mentionsCommandHandler = MentionsCommandHandler(
+            channelController: channelController,
+            commandSymbol: mentionsSymbol,
+            provider: provider
+        )
+        return DefaultCommandsConfig.makeCommandsHandler(
+            mentionsCommandHandler: mentionsCommandHandler,
+            channelController: channelController
+        )
+    }
+}
+
+private final class DelayedMentionSuggestionsProvider: MentionSuggestionsProvider, @unchecked Sendable {
+    private let suggestions: [MentionSuggestion]
+    private let delayNanoseconds: UInt64
+    private let onStarted: @Sendable () -> Void
+    private let onFinished: @Sendable () -> Void
+
+    init(
+        suggestions: [MentionSuggestion],
+        delayNanoseconds: UInt64,
+        onStarted: @escaping @Sendable () -> Void,
+        onFinished: @escaping @Sendable () -> Void
+    ) {
+        self.suggestions = suggestions
+        self.delayNanoseconds = delayNanoseconds
+        self.onStarted = onStarted
+        self.onFinished = onFinished
+    }
+
+    func mentionSuggestions(for request: MentionSuggestionsRequest) async throws -> [MentionSuggestion] {
+        onStarted()
+        defer { onFinished() }
+        try await Task.sleep(nanoseconds: delayNanoseconds)
+        try Task.checkCancellation()
+        return suggestions
     }
 }

--- a/StreamChatSwiftUITests/Tests/ChatChannel/MessageComposerViewModel_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/MessageComposerViewModel_Tests.swift
@@ -686,6 +686,54 @@ import XCTest
         XCTAssert(viewModel.mentionedUsers.isEmpty)
     }
 
+    func test_messageComposerVM_clearingTextClearsMentionSuggestionsAndCommand() {
+        let viewModel = makeComposerViewModel()
+        viewModel.suggestions = ["mentions": [ChatUser.mock(id: "ios", name: "iOS")]]
+        viewModel.composerCommand = ComposerCommand(
+            id: "mentions",
+            typingSuggestion: TypingSuggestion(text: "i", locationRange: NSRange(location: 1, length: 1)),
+            displayInfo: nil
+        )
+
+        viewModel.text = ""
+
+        XCTAssertNil(viewModel.composerCommand)
+        XCTAssertTrue(viewModel.suggestions.isEmpty)
+    }
+
+    func test_messageComposerVM_endingMentionClearsSuggestions() {
+        let viewModel = makeComposerViewModel()
+        viewModel.selectedRangeLocation = 8
+        viewModel.text = "hello @i"
+        XCTAssertEqual(viewModel.composerCommand?.id, "mentions")
+
+        viewModel.selectedRangeLocation = 6
+        viewModel.text = "hello "
+
+        XCTAssertNil(viewModel.composerCommand)
+        XCTAssertTrue(viewModel.suggestions.isEmpty)
+    }
+
+    func test_messageComposerVM_deletingMentionQuery_doesNotShowStaleSuggestionsWhenEmpty() async {
+        let viewModel = makeComposerViewModel()
+        viewModel.selectedRangeLocation = 4
+        viewModel.text = "@iOS"
+        viewModel.selectedRangeLocation = 3
+        viewModel.text = "@iO"
+        viewModel.selectedRangeLocation = 2
+        viewModel.text = "@i"
+        viewModel.selectedRangeLocation = 1
+        viewModel.text = "@"
+        viewModel.selectedRangeLocation = 0
+        viewModel.text = ""
+
+        // Allow any in-flight / debounced suggestion request to finish.
+        try? await Task.sleep(nanoseconds: 800_000_000)
+
+        XCTAssertNil(viewModel.composerCommand)
+        XCTAssertTrue(viewModel.suggestions.isEmpty)
+    }
+
     func test_checkForMentionedUsers_withUserSuggestion() {
         // Given
         let viewModel = makeComposerViewModel()

--- a/StreamChatSwiftUITests/Tests/ChatChannel/Suggestions/MentionsCommandHandler_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/Suggestions/MentionsCommandHandler_Tests.swift
@@ -289,6 +289,30 @@ import XCTest
         XCTAssertTrue(provider.receivedRequests.isEmpty)
     }
 
+    func test_clearSuggestions_cancelsInFlightAndClearsProvider() async {
+        // Given
+        let provider = MockMentionSuggestionsProvider(suggestions: [.here], delayNanoseconds: 500_000_000)
+        let handler = makeHandler(provider: provider)
+        let expectation = expectation(description: "suggestions")
+        expectation.isInverted = true
+
+        let cancellable = handler.showSuggestions(for: mentionsCommand(text: "mar")).sink { _ in
+        } receiveValue: { _ in
+            expectation.fulfill()
+        }
+
+        // When
+        handler.clearSuggestions()
+
+        // Then
+        await fulfillment(of: [expectation], timeout: 0.2)
+        cancellable.cancel()
+
+        // Allow the async provider clear to run.
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertEqual(provider.clearResultsCallCount, 1)
+    }
+
     // MARK: - private
 
     private func makeHandler(provider: MentionSuggestionsProvider? = nil) -> MentionsCommandHandler {
@@ -328,18 +352,33 @@ private final class Box<Value> {
 private final class MockMentionSuggestionsProvider: MentionSuggestionsProvider, @unchecked Sendable {
     let suggestions: [MentionSuggestion]
     let error: Error?
+    let delayNanoseconds: UInt64
     private(set) var receivedRequests: [MentionSuggestionsRequest] = []
+    private(set) var clearResultsCallCount = 0
 
-    init(suggestions: [MentionSuggestion] = [], error: Error? = nil) {
+    init(
+        suggestions: [MentionSuggestion] = [],
+        error: Error? = nil,
+        delayNanoseconds: UInt64 = 0
+    ) {
         self.suggestions = suggestions
         self.error = error
+        self.delayNanoseconds = delayNanoseconds
     }
 
     func mentionSuggestions(for request: MentionSuggestionsRequest) async throws -> [MentionSuggestion] {
         receivedRequests.append(request)
+        if delayNanoseconds > 0 {
+            try await Task.sleep(nanoseconds: delayNanoseconds)
+        }
+        try Task.checkCancellation()
         if let error {
             throw error
         }
         return suggestions
+    }
+
+    func clearResults() async {
+        clearResultsCallCount += 1
     }
 }


### PR DESCRIPTION
### 🔗 Issue Links

- Linear: https://linear.app/stream/issue/IOS-989/cant-mention-user-in-large-group-chats
- GitHub: https://github.com/GetStream/stream-chat-swiftui/issues/882
- Depends on: https://github.com/GetStream/stream-chat-swift/pull/4213

### 🎯 Goal

Prevent stale mention suggestions from resurfacing while deleting an `@…` query, and clear LLC search state when mention mode ends.

### 📝 Summary

- Discard superseded suggestion results in `MessageComposerViewModel` when the active mention query changes or ends
- Clear non-instant composer commands when the text becomes empty (mentions have `displayInfo == nil`)
- Add `CommandHandler.clearSuggestions()` and implement it in `MentionsCommandHandler` to cancel in-flight work and call `MentionSuggestionsProvider.clearResults()`
- Pin StreamChat to `fix/mention-suggestions-large-channels` while the LLC PR is open

### 🛠 Implementation

Deleting `@iOS` character-by-character could race a slower search and leave suggestions visible after the query was cleared. The view model now cancels the active suggestions subscription, ignores results that no longer match the current command/query, and clears suggestions when `composerCommand` becomes `nil`.

`MentionsCommandHandler` tracks the suggestion `Task`, cancels it on clear, and forwards to the provider `clearResults()` API added in the LLC PR.

### 🧪 Manual Testing Notes

- Type `@` + a few characters in a channel, then delete back to empty
- Confirm suggestions disappear and do not reappear after a delay
- Select a mention and confirm the overlay dismisses cleanly
- Repeat on a large channel once the LLC branch is available

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mention suggestions in large channels by cancelling outdated requests and ignoring stale results.
  * Suggestions now clear correctly when text, commands, or mention queries are removed.
  * Clearing the composer reliably resets active command state.
  * Prevented delayed suggestion results from appearing after the composer’s context changes.

* **Tests**
  * Added coverage for mention cleanup, request cancellation, stale results, and clearing provider results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->