### PR TITLE
Update StreamChat dependency to 5.11.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/GetStream/stream-chat-swift.git", revision: "789071c145519fc9423f298e6905db216864af51")
+        .package(url: "https://github.com/GetStream/stream-chat-swift.git", from: "5.11.0")
     ],
     targets: [
         .target(

--- a/StreamChatSwiftUI.xcodeproj/project.pbxproj
+++ b/StreamChatSwiftUI.xcodeproj/project.pbxproj
@@ -1544,8 +1544,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/GetStream/stream-chat-swift.git";
 			requirement = {
-				kind = revision;
-				revision = 789071c145519fc9423f298e6905db216864af51;
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.11.0;
 			};
 		};
 		E3A1C01A282BAC66002D1E26 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {


### PR DESCRIPTION
### 🔗 Issue Links

https://linear.app/stream/issue/IOS-2013/release-5110

### 🎯 Goal

Point StreamChatSwiftUI at the newly published StreamChat `5.11.0` release (release step 7.1).

### 📝 Summary

- Update `Package.swift` StreamChat dependency to `from: "5.11.0"`
- Align the Xcode project package requirement to `upToNextMajorVersion` / `5.11.0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Stream Chat Swift package to use version-based resolution beginning with version 5.11.0.
  * This keeps the project aligned with compatible package updates while maintaining the existing public API and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->