### PR TITLE
Track immutable models branch for SDK size work

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/GetStream/stream-chat-swift.git", branch: "patch/improve-sdk-size-immutable-models")
+        .package(url: "https://github.com/GetStream/stream-chat-swift.git", revision: "e657e5ad01000f5bf4ceff12b0fd9bccc04ff9bf")
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/GetStream/stream-chat-swift.git", revision: "5a0b822148390c4e2963d2260f2a9047a4f79b25")
+        .package(url: "https://github.com/GetStream/stream-chat-swift.git", branch: "patch/improve-sdk-size-immutable-models")
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/GetStream/stream-chat-swift.git", revision: "e657e5ad01000f5bf4ceff12b0fd9bccc04ff9bf")
+        .package(url: "https://github.com/GetStream/stream-chat-swift.git", revision: "ba75a71c3196988dc21339422ad8b1968de4bbf0")
     ],
     targets: [
         .target(

--- a/StreamChatSwiftUI.xcodeproj/project.pbxproj
+++ b/StreamChatSwiftUI.xcodeproj/project.pbxproj
@@ -1544,7 +1544,7 @@
 			repositoryURL = "https://github.com/GetStream/stream-chat-swift.git";
 			requirement = {
 				kind = revision;
-				revision = e657e5ad01000f5bf4ceff12b0fd9bccc04ff9bf;
+				revision = ba75a71c3196988dc21339422ad8b1968de4bbf0;
 			};
 		};
 		E3A1C01A282BAC66002D1E26 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {

--- a/StreamChatSwiftUI.xcodeproj/project.pbxproj
+++ b/StreamChatSwiftUI.xcodeproj/project.pbxproj
@@ -1543,8 +1543,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/GetStream/stream-chat-swift.git";
 			requirement = {
-				branch = "patch/improve-sdk-size-immutable-models";
-				kind = branch;
+				kind = revision;
+				revision = e657e5ad01000f5bf4ceff12b0fd9bccc04ff9bf;
 			};
 		};
 		E3A1C01A282BAC66002D1E26 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {

--- a/StreamChatSwiftUI.xcodeproj/project.pbxproj
+++ b/StreamChatSwiftUI.xcodeproj/project.pbxproj
@@ -1543,8 +1543,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/GetStream/stream-chat-swift.git";
 			requirement = {
-				kind = revision;
-				revision = 5a0b822148390c4e2963d2260f2a9047a4f79b25;
+				branch = "patch/improve-sdk-size-immutable-models";
+				kind = branch;
 			};
 		};
 		E3A1C01A282BAC66002D1E26 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {


### PR DESCRIPTION
### 🔗 Issue Links

https://linear.app/stream/issue/IOS-1909/sdk-size-convert-chatthread-poll-chatmessagereaction-and

Companion LLC PR: https://github.com/GetStream/stream-chat-swift/pull/4227

### 🎯 Goal

Build and validate SwiftUI against the in-progress LLC changes for IOS-1909 until the core SDK branch is merged and released.

### 📝 Summary

- Point the `stream-chat-swift` dependency at `patch/improve-sdk-size-immutable-models` in `Package.swift` and the Xcode project

### 🛠 Implementation

This PR contains no SwiftUI SDK changes — only the dependency pin to the LLC branch. Once https://github.com/GetStream/stream-chat-swift/pull/4227 is merged, this pin should be updated back to a fixed revision on `develop`.

### 🎨 Showcase

N/A

### 🧪 Manual Testing Notes

- Resolve packages and build `StreamChatSwiftUI`
- Smoke test thread list, polls, reactions, and read indicators in the demo app

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the underlying Stream Chat components to a stable, pinned release.
  * Improved build consistency by aligning the chat component version across supported build configurations.
  * No changes to the app’s public interfaces or user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->