### PR TITLE
Fix jumping back to latest messages after a mid-page jump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Allow overriding the leave conversation, block user and add members actions in `ChatChannelInfoViewModel` [#1573](https://github.com/GetStream/stream-chat-swiftui/pull/1573)
 
 ### 🐞 Fixed
+- Fix sending a message after jumping to a mid-page quoted message not loading the latest messages [#1584](https://github.com/GetStream/stream-chat-swiftui/pull/1584)
+- Fix the scroll-to-bottom button delaying the jump to latest messages after a mid-page jump [#1584](https://github.com/GetStream/stream-chat-swiftui/pull/1584)
 - Fix the voice message play icon disappearing when swiping a message to reply [#1581](https://github.com/GetStream/stream-chat-swiftui/pull/1581)
 - Fix the composer attachment picker icon clipping outside its circle when the keyboard opens or closes [#1581](https://github.com/GetStream/stream-chat-swiftui/pull/1581)
 

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelViewModel.swift
@@ -47,6 +47,7 @@ import SwiftUI
     private var loadingPreviousMessages: Bool = false
     private var loadingMessagesAround: Bool = false
     private var scrollsToUnreadAfterJumpToMessage = false
+    private var scrollsToLatestAfterLoadingFirstPage = false
     private var disableDateIndicator = false
     private var channelName = ""
     private var onlineIndicatorShown = false
@@ -299,13 +300,14 @@ import SwiftUI
     public func scrollToLastMessage() {
         if channelDataSource.hasLoadedAllNextMessages {
             updateScrolledIdToNewestMessage()
-        } else {
-            channelDataSource.loadFirstPage { [weak self] _ in
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                    self?.scrolledId = self?.messages.first?.messageId
-                    self?.showScrollToLatestButton = false
-                }
-            }
+            showScrollToLatestButton = false
+            return
+        }
+
+        scrollsToLatestAfterLoadingFirstPage = true
+        channelDataSource.loadFirstPage { [weak self] _ in
+            guard let self, self.channelDataSource.hasLoadedAllNextMessages else { return }
+            self.finishScrollingToLatestAfterLoadingFirstPage()
         }
     }
 
@@ -514,7 +516,11 @@ import SwiftUI
             scrolledId = firstUnreadMessageId
         }
         
-        if !showScrollToLatestButton && scrolledId == nil && !loadingNextMessages {
+        if scrollsToLatestAfterLoadingFirstPage {
+            if channelDataSource.hasLoadedAllNextMessages {
+                finishScrollingToLatestAfterLoadingFirstPage()
+            }
+        } else if !showScrollToLatestButton && scrolledId == nil && !loadingNextMessages {
             updateScrolledIdToNewestMessage()
         } else if changes.first?.isInsertion == true && currentUserSentNewMessage {
             if channelDataSource.hasLoadedAllNextMessages {
@@ -904,6 +910,13 @@ import SwiftUI
             scrolledId = nil
         }
         scrolledId = messages.first?.messageId
+    }
+
+    private func finishScrollingToLatestAfterLoadingFirstPage() {
+        guard scrollsToLatestAfterLoadingFirstPage else { return }
+        scrollsToLatestAfterLoadingFirstPage = false
+        updateScrolledIdToNewestMessage()
+        showScrollToLatestButton = false
     }
     
     private func cleanupAudioPlayer() {

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelViewModel.swift
@@ -608,7 +608,9 @@ import SwiftUI
         guard pendingEvent.cid == channelController.cid else { return }
 
         let newMessage = pendingEvent.message
-        let isRelevantMessage = isMessageThread ? newMessage.isPartOfThread : !newMessage.isPartOfThread
+        let isRelevantMessage = isMessageThread
+            ? newMessage.parentMessageId == messageController?.messageId
+            : !newMessage.isPartOfThread
         guard newMessage.isSentByCurrentUser, isRelevantMessage else { return }
         guard !channelDataSource.hasLoadedAllNextMessages else { return }
 

--- a/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatChannel/ChatChannelViewModel.swift
@@ -7,12 +7,13 @@ import StreamChat
 import SwiftUI
 
 /// View model for the `ChatChannelView`.
-@MainActor open class ChatChannelViewModel: ObservableObject, MessagesDataSource {
+@MainActor open class ChatChannelViewModel: ObservableObject, MessagesDataSource, EventsControllerDelegate {
     @Injected(\.chatClient) private var chatClient
     @Injected(\.utils) private var utils
     @Injected(\.images) private var images
     
     private var channelDataSource: ChannelDataSource
+    private var eventsController: EventsController?
     private var cancellables = Set<AnyCancellable>()
     private var lastRefreshThreshold = 200
     private let refreshThreshold = 200
@@ -249,6 +250,9 @@ import SwiftUI
         channelName = channel?.name ?? ""
         checkHeaderType()
         checkUnreadCount()
+
+        eventsController = channelController.client.eventsController()
+        eventsController?.delegate = self
     }
 
     @objc
@@ -513,7 +517,9 @@ import SwiftUI
         if !showScrollToLatestButton && scrolledId == nil && !loadingNextMessages {
             updateScrolledIdToNewestMessage()
         } else if changes.first?.isInsertion == true && currentUserSentNewMessage {
-            updateScrolledIdToNewestMessage()
+            if channelDataSource.hasLoadedAllNextMessages {
+                updateScrolledIdToNewestMessage()
+            }
             currentUserSentNewMessage = false
         }
         
@@ -589,6 +595,18 @@ import SwiftUI
     
     public func setActive() {
         isActive = true
+    }
+
+    open func eventsController(_ controller: EventsController, didReceiveEvent event: Event) {
+        guard let pendingEvent = event as? NewMessagePendingEvent else { return }
+        guard pendingEvent.cid == channelController.cid else { return }
+
+        let newMessage = pendingEvent.message
+        let isRelevantMessage = isMessageThread ? newMessage.isPartOfThread : !newMessage.isPartOfThread
+        guard newMessage.isSentByCurrentUser, isRelevantMessage else { return }
+        guard !channelDataSource.hasLoadedAllNextMessages else { return }
+
+        scrollToLastMessage()
     }
     
     // MARK: - private

--- a/StreamChatSwiftUITests/Infrastructure/Mocks/ChatMessageControllerSUI_Mock.swift
+++ b/StreamChatSwiftUITests/Infrastructure/Mocks/ChatMessageControllerSUI_Mock.swift
@@ -39,6 +39,19 @@ public class ChatMessageControllerSUI_Mock: ChatMessageController, @unchecked Se
         replies_mock ?? super.replies
     }
 
+    public var hasLoadedAllNextReplies_mock: Bool?
+    override public var hasLoadedAllNextReplies: Bool {
+        hasLoadedAllNextReplies_mock ?? super.hasLoadedAllNextReplies
+    }
+
+    var loadFirstPageCallCount = 0
+    override public func loadFirstPage(
+        limit: Int? = nil,
+        _ completion: (@MainActor (_ error: Error?) -> Void)? = nil
+    ) {
+        loadFirstPageCallCount += 1
+    }
+
     public var state_mock: State?
     override public var state: DataController.State {
         get { state_mock ?? super.state }

--- a/StreamChatSwiftUITests/Tests/ChatChannel/ChatChannelViewModel_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/ChatChannelViewModel_Tests.swift
@@ -227,6 +227,158 @@ import XCTest
         XCTAssertEqual(viewModel.scrolledId, messages[0].id)
     }
 
+    func test_chatChannelVM_newMessageSent_whenFirstPageNotLoaded_doesNotScrollToCurrentNewestMessage() {
+        // Given
+        var messages = [ChatMessage]()
+        for i in 0..<5 {
+            let message = ChatMessage.mock(
+                id: .unique,
+                cid: .unique,
+                text: "Test Message \(i)",
+                author: ChatUser.mock(id: chatClient.currentUserId!)
+            )
+            messages.append(message)
+        }
+        let channelController = makeChannelController(messages: messages)
+        channelController.hasLoadedAllNextMessages_mock = false
+        let viewModel = ChatChannelViewModel(channelController: channelController)
+
+        // When
+        viewModel.showScrollToLatestButton = true
+        viewModel.messageSentTapped()
+        viewModel.dataSource(
+            channelDataSource: ChatChannelDataSource(controller: channelController),
+            didUpdateMessages: messages,
+            changes: [
+                .insert(messages[0], index: .init(item: 0, section: 0))
+            ]
+        )
+
+        // Then
+        XCTAssertNotEqual(viewModel.scrolledId, messages[0].id)
+        XCTAssertEqual(channelController.loadFirstPageCallCount, 0)
+    }
+
+    func test_chatChannelVM_newMessagePendingEvent_whenFirstPageNotLoaded_whenMessageSentByCurrentUser_whenMessageNotPartOfThread_thenLoadsFirstPage() {
+        // Given
+        let channelController = makeChannelController()
+        channelController.hasLoadedAllNextMessages_mock = false
+        let viewModel = ChatChannelViewModel(channelController: channelController)
+        let message = ChatMessage.mock(
+            parentMessageId: nil,
+            isSentByCurrentUser: true
+        )
+
+        // When
+        sendPendingMessageEvent(to: viewModel, channelController: channelController, message: message)
+
+        // Then
+        XCTAssertEqual(channelController.loadFirstPageCallCount, 1)
+    }
+
+    func test_chatChannelVM_newMessagePendingEvent_whenFirstPageLoaded_doesNotLoadFirstPage() {
+        // Given
+        let channelController = makeChannelController()
+        channelController.hasLoadedAllNextMessages_mock = true
+        let viewModel = ChatChannelViewModel(channelController: channelController)
+        let message = ChatMessage.mock(
+            parentMessageId: nil,
+            isSentByCurrentUser: true
+        )
+
+        // When
+        sendPendingMessageEvent(to: viewModel, channelController: channelController, message: message)
+
+        // Then
+        XCTAssertEqual(channelController.loadFirstPageCallCount, 0)
+    }
+
+    func test_chatChannelVM_newMessagePendingEvent_whenMessageSentByOtherUser_doesNotLoadFirstPage() {
+        // Given
+        let channelController = makeChannelController()
+        channelController.hasLoadedAllNextMessages_mock = false
+        let viewModel = ChatChannelViewModel(channelController: channelController)
+        let message = ChatMessage.mock(
+            parentMessageId: nil,
+            isSentByCurrentUser: false
+        )
+
+        // When
+        sendPendingMessageEvent(to: viewModel, channelController: channelController, message: message)
+
+        // Then
+        XCTAssertEqual(channelController.loadFirstPageCallCount, 0)
+    }
+
+    func test_chatChannelVM_newMessagePendingEvent_whenMessageIsPartOfThread_doesNotLoadFirstPage() {
+        // Given
+        let channelController = makeChannelController()
+        channelController.hasLoadedAllNextMessages_mock = false
+        let viewModel = ChatChannelViewModel(channelController: channelController)
+        let message = ChatMessage.mock(
+            parentMessageId: .unique,
+            isSentByCurrentUser: true
+        )
+
+        // When
+        sendPendingMessageEvent(to: viewModel, channelController: channelController, message: message)
+
+        // Then
+        XCTAssertEqual(channelController.loadFirstPageCallCount, 0)
+    }
+
+    func test_chatChannelVM_newMessagePendingEvent_whenDifferentChannel_doesNotLoadFirstPage() {
+        // Given
+        let channelController = makeChannelController()
+        channelController.hasLoadedAllNextMessages_mock = false
+        let viewModel = ChatChannelViewModel(channelController: channelController)
+        let message = ChatMessage.mock(
+            parentMessageId: nil,
+            isSentByCurrentUser: true
+        )
+
+        // When
+        let pendingEvent = NewMessagePendingEvent(message: message, cid: .unique)
+        viewModel.eventsController(
+            channelController.client.eventsController(),
+            didReceiveEvent: pendingEvent
+        )
+
+        // Then
+        XCTAssertEqual(channelController.loadFirstPageCallCount, 0)
+    }
+
+    func test_chatChannelVM_newMessagePendingEvent_whenFirstPageNotLoaded_scrollsToNewestMessage() {
+        // Given
+        let messageId: String = .unique
+        let message = ChatMessage.mock(
+            id: messageId,
+            cid: .unique,
+            text: "Test message",
+            author: ChatUser.mock(id: chatClient.currentUserId!)
+        )
+        let channelController = makeChannelController(messages: [message])
+        channelController.hasLoadedAllNextMessages_mock = false
+        let viewModel = ChatChannelViewModel(channelController: channelController)
+        viewModel.showScrollToLatestButton = true
+        let expectation = XCTestExpectation(description: "Should scroll to newest message")
+
+        // When
+        sendPendingMessageEvent(
+            to: viewModel,
+            channelController: channelController,
+            message: ChatMessage.mock(parentMessageId: nil, isSentByCurrentUser: true)
+        )
+
+        // Then
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
+            XCTAssertEqual(viewModel.scrolledId, message.messageId)
+            XCTAssertFalse(viewModel.showScrollToLatestButton)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.5)
+    }
+
     func test_chatChannelVM_messageThread() {
         // Given
         let channelController = makeChannelController()
@@ -1274,6 +1426,19 @@ import XCTest
         ChatChannelTestHelpers.makeChannelController(
             chatClient: chatClient,
             messages: messages
+        )
+    }
+
+    private func sendPendingMessageEvent(
+        to viewModel: ChatChannelViewModel,
+        channelController: ChatChannelController_Mock,
+        message: ChatMessage
+    ) {
+        let cid = channelController.cid ?? message.cid ?? .unique
+        let pendingEvent = NewMessagePendingEvent(message: message, cid: cid)
+        viewModel.eventsController(
+            channelController.client.eventsController(),
+            didReceiveEvent: pendingEvent
         )
     }
 }

--- a/StreamChatSwiftUITests/Tests/ChatChannel/ChatChannelViewModel_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/ChatChannelViewModel_Tests.swift
@@ -366,6 +366,32 @@ import XCTest
         XCTAssertEqual(channelController.loadFirstPageCallCount, 0)
     }
 
+    func test_chatChannelVM_newMessagePendingEvent_whenThread_whenReplyHasDifferentParentId_doesNotLoadFirstPage() {
+        // Given
+        let channelController = makeChannelController()
+        let threadRootId: MessageId = .unique
+        let messageController = ChatMessageControllerSUI_Mock.mock(
+            chatClient: chatClient,
+            cid: channelController.cid,
+            messageId: threadRootId
+        )
+        messageController.hasLoadedAllNextReplies_mock = false
+        let viewModel = ChatChannelViewModel(
+            channelController: channelController,
+            messageController: messageController
+        )
+        let message = ChatMessage.mock(
+            parentMessageId: .unique,
+            isSentByCurrentUser: true
+        )
+
+        // When
+        sendPendingMessageEvent(to: viewModel, channelController: channelController, message: message)
+
+        // Then
+        XCTAssertEqual(messageController.loadFirstPageCallCount, 0)
+    }
+
     func test_chatChannelVM_newMessagePendingEvent_whenDifferentChannel_doesNotLoadFirstPage() {
         // Given
         let channelController = makeChannelController()

--- a/StreamChatSwiftUITests/Tests/ChatChannel/ChatChannelViewModel_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/ChatChannelViewModel_Tests.swift
@@ -94,6 +94,45 @@ import XCTest
         XCTAssert(viewModel.scrolledId!.contains(messageId))
     }
 
+    func test_chatChannelVM_scrollToLastMessage_whenFirstPageNotLoaded_scrollsWhenFirstPageArrives() {
+        // Given
+        let midPageMessage = ChatMessage.mock(
+            id: .unique,
+            cid: .unique,
+            text: "Mid page",
+            author: ChatUser.mock(id: chatClient.currentUserId!)
+        )
+        let newestMessage = ChatMessage.mock(
+            id: .unique,
+            cid: .unique,
+            text: "Newest",
+            author: ChatUser.mock(id: chatClient.currentUserId!)
+        )
+        let channelController = makeChannelController(messages: [midPageMessage])
+        channelController.hasLoadedAllNextMessages_mock = false
+        let viewModel = ChatChannelViewModel(channelController: channelController)
+        viewModel.showScrollToLatestButton = true
+
+        // When
+        viewModel.scrollToLastMessage()
+
+        // Then
+        XCTAssertEqual(channelController.loadFirstPageCallCount, 1)
+        XCTAssertNotEqual(viewModel.scrolledId, newestMessage.messageId)
+
+        // When the first page arrives
+        channelController.hasLoadedAllNextMessages_mock = true
+        viewModel.dataSource(
+            channelDataSource: ChatChannelDataSource(controller: channelController),
+            didUpdateMessages: [newestMessage],
+            changes: [.insert(newestMessage, index: .init(item: 0, section: 0))]
+        )
+
+        // Then
+        XCTAssertEqual(viewModel.scrolledId, newestMessage.messageId)
+        XCTAssertFalse(viewModel.showScrollToLatestButton)
+    }
+
     func test_chatChannelVM_messageSentTapped_whenEditingMessage_shouldNotScroll() {
         // Given
         let messageId: String = .unique
@@ -350,18 +389,22 @@ import XCTest
 
     func test_chatChannelVM_newMessagePendingEvent_whenFirstPageNotLoaded_scrollsToNewestMessage() {
         // Given
-        let messageId: String = .unique
-        let message = ChatMessage.mock(
-            id: messageId,
+        let midPageMessage = ChatMessage.mock(
+            id: .unique,
             cid: .unique,
-            text: "Test message",
+            text: "Mid page",
             author: ChatUser.mock(id: chatClient.currentUserId!)
         )
-        let channelController = makeChannelController(messages: [message])
+        let newestMessage = ChatMessage.mock(
+            id: .unique,
+            cid: .unique,
+            text: "Newest",
+            author: ChatUser.mock(id: chatClient.currentUserId!)
+        )
+        let channelController = makeChannelController(messages: [midPageMessage])
         channelController.hasLoadedAllNextMessages_mock = false
         let viewModel = ChatChannelViewModel(channelController: channelController)
         viewModel.showScrollToLatestButton = true
-        let expectation = XCTestExpectation(description: "Should scroll to newest message")
 
         // When
         sendPendingMessageEvent(
@@ -369,14 +412,17 @@ import XCTest
             channelController: channelController,
             message: ChatMessage.mock(parentMessageId: nil, isSentByCurrentUser: true)
         )
+        channelController.hasLoadedAllNextMessages_mock = true
+        viewModel.dataSource(
+            channelDataSource: ChatChannelDataSource(controller: channelController),
+            didUpdateMessages: [newestMessage],
+            changes: [.insert(newestMessage, index: .init(item: 0, section: 0))]
+        )
 
         // Then
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
-            XCTAssertEqual(viewModel.scrolledId, message.messageId)
-            XCTAssertFalse(viewModel.showScrollToLatestButton)
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: 1.5)
+        XCTAssertEqual(channelController.loadFirstPageCallCount, 1)
+        XCTAssertEqual(viewModel.scrolledId, newestMessage.messageId)
+        XCTAssertFalse(viewModel.showScrollToLatestButton)
     }
 
     func test_chatChannelVM_messageThread() {

--- a/StreamChatSwiftUITestsAppTests/Robots/UserRobot.swift
+++ b/StreamChatSwiftUITestsAppTests/Robots/UserRobot.swift
@@ -215,6 +215,51 @@ extension UserRobot {
     }
 
     @discardableResult
+    func quoteMessage(
+        _ text: String,
+        quotingMessageText quotedText: String,
+        waitForAppearance: Bool = true,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> Self {
+        var didQuoteMessage = false
+        for _ in 0..<20 {
+            let cellCount = cells.count
+            for index in 0..<cellCount {
+                let cell = cells.element(boundBy: index)
+                guard attributes.text(in: cell).text == quotedText else { continue }
+
+                let messageBubble = attributes.messageBubble(in: cell)
+                guard messageBubble.isHittable else { break }
+
+                messageBubble.waitForHitPoint().press(forDuration: 1)
+                contextMenu.reply.element.wait().safeTap()
+                didQuoteMessage = true
+                break
+            }
+            if didQuoteMessage {
+                break
+            }
+            scrollMessageListUp()
+        }
+
+        XCTAssertTrue(
+            didQuoteMessage,
+            "Message with text '\(quotedText)' was not found",
+            file: file,
+            line: line
+        )
+
+        sendMessage(
+            text,
+            waitForAppearance: waitForAppearance,
+            file: file,
+            line: line
+        )
+        return self
+    }
+
+    @discardableResult
     func openThread(messageCellIndex: Int = 0, waitForThreadIcon: Bool = false) -> Self {
         let messageCell = messageCell(withIndex: messageCellIndex)
         let threadButton = MessageListPage.Attributes.threadReplyCountButton(in: messageCell)

--- a/StreamChatSwiftUITestsAppTests/Tests/QuotedReply_Tests.swift
+++ b/StreamChatSwiftUITestsAppTests/Tests/QuotedReply_Tests.swift
@@ -122,6 +122,73 @@ final class QuotedReply_Tests: StreamTestCase {
         }
     }
 
+    func test_messageListScrollsToLatest_whenUserSendsMessageAfterJumpingToQuotedMessage() throws {
+        linkToScenario(withId: 10074)
+
+        let messageCount = 60
+        let quotedText = "30"
+        let newMessage = "New message after jump"
+
+        GIVEN("user opens a channel with \(messageCount) messages") {
+            backendRobot.generateChannels(channelsCount: 1, messagesCount: messageCount)
+            userRobot.login().openChannel()
+        }
+        AND("user quotes a mid-page message") {
+            userRobot.quoteMessage(replyText, quotingMessageText: quotedText)
+        }
+        AND("user closes and reopens the channel") {
+            userRobot
+                .tapOnBackButton()
+                .openChannel()
+        }
+        WHEN("user taps on the quoted message") {
+            userRobot
+                .tapOnQuotedMessage(quotedText, at: 0)
+                .assertScrollToBottomButton(isVisible: true)
+        }
+        AND("user sends a new message") {
+            userRobot.sendMessage(newMessage)
+        }
+        THEN("message list shows the latest message") {
+            userRobot
+                .assertMessage(newMessage)
+                .assertScrollToBottomButton(isVisible: false)
+        }
+    }
+
+    func test_messageListScrollsToLatest_whenUserTapsScrollToBottomAfterJumpingToQuotedMessage() throws {
+        linkToScenario(withId: 10075)
+
+        let messageCount = 60
+        let quotedText = "30"
+
+        GIVEN("user opens a channel with \(messageCount) messages") {
+            backendRobot.generateChannels(channelsCount: 1, messagesCount: messageCount)
+            userRobot.login().openChannel()
+        }
+        AND("user quotes a mid-page message") {
+            userRobot.quoteMessage(replyText, quotingMessageText: quotedText)
+        }
+        AND("user closes and reopens the channel") {
+            userRobot
+                .tapOnBackButton()
+                .openChannel()
+        }
+        WHEN("user taps on the quoted message") {
+            userRobot
+                .tapOnQuotedMessage(quotedText, at: 0)
+                .assertScrollToBottomButton(isVisible: true)
+        }
+        AND("user taps on the scroll to bottom button") {
+            userRobot.tapOnScrollToBottomButton()
+        }
+        THEN("message list shows the latest message") {
+            userRobot
+                .assertMessage(replyText)
+                .assertScrollToBottomButton(isVisible: false)
+        }
+    }
+
     func test_quotedReplyNotInList_whenParticipantAddsQuotedReply_Message() {
         linkToScenario(withId: 1702)
         


### PR DESCRIPTION
### 🔗 Issue Links

https://linear.app/stream/issue/IOS-1980/swiftui-sending-message-after-jumping-to-mid-page-does-not-load-first

### 🎯 Goal

After jumping to a quoted message on a mid page, sending a new message (or tapping scroll to bottom) should load the first page and jump to the latest messages. UIKit already does this; SwiftUI did not.

### 📝 Summary

- Load the first page when the current user sends a message while not on the latest page
- Scroll to the newest message as soon as that first page arrives
- Use the same path for the scroll-to-bottom button, instead of waiting 0.5s after `loadFirstPage`

### 🛠 Implementation

`ChatChannelViewModel` now listens for `NewMessagePendingEvent`, matching UIKit. If the current user sent a channel message and the first page is not loaded, it loads the first page.

Both sending and tapping scroll-to-bottom set a flag and call `loadFirstPage()`. When the first page lands in `didUpdateMessages`, we scroll to the newest message and hide the scroll-to-bottom button.

A mid-page insert from the current user no longer scrolls to the newest message on the current page.

### 🎨 Showcase

N/A

### 🧪 Manual Testing Notes

1. Open a channel with enough messages to paginate
2. Quote a message on a mid page and tap it to jump there
3. Send a new message — the list should load the first page and jump to the new message
4. Repeat the jump, then tap the scroll-to-bottom button — the list should load the first page and jump to the latest messages without a noticeable delay

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Sending a message after jumping to a quoted message now loads and displays the latest messages correctly.
  - The scroll-to-latest button now navigates immediately to the newest messages after jumping to the middle of a conversation.
  - New messages you send now trigger the appropriate latest-message loading behavior in conversations and threads.
  - Message navigation now correctly handles quoted replies and returns to the latest content when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->