### PR TITLE
Fix image blink when opening attachment picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix the scroll-to-bottom button delaying the jump to latest messages after a mid-page jump [#1584](https://github.com/GetStream/stream-chat-swiftui/pull/1584)
 - Fix the voice message play icon disappearing when swiping a message to reply [#1581](https://github.com/GetStream/stream-chat-swiftui/pull/1581)
 - Fix the composer attachment picker icon clipping outside its circle when the keyboard opens or closes [#1581](https://github.com/GetStream/stream-chat-swiftui/pull/1581)
+- Fix image blink when opening attachment picker on Xcode 27 beta [#1587](https://github.com/GetStream/stream-chat-swiftui/pull/1587)
 
 ### ⚡ Performance
 - Improve scrolling performance by caching background observer reads [#1570](https://github.com/GetStream/stream-chat-swiftui/pull/1570)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix the scroll-to-bottom button delaying the jump to latest messages after a mid-page jump [#1584](https://github.com/GetStream/stream-chat-swiftui/pull/1584)
 - Fix the voice message play icon disappearing when swiping a message to reply [#1581](https://github.com/GetStream/stream-chat-swiftui/pull/1581)
 - Fix the composer attachment picker icon clipping outside its circle when the keyboard opens or closes [#1581](https://github.com/GetStream/stream-chat-swiftui/pull/1581)
-- Fix image blink when opening attachment picker on Xcode 27 beta [#1587](https://github.com/GetStream/stream-chat-swiftui/pull/1587)
+- Fix image blink when opening attachment picker on iOS 27 [#1587](https://github.com/GetStream/stream-chat-swiftui/pull/1587)
 
 ### ⚡ Performance
 - Improve scrolling performance by caching background observer reads [#1570](https://github.com/GetStream/stream-chat-swiftui/pull/1570)

--- a/Sources/StreamChatSwiftUI/ChatMessageList/MessageListView.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/MessageListView.swift
@@ -337,7 +337,9 @@ public struct MessageListView<Factory: ViewFactory>: View, KeyboardReadable {
                         )
                     }
                 }
-                .modifier(MessageListScrollEdgeEffectModifier())
+                // The flipped list's logical top edge is the composer edge, where
+                // iOS 27's scroll blur can snapshot media while the viewport resizes.
+                .compatibility.scrollEdgeEffectHidden(true, for: .top)
                 .modifier(ScrollPositionModifier(scrollPosition: loadingNextMessages ? $scrollPosition : .constant(nil)))
                 .background(
                     factory.makeMessageListBackground(
@@ -612,22 +614,6 @@ public struct MessageListView<Factory: ViewFactory>: View, KeyboardReadable {
         } else {
             LazyVStack(spacing: 0, content: content)
         }
-    }
-}
-
-private struct MessageListScrollEdgeEffectModifier: ViewModifier {
-    func body(content: Content) -> some View {
-        #if os(iOS)
-        if #available(iOS 27.0, *) {
-            // The flipped list's logical top edge is the composer edge, where
-            // iOS 27's scroll blur can snapshot media while the viewport resizes.
-            content.scrollEdgeEffectHidden(true, for: .top)
-        } else {
-            content
-        }
-        #else
-        content
-        #endif
     }
 }
 

--- a/Sources/StreamChatSwiftUI/ChatMessageList/MessageListView.swift
+++ b/Sources/StreamChatSwiftUI/ChatMessageList/MessageListView.swift
@@ -337,6 +337,7 @@ public struct MessageListView<Factory: ViewFactory>: View, KeyboardReadable {
                         )
                     }
                 }
+                .modifier(MessageListScrollEdgeEffectModifier())
                 .modifier(ScrollPositionModifier(scrollPosition: loadingNextMessages ? $scrollPosition : .constant(nil)))
                 .background(
                     factory.makeMessageListBackground(
@@ -611,6 +612,22 @@ public struct MessageListView<Factory: ViewFactory>: View, KeyboardReadable {
         } else {
             LazyVStack(spacing: 0, content: content)
         }
+    }
+}
+
+private struct MessageListScrollEdgeEffectModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        #if os(iOS)
+        if #available(iOS 27.0, *) {
+            // The flipped list's logical top edge is the composer edge, where
+            // iOS 27's scroll blur can snapshot media while the viewport resizes.
+            content.scrollEdgeEffectHidden(true, for: .top)
+        } else {
+            content
+        }
+        #else
+        content
+        #endif
     }
 }
 

--- a/Sources/StreamChatSwiftUI/Utils/Common/Compatibility+ScrollEdgeEffect.swift
+++ b/Sources/StreamChatSwiftUI/Utils/Common/Compatibility+ScrollEdgeEffect.swift
@@ -7,7 +7,7 @@ import SwiftUI
 extension Compatibility where Content: View {
     @ViewBuilder
     func scrollEdgeEffectHidden(_ hidden: Bool, for edges: Edge.Set) -> some View {
-        #if os(iOS)
+        #if os(iOS) && compiler(>=6.3)
         if #available(iOS 27.0, *) {
             content.scrollEdgeEffectHidden(hidden, for: edges)
         } else {

--- a/Sources/StreamChatSwiftUI/Utils/Common/Compatibility+ScrollEdgeEffect.swift
+++ b/Sources/StreamChatSwiftUI/Utils/Common/Compatibility+ScrollEdgeEffect.swift
@@ -1,0 +1,20 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import SwiftUI
+
+extension Compatibility where Content: View {
+    @ViewBuilder
+    func scrollEdgeEffectHidden(_ hidden: Bool, for edges: Edge.Set) -> some View {
+        #if os(iOS)
+        if #available(iOS 27.0, *) {
+            content.scrollEdgeEffectHidden(hidden, for: edges)
+        } else {
+            content
+        }
+        #else
+        content
+        #endif
+    }
+}


### PR DESCRIPTION
### 🔗 Issue Links

Resolves https://linear.app/stream/issue/IOS-1902/swiftuiios27-attachment-previews-flicker-when-opening-keyboard.

### 🎯 Goal

Prevent flickering when attachment picker is shown on iOS 27.

### 📝 Summary

Disable scroll edge effect on the message list (new iOS 27 API).

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Updated message list scrolling on iOS 27 and later by disabling the top scroll-edge effect.
  * Preserved existing scrolling behavior on earlier iOS versions and other platforms.

* **Bug Fixes**
  * Fixed an image blinking issue that could occur when opening the attachment picker on iOS 27.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->