### PR TITLE
Fix edit message not passing mentions from composer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Upcoming
 
-### 🔄 Changed
+### 🐞 Fixed
+- Fix mentions not being persisted when editing a message [#1590](https://github.com/GetStream/stream-chat-swiftui/pull/1590)
 
 # [5.10.0](https://github.com/GetStream/stream-chat-swiftui/releases/tag/5.10.0)
 _August 27, 2026_

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/GetStream/stream-chat-swift.git", revision: "609ea69fba757994c112724689e7a9b148835bbc")
+        .package(url: "https://github.com/GetStream/stream-chat-swift.git", revision: "789071c145519fc9423f298e6905db216864af51")
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/GetStream/stream-chat-swift.git", revision: "dadd0ccc782d5a23ed340bdba0758ed334cdc93c")
+        .package(url: "https://github.com/GetStream/stream-chat-swift.git", revision: "609ea69fba757994c112724689e7a9b148835bbc")
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/GetStream/stream-chat-swift.git", from: "5.10.0")
+        .package(url: "https://github.com/GetStream/stream-chat-swift.git", branch: "fix/ios-2005-edit-message-mentions")
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/GetStream/stream-chat-swift.git", branch: "fix/ios-2005-edit-message-mentions")
+        .package(url: "https://github.com/GetStream/stream-chat-swift.git", revision: "dadd0ccc782d5a23ed340bdba0758ed334cdc93c")
     ],
     targets: [
         .target(

--- a/Sources/StreamChatSwiftUI/ChatComposer/MessageComposerViewModel.swift
+++ b/Sources/StreamChatSwiftUI/ChatComposer/MessageComposerViewModel.swift
@@ -550,6 +550,11 @@ import SwiftUI
             edit(
                 message: editedMessage,
                 attachments: try? convertAddedAssetsToPayloads(),
+                mentionedUserIds: mentionedUserIds,
+                mentionedRoles: mentionedRoles,
+                mentionedGroupIds: mentionedGroupIds,
+                mentionsHere: mentionsHere,
+                mentionsChannel: mentionsChannel,
                 completion: completion
             )
             return
@@ -966,6 +971,11 @@ import SwiftUI
     private func edit(
         message: ChatMessage,
         attachments: [AnyAttachmentPayload]?,
+        mentionedUserIds: [UserId],
+        mentionedRoles: [String],
+        mentionedGroupIds: [String],
+        mentionsHere: Bool,
+        mentionsChannel: Bool,
         completion: @escaping @MainActor () -> Void
     ) {
         guard let channelId = channelController.channel?.cid else {
@@ -978,7 +988,12 @@ import SwiftUI
         
         messageController.editMessage(
             text: adjustedText,
-            attachments: attachments ?? []
+            attachments: attachments ?? [],
+            mentionedUserIds: mentionedUserIds,
+            mentionedHere: mentionsHere,
+            mentionedChannel: mentionsChannel,
+            mentionedGroupIds: mentionedGroupIds,
+            mentionedRoles: mentionedRoles
         ) { [weak self] error in
             if error != nil {
                 self?.isSendingMessage = false

--- a/StreamChatSwiftUI.xcodeproj/project.pbxproj
+++ b/StreamChatSwiftUI.xcodeproj/project.pbxproj
@@ -1544,8 +1544,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/GetStream/stream-chat-swift.git";
 			requirement = {
-				kind = branch;
-				branch = "fix/ios-2005-edit-message-mentions";
+				kind = revision;
+				revision = dadd0ccc782d5a23ed340bdba0758ed334cdc93c;
 			};
 		};
 		E3A1C01A282BAC66002D1E26 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {

--- a/StreamChatSwiftUI.xcodeproj/project.pbxproj
+++ b/StreamChatSwiftUI.xcodeproj/project.pbxproj
@@ -1545,7 +1545,7 @@
 			repositoryURL = "https://github.com/GetStream/stream-chat-swift.git";
 			requirement = {
 				kind = revision;
-				revision = dadd0ccc782d5a23ed340bdba0758ed334cdc93c;
+				revision = 609ea69fba757994c112724689e7a9b148835bbc;
 			};
 		};
 		E3A1C01A282BAC66002D1E26 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {

--- a/StreamChatSwiftUI.xcodeproj/project.pbxproj
+++ b/StreamChatSwiftUI.xcodeproj/project.pbxproj
@@ -1545,7 +1545,7 @@
 			repositoryURL = "https://github.com/GetStream/stream-chat-swift.git";
 			requirement = {
 				kind = revision;
-				revision = 609ea69fba757994c112724689e7a9b148835bbc;
+				revision = 789071c145519fc9423f298e6905db216864af51;
 			};
 		};
 		E3A1C01A282BAC66002D1E26 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {

--- a/StreamChatSwiftUI.xcodeproj/project.pbxproj
+++ b/StreamChatSwiftUI.xcodeproj/project.pbxproj
@@ -1544,8 +1544,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/GetStream/stream-chat-swift.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 5.10.0;
+				kind = branch;
+				branch = "fix/ios-2005-edit-message-mentions";
 			};
 		};
 		E3A1C01A282BAC66002D1E26 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {

--- a/StreamChatSwiftUITests/Tests/ChatChannel/MessageComposerViewModel_Tests.swift
+++ b/StreamChatSwiftUITests/Tests/ChatChannel/MessageComposerViewModel_Tests.swift
@@ -2761,7 +2761,7 @@ import XCTest
             config: .mock(),
             ownCapabilities: ownCapabilities,
             lastActiveMembers: [],
-            currentlyTypingUsers: [],
+            typingUsers: [],
             lastActiveWatchers: [],
             unreadCount: .noUnread,
             cooldownDuration: cooldownDuration,


### PR DESCRIPTION
### 🔗 Issue Links

- [IOS-2005](https://linear.app/stream/issue/IOS-2005/edit-message-does-not-persist-mentions-swiftui-uikit)
- LLC: https://github.com/GetStream/stream-chat-swift/pull/4268 (merged)
- StreamChatTestTools compile fix: https://github.com/GetStream/stream-chat-swift/pull/4269

### 🎯 Goal

Editing a message in SwiftUI and adding `@` mentions does not persist those mentions. `MessageComposerViewModel` already collects mention state for new messages, but `edit()` only called `messageController.editMessage(text:attachments:)`.

This PR forwards the mention data collected during edit so edited messages keep user, role, group, `@here`, and `@channel` mentions.

### 📝 Summary

- `MessageComposerViewModel.edit()` now receives the mention state already collected in `sendMessage()`.
- That state is passed through to `messageController.editMessage` (`mentionedUserIds`, `mentionedRoles`, `mentionedGroupIds`, `mentionedHere`, `mentionedChannel`).
- StreamChat is pinned to `609ea69fb` so this builds against the merged mention APIs and the StreamChatTestTools `@retroactive` compile fix. Restore a version pin after the next LLC release.

### 🛠 Implementation

`sendMessage()` already runs `clearRemovedMentions()` and snapshots mention fields before deciding between edit and send. The edit path now takes those same values instead of dropping them.

### 🎨 Showcase

N/A — no visual change. Mentions persist after edit; the composer UI is unchanged.

### 🧪 Manual Testing Notes

1. Send a message without mentions, then edit it and add an `@user` mention. Confirm the mention is highlighted after save.
2. Edit a message that already has mentions and remove one `@user` from the text. Confirm that mention is dropped after save.
3. Edit a message and add `@here` / `@channel` (or role/group mentions where available). Confirm they persist after save.
4. Repeat in a thread reply.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [x] Changelog is updated with new localization keys (n/a - no new strings)
- [x] New code is covered by unit tests (n/a - wires existing LLC API; coverage is in stream-chat-swift#4268)
- [ ] Documentation has been updated in the `docs-content` repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Editing a message now preserves all mentions, including mentioned users, roles, groups, `@here`, and `@channel`.
  - Mentions remain visible and functional after saving message edits.
  - Improved consistency when composing and updating messages with mention content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->